### PR TITLE
feat: add Stellar/Soroban client adapter (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ API runs at [http://localhost:3000](http://localhost:3000). The frontend proxies
 | `npm run build`      | Compile TypeScript       |
 | `npm start`          | Run compiled `dist/`     |
 | `npm run lint`       | Run ESLint               |
-| `npm test`           | Run tests                |
+| `npm test`           | Run test suite           |
 | `npm run test:coverage` | Run tests with coverage |
 
 ## API (current)
@@ -131,5 +131,11 @@ Tests cover: no drift (no update), single drift (one address corrected), full re
 - Node.js
 - TypeScript
 - Express
+
+## Stellar/Soroban Integration
+
+- Adapter implementation: `src/clients/soroban.ts`
+- Integration notes: `docs/stellar-integration.md`
+- Tests: `src/clients/soroban.test.ts`
 
 Extend with PostgreSQL, Redis, and Horizon event ingestion when implementing the full architecture.

--- a/docs/stellar-integration.md
+++ b/docs/stellar-integration.md
@@ -1,0 +1,93 @@
+# Stellar/Soroban Client Adapter
+
+This project includes a dedicated Soroban RPC adapter in `src/clients/soroban.ts`.
+
+## Goals
+
+- Encapsulate Soroban network configuration (`rpcUrl`, `network`, `contractId`)
+- Provide a stable facade for contract interactions
+- Apply consistent timeout, retry, and error handling
+- Keep transport logic testable via dependency injection
+
+## API
+
+### `createSorobanClient(config, deps?)`
+
+Creates a `SorobanClient` instance.
+
+### `getIdentityState(address)`
+
+Fetches identity state from the configured contract using a `getContractData` RPC call shape.
+
+### `getContractEvents(cursor?)`
+
+Fetches contract-scoped events using `getEvents`, and returns:
+
+- `events`: parsed event array
+- `cursor`: normalized next cursor (`latestCursor` or `cursor` or `null`)
+
+## Configuration
+
+Example environment variables:
+
+```bash
+SOROBAN_RPC_URL=https://rpc.testnet.stellar.org
+SOROBAN_NETWORK=testnet
+SOROBAN_CONTRACT_ID=CDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+SOROBAN_TIMEOUT_MS=5000
+```
+
+Example initialization:
+
+```ts
+import { createSorobanClient } from '../src/clients/soroban.js'
+
+const soroban = createSorobanClient({
+  rpcUrl: process.env.SOROBAN_RPC_URL!,
+  network: (process.env.SOROBAN_NETWORK as 'testnet' | 'mainnet') ?? 'testnet',
+  contractId: process.env.SOROBAN_CONTRACT_ID!,
+  timeoutMs: Number(process.env.SOROBAN_TIMEOUT_MS ?? 5000),
+  retry: {
+    maxAttempts: 3,
+    baseDelayMs: 200,
+    backoffMultiplier: 2,
+    maxDelayMs: 2000,
+  },
+})
+```
+
+## Error handling
+
+The adapter throws `SorobanClientError` with a typed `code`:
+
+- `CONFIG_ERROR`
+- `NETWORK_ERROR`
+- `TIMEOUT_ERROR`
+- `HTTP_ERROR`
+- `RPC_ERROR`
+- `PARSE_ERROR`
+
+Retries are attempted for:
+
+- transport failures
+- timeouts
+- HTTP `408`, `429`, and `5xx`
+- retryable RPC errors (`-32004`, `-32005`)
+
+All other errors fail fast.
+
+## Testing
+
+Tests live in `src/clients/soroban.test.ts` and use mocked `fetchFn` and `sleepFn` to validate:
+
+- success paths for both facade methods
+- timeout behavior
+- retry/backoff behavior
+- non-retryable failures
+- parse and payload-shape errors
+
+Run tests with:
+
+```bash
+npm test
+```

--- a/src/clients/soroban.test.ts
+++ b/src/clients/soroban.test.ts
@@ -1,0 +1,511 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createSorobanClient, SorobanClient, SorobanClientError } from './soroban.js'
+
+const baseConfig = {
+  rpcUrl: 'https://rpc.testnet.stellar.org',
+  network: 'testnet' as const,
+  contractId: 'CDUMMYCONTRACTID',
+}
+
+test('throws config error for invalid network', () => {
+  assert.throws(
+    () =>
+      new SorobanClient({
+        ...baseConfig,
+        network: 'devnet' as never,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof SorobanClientError)
+      assert.equal(error.code, 'CONFIG_ERROR')
+      return true
+    },
+  )
+})
+
+test('throws config error for missing rpcUrl', () => {
+  assert.throws(
+    () =>
+      new SorobanClient({
+        ...baseConfig,
+        rpcUrl: '',
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof SorobanClientError)
+      assert.equal(error.code, 'CONFIG_ERROR')
+      return true
+    },
+  )
+})
+
+test('throws config error for missing contractId', () => {
+  assert.throws(
+    () =>
+      new SorobanClient({
+        ...baseConfig,
+        contractId: '',
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof SorobanClientError)
+      assert.equal(error.code, 'CONFIG_ERROR')
+      return true
+    },
+  )
+})
+
+test('getIdentityState validates address input', async () => {
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'unused',
+          result: {},
+        }),
+        { status: 200 },
+      ),
+  })
+
+  await assert.rejects(client.getIdentityState('  '), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'CONFIG_ERROR')
+    return true
+  })
+})
+
+test('getIdentityState issues RPC request and returns result', async () => {
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = []
+
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        method: string
+        params: Record<string, unknown>
+      }
+      calls.push({ method: body.method, params: body.params })
+
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: '1',
+          result: { address: 'GABC', score: 87 },
+        }),
+        { status: 200 },
+      )
+    },
+  })
+
+  const result = await client.getIdentityState('GABC')
+  assert.deepEqual(result, { address: 'GABC', score: 87 })
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]?.method, 'getContractData')
+  assert.deepEqual(calls[0]?.params.key, { type: 'identity', address: 'GABC' })
+})
+
+test('getContractEvents returns normalized cursor and events', async () => {
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: '2',
+          result: {
+            events: [{ id: 'evt-1', ledger: 100 }],
+            latestCursor: 'cursor-2',
+          },
+        }),
+        { status: 200 },
+      ),
+  })
+
+  const result = await client.getContractEvents('cursor-1')
+  assert.deepEqual(result, {
+    events: [{ id: 'evt-1', ledger: 100 }],
+    cursor: 'cursor-2',
+  })
+})
+
+test('getContractEvents returns empty defaults when payload omits fields', async () => {
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () =>
+      new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: '4',
+          result: {},
+        }),
+        { status: 200 },
+      ),
+  })
+
+  const result = await client.getContractEvents()
+  assert.deepEqual(result, { events: [], cursor: null })
+})
+
+test('retries transient HTTP failures with backoff and then succeeds', async () => {
+  const sleepCalls: number[] = []
+  let attempt = 0
+
+  const client = new SorobanClient(
+    {
+      ...baseConfig,
+      retry: {
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        backoffMultiplier: 2,
+        maxDelayMs: 100,
+      },
+    },
+    {
+      fetchFn: async () => {
+        attempt += 1
+        if (attempt < 3) {
+          return new Response('unavailable', { status: 503 })
+        }
+
+        return new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: '3',
+            result: { events: [], latestCursor: 'final-cursor' },
+          }),
+          { status: 200 },
+        )
+      },
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms)
+      },
+    },
+  )
+
+  const result = await client.getContractEvents()
+  assert.equal(attempt, 3)
+  assert.deepEqual(sleepCalls, [10, 20])
+  assert.equal(result.cursor, 'final-cursor')
+})
+
+test('retries on HTTP 429 and caps backoff at maxDelayMs', async () => {
+  const sleepCalls: number[] = []
+  let attempt = 0
+
+  const client = new SorobanClient(
+    {
+      ...baseConfig,
+      retry: {
+        maxAttempts: 3,
+        baseDelayMs: 100,
+        backoffMultiplier: 2,
+        maxDelayMs: 150,
+      },
+    },
+    {
+      fetchFn: async () => {
+        attempt += 1
+        if (attempt < 3) {
+          return new Response('rate limited', { status: 429 })
+        }
+
+        return new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'rate-limit-success',
+            result: { events: [], cursor: 'done' },
+          }),
+          { status: 200 },
+        )
+      },
+      sleepFn: async (ms) => {
+        sleepCalls.push(ms)
+      },
+    },
+  )
+
+  const result = await client.getContractEvents()
+  assert.equal(attempt, 3)
+  assert.deepEqual(sleepCalls, [100, 150])
+  assert.equal(result.cursor, 'done')
+})
+
+test('does not retry non-retryable HTTP errors', async () => {
+  let attempt = 0
+
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () => {
+      attempt += 1
+      return new Response('bad request', { status: 400 })
+    },
+  })
+
+  await assert.rejects(client.getContractEvents(), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'HTTP_ERROR')
+    assert.equal(error.attempts, 1)
+    return true
+  })
+
+  assert.equal(attempt, 1)
+})
+
+test('retries on retryable RPC codes and succeeds', async () => {
+  let attempt = 0
+
+  const client = new SorobanClient(
+    {
+      ...baseConfig,
+      retry: {
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        backoffMultiplier: 2,
+        maxDelayMs: 5,
+      },
+    },
+    {
+      fetchFn: async () => {
+        attempt += 1
+        if (attempt < 3) {
+          return new Response(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: `${attempt}`,
+              error: { code: -32004, message: 'temporarily unavailable' },
+            }),
+            { status: 200 },
+          )
+        }
+
+        return new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 'ok',
+            result: { events: [] },
+          }),
+          { status: 200 },
+        )
+      },
+      sleepFn: async () => {
+        return
+      },
+    },
+  )
+
+  const result = await client.getContractEvents()
+  assert.equal(attempt, 3)
+  assert.deepEqual(result.events, [])
+})
+
+test('does not retry non-retryable RPC errors', async () => {
+  let attempt = 0
+
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () => {
+      attempt += 1
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'rpc-error',
+          error: { code: -1, message: 'bad invocation', data: { reason: 'invalid args' } },
+        }),
+        { status: 200 },
+      )
+    },
+  })
+
+  await assert.rejects(client.getContractEvents(), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'RPC_ERROR')
+    assert.equal(error.attempts, 1)
+    assert.deepEqual(error.details, { reason: 'invalid args' })
+    return true
+  })
+
+  assert.equal(attempt, 1)
+})
+
+test('retries on timeout and surfaces timeout error when exhausted', async () => {
+  const client = new SorobanClient(
+    {
+      ...baseConfig,
+      timeoutMs: 5,
+      retry: {
+        maxAttempts: 2,
+        baseDelayMs: 1,
+        backoffMultiplier: 2,
+        maxDelayMs: 5,
+      },
+    },
+    {
+      fetchFn: async (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const abortError = new Error('Aborted')
+            abortError.name = 'AbortError'
+            reject(abortError)
+          })
+        }),
+      sleepFn: async () => {
+        return
+      },
+    },
+  )
+
+  await assert.rejects(client.getContractEvents(), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'TIMEOUT_ERROR')
+    assert.equal(error.attempts, 2)
+    return true
+  })
+})
+
+test('retries on transport errors and throws network error after max attempts', async () => {
+  let attempt = 0
+
+  const client = new SorobanClient(
+    {
+      ...baseConfig,
+      retry: {
+        maxAttempts: 2,
+        baseDelayMs: 1,
+        backoffMultiplier: 2,
+        maxDelayMs: 5,
+      },
+    },
+    {
+      fetchFn: async () => {
+        attempt += 1
+        throw new Error('socket hang up')
+      },
+      sleepFn: async () => {
+        return
+      },
+    },
+  )
+
+  await assert.rejects(client.getContractEvents(), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'NETWORK_ERROR')
+    assert.equal(error.attempts, 2)
+    return true
+  })
+  assert.equal(attempt, 2)
+})
+
+test('normalizes unknown throwables as network errors', async () => {
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () => {
+      throw 'boom'
+    },
+    sleepFn: async () => {
+      return
+    },
+  })
+
+  await assert.rejects(client.getContractEvents(), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'NETWORK_ERROR')
+    assert.equal(error.details, 'boom')
+    return true
+  })
+})
+
+test('surfaces parse error when response JSON is invalid', async () => {
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () =>
+      new Response('not-json', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  })
+
+  await assert.rejects(client.getContractEvents(), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'PARSE_ERROR')
+    return true
+  })
+})
+
+test('does not retry parse errors from invalid payload shape', async () => {
+  let calls = 0
+
+  const client = new SorobanClient(baseConfig, {
+    fetchFn: async () => {
+      calls += 1
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 'no-result',
+        }),
+        { status: 200 },
+      )
+    },
+  })
+
+  await assert.rejects(client.getContractEvents(), (error: unknown) => {
+    assert.ok(error instanceof SorobanClientError)
+    assert.equal(error.code, 'PARSE_ERROR')
+    assert.equal(error.attempts, 1)
+    return true
+  })
+
+  assert.equal(calls, 1)
+})
+
+test('uses createSorobanClient factory and default global fetch dependency', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'factory',
+        result: { events: [], cursor: 'factory-cursor' },
+      }),
+      { status: 200 },
+    )
+
+  try {
+    const client = createSorobanClient(baseConfig)
+    const page = await client.getContractEvents()
+    assert.equal(page.cursor, 'factory-cursor')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test('uses default sleep dependency during retry flow', async () => {
+  const originalFetch = globalThis.fetch
+  let calls = 0
+
+  globalThis.fetch = async () => {
+    calls += 1
+    if (calls === 1) {
+      return new Response('temporarily unavailable', { status: 503 })
+    }
+
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'default-sleep',
+        result: { events: [], cursor: null },
+      }),
+      { status: 200 },
+    )
+  }
+
+  try {
+    const client = createSorobanClient({
+      ...baseConfig,
+      retry: {
+        maxAttempts: 2,
+        baseDelayMs: 0,
+        backoffMultiplier: 2,
+        maxDelayMs: 0,
+      },
+    })
+
+    const result = await client.getContractEvents()
+    assert.equal(calls, 2)
+    assert.equal(result.cursor, null)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/src/clients/soroban.ts
+++ b/src/clients/soroban.ts
@@ -1,0 +1,343 @@
+export type SorobanNetwork = 'testnet' | 'mainnet'
+
+export interface RetryOptions {
+  maxAttempts: number
+  baseDelayMs: number
+  maxDelayMs: number
+  backoffMultiplier: number
+}
+
+export interface SorobanClientConfig {
+  rpcUrl: string
+  network: SorobanNetwork
+  contractId: string
+  timeoutMs?: number
+  retry?: Partial<RetryOptions>
+}
+
+export interface ContractEvent {
+  id?: string
+  type?: string
+  ledger?: number
+  topic?: string[]
+  value?: unknown
+  [key: string]: unknown
+}
+
+export interface ContractEventsPage {
+  events: ContractEvent[]
+  cursor: string | null
+}
+
+interface SorobanRpcResponse<T> {
+  jsonrpc: string
+  id: string
+  result?: T
+  error?: {
+    code: number
+    message: string
+    data?: unknown
+  }
+}
+
+export interface SorobanClientDependencies {
+  fetchFn?: typeof fetch
+  sleepFn?: (ms: number) => Promise<void>
+}
+
+export class SorobanClientError extends Error {
+  public readonly code:
+    | 'CONFIG_ERROR'
+    | 'NETWORK_ERROR'
+    | 'TIMEOUT_ERROR'
+    | 'HTTP_ERROR'
+    | 'RPC_ERROR'
+    | 'PARSE_ERROR'
+
+  public readonly status?: number
+  public readonly rpcCode?: number
+  public readonly details?: unknown
+  public readonly attempts: number
+
+  constructor(params: {
+    message: string
+    code:
+      | 'CONFIG_ERROR'
+      | 'NETWORK_ERROR'
+      | 'TIMEOUT_ERROR'
+      | 'HTTP_ERROR'
+      | 'RPC_ERROR'
+      | 'PARSE_ERROR'
+    attempts?: number
+    status?: number
+    rpcCode?: number
+    details?: unknown
+    cause?: unknown
+  }) {
+    super(params.message, { cause: params.cause })
+    this.name = 'SorobanClientError'
+    this.code = params.code
+    this.status = params.status
+    this.rpcCode = params.rpcCode
+    this.details = params.details
+    this.attempts = params.attempts ?? 1
+  }
+}
+
+const DEFAULT_RETRY: RetryOptions = {
+  maxAttempts: 3,
+  baseDelayMs: 200,
+  maxDelayMs: 2_000,
+  backoffMultiplier: 2,
+}
+
+export class SorobanClient {
+  private readonly rpcUrl: string
+  private readonly network: SorobanNetwork
+  private readonly contractId: string
+  private readonly timeoutMs: number
+  private readonly retryOptions: RetryOptions
+  private readonly fetchFn: typeof fetch
+  private readonly sleepFn: (ms: number) => Promise<void>
+
+  constructor(config: SorobanClientConfig, deps: SorobanClientDependencies = {}) {
+    this.assertConfig(config)
+
+    this.rpcUrl = config.rpcUrl
+    this.network = config.network
+    this.contractId = config.contractId
+    this.timeoutMs = config.timeoutMs ?? 5_000
+    this.retryOptions = { ...DEFAULT_RETRY, ...(config.retry ?? {}) }
+    this.fetchFn = deps.fetchFn ?? fetch
+    this.sleepFn = deps.sleepFn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+  }
+
+  /**
+   * Fetches the current identity state for an address from the configured contract.
+   */
+  async getIdentityState(address: string): Promise<unknown> {
+    if (!address?.trim()) {
+      throw new SorobanClientError({
+        code: 'CONFIG_ERROR',
+        message: 'Address is required for getIdentityState(address).',
+      })
+    }
+
+    return this.callRpc<unknown>('getContractData', {
+      contractId: this.contractId,
+      network: this.network,
+      key: { type: 'identity', address },
+    })
+  }
+
+  /**
+   * Fetches contract-scoped events and returns the normalized next cursor.
+   */
+  async getContractEvents(cursor?: string): Promise<ContractEventsPage> {
+    const result = await this.callRpc<{
+      events?: ContractEvent[]
+      latestCursor?: string
+      cursor?: string
+    }>('getEvents', {
+      network: this.network,
+      contractIds: [this.contractId],
+      ...(cursor ? { cursor } : {}),
+    })
+
+    return {
+      events: result.events ?? [],
+      cursor: result.latestCursor ?? result.cursor ?? null,
+    }
+  }
+
+  private assertConfig(config: SorobanClientConfig): void {
+    if (!config.rpcUrl?.trim()) {
+      throw new SorobanClientError({
+        code: 'CONFIG_ERROR',
+        message: 'Soroban client configuration requires rpcUrl.',
+      })
+    }
+
+    if (!config.contractId?.trim()) {
+      throw new SorobanClientError({
+        code: 'CONFIG_ERROR',
+        message: 'Soroban client configuration requires contractId.',
+      })
+    }
+
+    if (!config.network || (config.network !== 'testnet' && config.network !== 'mainnet')) {
+      throw new SorobanClientError({
+        code: 'CONFIG_ERROR',
+        message: 'Soroban client configuration requires network: testnet | mainnet.',
+      })
+    }
+  }
+
+  private async callRpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    let attempt = 0
+    let lastError: SorobanClientError | null = null
+
+    while (attempt < this.retryOptions.maxAttempts) {
+      attempt += 1
+      try {
+        return await this.executeRpc<T>(method, params, attempt)
+      } catch (error) {
+        const normalized = this.normalizeError(error, attempt)
+        lastError = normalized
+
+        const hasAttemptsRemaining = attempt < this.retryOptions.maxAttempts
+        const shouldRetry = hasAttemptsRemaining && this.isRetryable(normalized)
+
+        if (!shouldRetry) {
+          throw normalized
+        }
+
+        const delay = this.getDelayMs(attempt)
+        await this.sleepFn(delay)
+      }
+    }
+
+    throw (
+      lastError ??
+      new SorobanClientError({
+        code: 'NETWORK_ERROR',
+        message: `Unknown Soroban RPC failure after ${this.retryOptions.maxAttempts} attempts.`,
+        attempts: this.retryOptions.maxAttempts,
+      })
+    )
+  }
+
+  private async executeRpc<T>(
+    method: string,
+    params: Record<string, unknown>,
+    attempt: number,
+  ): Promise<T> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    try {
+      const response = await this.fetchFn(this.rpcUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `${method}-${attempt}`,
+          method,
+          params,
+        }),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        throw this.buildHttpError(response.status, attempt)
+      }
+
+      let payload: SorobanRpcResponse<T>
+      try {
+        payload = (await response.json()) as SorobanRpcResponse<T>
+      } catch (error) {
+        throw new SorobanClientError({
+          code: 'PARSE_ERROR',
+          message: 'Unable to parse Soroban RPC response JSON.',
+          attempts: attempt,
+          cause: error,
+        })
+      }
+
+      if (payload.error) {
+        throw new SorobanClientError({
+          code: 'RPC_ERROR',
+          message: `Soroban RPC error: ${payload.error.message}`,
+          rpcCode: payload.error.code,
+          details: payload.error.data,
+          attempts: attempt,
+        })
+      }
+
+      if (payload.result === undefined) {
+        throw new SorobanClientError({
+          code: 'PARSE_ERROR',
+          message: 'Soroban RPC response missing result field.',
+          attempts: attempt,
+        })
+      }
+
+      return payload.result
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  private buildHttpError(status: number, attempts: number): SorobanClientError {
+    return new SorobanClientError({
+      code: 'HTTP_ERROR',
+      message: `Soroban RPC request failed with HTTP ${status}.`,
+      status,
+      attempts,
+    })
+  }
+
+  private normalizeError(error: unknown, attempts: number): SorobanClientError {
+    if (error instanceof SorobanClientError) {
+      return error
+    }
+
+    if (error instanceof Error && error.name === 'AbortError') {
+      return new SorobanClientError({
+        code: 'TIMEOUT_ERROR',
+        message: `Soroban RPC request timed out after ${this.timeoutMs}ms.`,
+        attempts,
+        cause: error,
+      })
+    }
+
+    if (error instanceof Error) {
+      return new SorobanClientError({
+        code: 'NETWORK_ERROR',
+        message: `Soroban RPC transport error: ${error.message}`,
+        attempts,
+        cause: error,
+      })
+    }
+
+    return new SorobanClientError({
+      code: 'NETWORK_ERROR',
+      message: 'Unknown Soroban RPC transport error.',
+      attempts,
+      details: error,
+    })
+  }
+
+  private isRetryable(error: SorobanClientError): boolean {
+    if (error.code === 'NETWORK_ERROR' || error.code === 'TIMEOUT_ERROR') {
+      return true
+    }
+
+    if (error.code === 'HTTP_ERROR') {
+      return error.status === 408 || error.status === 429 || (error.status !== undefined && error.status >= 500)
+    }
+
+    if (error.code === 'RPC_ERROR') {
+      return error.rpcCode === -32004 || error.rpcCode === -32005
+    }
+
+    return false
+  }
+
+  private getDelayMs(attempt: number): number {
+    const delay =
+      this.retryOptions.baseDelayMs *
+      Math.pow(this.retryOptions.backoffMultiplier, Math.max(0, attempt - 1))
+
+    return Math.min(delay, this.retryOptions.maxDelayMs)
+  }
+}
+
+export function createSorobanClient(
+  config: SorobanClientConfig,
+  deps?: SorobanClientDependencies,
+): SorobanClient {
+  return new SorobanClient(config, deps)
+}


### PR DESCRIPTION
Closes #44

## Changes
- Added a dedicated Stellar/Soroban adapter at `src/clients/soroban.ts`.
- Encapsulated Soroban config in one client:
  - `rpcUrl`
  - `network` (`testnet` | `mainnet`)
  - `contractId`
  - timeout + retry/backoff options
- Implemented facade methods:
  - `getIdentityState(address)`
  - `getContractEvents(cursor?)`
- Added consistent error handling via `SorobanClientError` with typed error codes:
  - `CONFIG_ERROR`, `NETWORK_ERROR`, `TIMEOUT_ERROR`, `HTTP_ERROR`, `RPC_ERROR`, `PARSE_ERROR`
- Added retry/backoff behavior for retryable transport/HTTP/RPC errors.
- Added integration docs: `docs/stellar-integration.md`.
- Added test script in `package.json`:
  - `npm test` → `tsx --test src/**/*.test.ts`

## Testing
Commands run:
- `npm test`
- `npm run build`
- `node --test --experimental-test-coverage dist/clients/soroban.test.js`

Results:
- Tests: `19 passed, 0 failed`
- Coverage (`dist/clients/soroban.js`):
  - Line: `97.80%`
  - Branch: `98.53%`
  - Functions: `100.00%`

## Notes
- This PR implements the adapter in isolation (client + tests + docs).
- Route wiring in `src/index.ts` is intentionally out of scope for this issue and can be done in a follow-up PR.
