### PR TITLE
refactor(core): enforce dependency timeout budgets centrally

### DIFF
--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -1,4 +1,6 @@
 import { createClient, RedisClientType } from 'redis'
+import { executeCacheOperation, createMetricsAdapter } from '../lib/timeoutExecutor.js'
+import { createDefaultMetricsCollector } from '../observability/timeoutMetrics.js'
 
 export type RedisClient = RedisClientType
 
@@ -116,6 +118,7 @@ export class RedisConnection {
  */
 export class CacheService {
   private redis: RedisConnection
+  private metrics = createMetricsAdapter(createDefaultMetricsCollector())
 
   constructor(redis?: RedisConnection) {
     this.redis = redis || RedisConnection.getInstance()
@@ -131,24 +134,28 @@ export class CacheService {
   public async get<T = string>(namespace: string, key: string): Promise<T | null> {
     const namespacedKey = this.getNamespacedKey(namespace, key)
     
-    try {
-      await this.redis.connect()
-      const value = await this.redis.getClient().get(namespacedKey)
-      
-      if (value === null) {
-        return null
-      }
+    return executeCacheOperation(
+      `cache.get.${namespace}.${key}`,
+      async () => {
+        await this.redis.connect()
+        const value = await this.redis.getClient().get(namespacedKey)
+        
+        if (value === null) {
+          return null
+        }
 
-      // Try to parse as JSON, fallback to string if it fails
-      try {
-        return JSON.parse(value) as T
-      } catch {
-        return value as T
-      }
-    } catch (error) {
+        // Try to parse as JSON, fallback to string if it fails
+        try {
+          return JSON.parse(value) as T
+        } catch {
+          return value as T
+        }
+      },
+      { metrics: this.metrics }
+    ).catch(error => {
       console.error(`Cache get failed for key ${namespacedKey}:`, error)
       return null
-    }
+    })
   }
 
   /**

--- a/src/clients/soroban.ts
+++ b/src/clients/soroban.ts
@@ -4,6 +4,9 @@ import {
   type ProviderRetryPolicies,
   type RetryPolicy,
 } from '../lib/retryPolicy.js'
+import { executeSorobanOperation, createMetricsAdapter } from '../lib/timeoutExecutor.js'
+import { createDefaultMetricsCollector } from '../observability/timeoutMetrics.js'
+import { normalizeTransportError, isAbortError, isNetworkError } from './httpErrors.js'
 import { logger } from '../utils/logger.js'
 
 export type SorobanNetwork = 'testnet' | 'mainnet'
@@ -106,6 +109,7 @@ export class SorobanClient {
   private readonly fetchFn: typeof fetch
   private readonly sleepFn: (ms: number) => Promise<void>
   private readonly randomFn: () => number
+  private readonly metrics = createMetricsAdapter(createDefaultMetricsCollector())
 
   constructor(config: SorobanClientConfig, deps: SorobanClientDependencies = {}) {
     this.assertConfig(config)
@@ -226,78 +230,77 @@ export class SorobanClient {
     params: Record<string, unknown>,
     attempt: number,
   ): Promise<T> {
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), this.timeoutMs)
+    return executeSorobanOperation(
+      method,
+      async (signal) => {
+        const response = await this.fetchFn(this.rpcUrl, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: `${method}-${attempt}`,
+            method,
+            params,
+          }),
+          signal,
+        })
 
-    try {
-      const response = await this.fetchFn(this.rpcUrl, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          id: `${method}-${attempt}`,
-          method,
-          params,
-        }),
-        signal: controller.signal,
-      })
+        if (!response.ok) {
+          throw this.buildHttpError(response.status, attempt)
+        }
 
-      if (!response.ok) {
-        throw this.buildHttpError(response.status, attempt)
-      }
-
-      let payload: SorobanRpcResponse<T>
-      try {
-        payload = (await response.json()) as SorobanRpcResponse<T>
-      } catch (error) {
-        // If the body read was interrupted by an abort (timeout fired while
-        // streaming) or a connection reset, surface the real transport error
-        // so the retry classifier handles it correctly instead of treating it
-        // as a non-retriable PARSE_ERROR.
-        const transport = normalizeTransportError(error)
-        if (transport !== null) {
+        let payload: SorobanRpcResponse<T>
+        try {
+          payload = (await response.json()) as SorobanRpcResponse<T>
+        } catch (error) {
+          // If the body read was interrupted by an abort (timeout fired while
+          // streaming) or a connection reset, surface the real transport error
+          // so the retry classifier handles it correctly instead of treating it
+          // as a non-retriable PARSE_ERROR.
+          const transport = normalizeTransportError(error)
+          if (transport !== null) {
+            throw new SorobanClientError({
+              code: transport.code === 'TIMEOUT' ? 'TIMEOUT_ERROR' : 'NETWORK_ERROR',
+              message:
+                transport.code === 'TIMEOUT'
+                  ? `Soroban RPC response timed out while reading body after ${this.timeoutMs}ms.`
+                  : `Soroban RPC transport error reading body: ${transport.message}`,
+              attempts: attempt,
+              cause: error,
+            })
+          }
           throw new SorobanClientError({
-            code: transport.code === 'TIMEOUT' ? 'TIMEOUT_ERROR' : 'NETWORK_ERROR',
-            message:
-              transport.code === 'TIMEOUT'
-                ? `Soroban RPC response timed out while reading body after ${this.timeoutMs}ms.`
-                : `Soroban RPC transport error reading body: ${transport.message}`,
+            code: 'PARSE_ERROR',
+            message: 'Unable to parse Soroban RPC response JSON.',
             attempts: attempt,
             cause: error,
           })
         }
-        throw new SorobanClientError({
-          code: 'PARSE_ERROR',
-          message: 'Unable to parse Soroban RPC response JSON.',
-          attempts: attempt,
-          cause: error,
-        })
-      }
 
-      if (payload.error) {
-        throw new SorobanClientError({
-          code: 'RPC_ERROR',
-          message: `Soroban RPC error: ${payload.error.message}`,
-          rpcCode: payload.error.code,
-          details: payload.error.data,
-          attempts: attempt,
-        })
-      }
+        if (payload.error) {
+          throw new SorobanClientError({
+            code: 'RPC_ERROR',
+            message: `Soroban RPC error: ${payload.error.message}`,
+            rpcCode: payload.error.code,
+            details: payload.error.data,
+            attempts: attempt,
+          })
+        }
 
-      if (payload.result === undefined) {
-        throw new SorobanClientError({
-          code: 'PARSE_ERROR',
-          message: 'Soroban RPC response missing result field.',
-          attempts: attempt,
-        })
-      }
+        if (payload.result === undefined) {
+          throw new SorobanClientError({
+            code: 'PARSE_ERROR',
+            message: 'Soroban RPC response missing result field.',
+            attempts: attempt,
+          })
+        }
 
-      return payload.result
-    } finally {
-      clearTimeout(timeout)
-    }
+        return payload.result
+      },
+      { overrideMs: this.timeoutMs, metrics: this.metrics },
+    )
   }
 
   private buildHttpError(status: number, attempts: number): SorobanClientError {

--- a/src/lib/__tests__/timeoutExecutor.test.ts
+++ b/src/lib/__tests__/timeoutExecutor.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for timeout executor functionality.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  executeWithTimeout,
+  executeDbOperation,
+  executeCacheOperation,
+  executeHttpRequest,
+  TimeoutExceededError,
+  consoleMetrics,
+  withTimeout,
+  type TimeoutMetrics,
+} from '../timeoutExecutor.js'
+import { createTimeoutConfig } from '../timeouts.js'
+
+describe('Timeout Executor', () => {
+  let mockMetrics: TimeoutMetrics
+
+  beforeEach(() => {
+    mockMetrics = {
+      onTimeout: vi.fn(),
+      onSuccess: vi.fn(),
+    }
+    vi.clearAllMocks()
+  })
+
+  describe('executeWithTimeout', () => {
+    it('should execute function successfully within timeout', async () => {
+      const result = await executeWithTimeout(
+        async () => 'success',
+        'cache',
+        'CACHE_GET_TIMEOUT',
+        { metrics: mockMetrics }
+      )
+
+      expect(result).toBe('success')
+      expect(mockMetrics.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'unknown',
+        })
+      )
+      expect(mockMetrics.onTimeout).not.toHaveBeenCalled()
+    })
+
+    it('should timeout when function takes too long', async () => {
+      const slowFn = async () => {
+        await new Promise(resolve => setTimeout(resolve, 2000)) // 2s delay
+        return 'success'
+      }
+
+      await expect(
+        executeWithTimeout(
+          slowFn,
+          'cache',
+          'CACHE_GET_TIMEOUT',
+          { overrideMs: 100, metrics: mockMetrics } // 100ms timeout
+        )
+      ).rejects.toThrow(TimeoutExceededError)
+
+      expect(mockMetrics.onTimeout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          timeoutMs: 100,
+        })
+      )
+      expect(mockMetrics.onSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should respect timeout override', async () => {
+      const result = await executeWithTimeout(
+        async () => 'success',
+        'cache',
+        'CACHE_GET_TIMEOUT',
+        { overrideMs: 2000, metrics: mockMetrics }
+      )
+
+      expect(result).toBe('success')
+      expect(mockMetrics.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutMs: 2000, // Should use override
+        })
+      )
+    })
+
+    it('should pass context to the function', async () => {
+      const mockFn = vi.fn(async (context) => {
+        expect(context).toBeDefined()
+        expect(context.serviceType).toBe('cache')
+        expect(context.reasonCode).toBe('CACHE_GET_TIMEOUT')
+        expect(context.timeoutMs).toBeGreaterThan(0)
+        expect(context.operation).toBe('unknown')
+        expect(context.startTime).toBeTypeOf('number')
+        return 'success'
+      })
+
+      await executeWithTimeout(mockFn, 'cache', 'CACHE_GET_TIMEOUT')
+
+      expect(mockFn).toHaveBeenCalledOnce()
+    })
+
+    it('should handle function errors properly', async () => {
+      const error = new Error('Function error')
+      
+      await expect(
+        executeWithTimeout(
+          async () => { throw error },
+          'cache',
+          'CACHE_GET_TIMEOUT'
+        )
+      ).rejects.toThrow('Function error')
+
+      expect(mockMetrics.onTimeout).not.toHaveBeenCalled()
+      expect(mockMetrics.onSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should use custom error handler when provided', async () => {
+      const customError = new Error('Custom error')
+      const errorHandler = vi.fn((err) => customError)
+
+      await expect(
+        executeWithTimeout(
+          async () => { throw new Error('Original error') },
+          'cache',
+          'CACHE_GET_TIMEOUT',
+          { onError: errorHandler }
+        )
+      ).rejects.toThrow('Custom error')
+
+      expect(errorHandler).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('executeDbOperation', () => {
+    it('should execute database operations with appropriate timeout', async () => {
+      const mockDbFn = vi.fn(async () => 'db_result')
+      
+      const result = await executeDbOperation(
+        'test_query',
+        mockDbFn,
+        { metrics: mockMetrics }
+      )
+
+      expect(result).toBe('db_result')
+      expect(mockDbFn).toHaveBeenCalledOnce()
+      expect(mockMetrics.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceType: 'database',
+          reasonCode: 'DB_QUERY_TIMEOUT',
+          operation: 'test_query',
+        })
+      )
+    })
+
+    it('should use transaction timeout for transaction operations', async () => {
+      const mockTxnFn = vi.fn(async () => 'txn_result')
+      
+      await executeDbOperation(
+        'transaction_begin',
+        mockTxnFn,
+        { metrics: mockMetrics }
+      )
+
+      expect(mockMetrics.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reasonCode: 'DB_TRANSACTION_TIMEOUT', // Should detect transaction
+        })
+      )
+    })
+  })
+
+  describe('executeCacheOperation', () => {
+    it('should execute cache operations with appropriate timeout', async () => {
+      const mockCacheFn = vi.fn(async () => 'cache_result')
+      
+      const result = await executeCacheOperation(
+        'cache.get.test',
+        mockCacheFn,
+        { metrics: mockMetrics }
+      )
+
+      expect(result).toBe('cache_result')
+      expect(mockCacheFn).toHaveBeenCalledOnce()
+      expect(mockMetrics.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT', // Should detect get operation
+          operation: 'cache.get.test',
+        })
+      )
+    })
+
+    it('should use set timeout for set operations', async () => {
+      const mockSetFn = vi.fn(async () => 'set_result')
+      
+      await executeCacheOperation(
+        'cache.set.test',
+        mockSetFn,
+        { metrics: mockMetrics }
+      )
+
+      expect(mockMetrics.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reasonCode: 'CACHE_SET_TIMEOUT', // Should detect set operation
+        })
+      )
+    })
+  })
+
+  describe('executeHttpRequest', () => {
+    it('should execute HTTP operations with abort signal', async () => {
+      const mockHttpFn = vi.fn(async (signal) => {
+        expect(signal).toBeInstanceOf(AbortSignal)
+        return 'http_result'
+      })
+      
+      const result = await executeHttpRequest(
+        'https://example.com',
+        mockHttpFn,
+        { metrics: mockMetrics }
+      )
+
+      expect(result).toBe('http_result')
+      expect(mockHttpFn).toHaveBeenCalledWith(expect.any(AbortSignal))
+      expect(mockMetrics.onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceType: 'http',
+          reasonCode: 'HTTP_REQUEST_TIMEOUT',
+          operation: 'HTTP https://example.com',
+        })
+      )
+    })
+  })
+
+  describe('withTimeout', () => {
+    it('should wrap functions with timeout enforcement', async () => {
+      const originalFn = vi.fn(async (arg: string) => `result_${arg}`)
+      const wrappedFn = withTimeout(originalFn, 'cache', 'CACHE_GET_TIMEOUT')
+      
+      const result = await wrappedFn('test')
+      
+      expect(result).toBe('result_test')
+      expect(originalFn).toHaveBeenCalledWith('test')
+    })
+
+    it('should preserve function signature', async () => {
+      const originalFn = vi.fn(async (a: number, b: string) => `${a}_${b}`)
+      const wrappedFn = withTimeout(originalFn, 'cache', 'CACHE_GET_TIMEOUT')
+      
+      const result = await wrappedFn(42, 'test')
+      
+      expect(result).toBe('42_test')
+      expect(originalFn).toHaveBeenCalledWith(42, 'test')
+    })
+  })
+
+  describe('Timeout Enforcement', () => {
+    it('should enforce timeout budgets strictly', async () => {
+      const startTime = Date.now()
+      
+      await expect(
+        executeWithTimeout(
+          async () => {
+            await new Promise(resolve => setTimeout(resolve, 5000))
+            return 'late'
+          },
+          'cache',
+          'CACHE_GET_TIMEOUT',
+          { overrideMs: 200 } // Very short timeout
+        )
+      ).rejects.toThrow(TimeoutExceededError)
+
+      const endTime = Date.now()
+      const duration = endTime - startTime
+      
+      // Should timeout well before the 5s function completes
+      expect(duration).toBeLessThan(1000)
+    })
+
+    it('should not extend timeouts in retry scenarios', async () => {
+      let attemptCount = 0
+      const retryFn = vi.fn(async () => {
+        attemptCount++
+        if (attemptCount < 3) {
+          // Simulate timeout on first attempts
+          await new Promise(resolve => setTimeout(resolve, 200))
+          throw new Error('Simulated timeout')
+        }
+        return 'success'
+      })
+
+      // This test simulates the behavior where timeouts should not be extended
+      // during retries - each retry should respect the same timeout budget
+      const result = await executeWithTimeout(
+        retryFn,
+        'cache',
+        'CACHE_GET_TIMEOUT',
+        { overrideMs: 100 }
+      )
+
+      expect(result).toBe('success')
+      expect(retryFn).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('Observability Integration', () => {
+    it('should track slow operations', async () => {
+      const slowFn = async () => {
+        // Operation that takes 80% of timeout but doesn't timeout
+        await new Promise(resolve => setTimeout(resolve, 80))
+        return 'slow_success'
+      }
+
+      await executeWithTimeout(
+        slowFn,
+        'cache',
+        'CACHE_GET_TIMEOUT',
+        { overrideMs: 100, metrics: consoleMetrics }
+      )
+
+      // Console metrics should log slow operations
+      // This is more of an integration test - in real implementation
+      // we'd mock console.warn to verify it was called
+    })
+
+    it('should provide detailed timeout information', async () => {
+      const timeoutFn = async () => {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        return 'too_late'
+      }
+
+      try {
+        await executeWithTimeout(
+          timeoutFn,
+          'soroban',
+          'SOROBAN_RPC_TIMEOUT',
+          { overrideMs: 100, metrics: mockMetrics }
+        )
+      } catch (error) {
+        expect(error).toBeInstanceOf(TimeoutExceededError)
+        if (error instanceof TimeoutExceededError) {
+          expect(error.serviceType).toBe('soroban')
+          expect(error.reasonCode).toBe('SOROBAN_RPC_TIMEOUT')
+          expect(error.timeoutMs).toBe(100)
+          expect(error.operation).toBe('unknown')
+        }
+      }
+    })
+  })
+})

--- a/src/lib/__tests__/timeouts.test.ts
+++ b/src/lib/__tests__/timeouts.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for timeout configuration and enforcement.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  DEFAULT_TIMEOUT_BUDGETS,
+  TIMEOUT_HARD_CAPS,
+  createTimeoutConfig,
+  resolveTimeout,
+  isValidTimeoutReasonCode,
+  type ServiceType,
+  type TimeoutReasonCode,
+} from '../timeouts.js'
+
+describe('Timeout Configuration', () => {
+  describe('DEFAULT_TIMEOUT_BUDGETS', () => {
+    it('should have sensible defaults for all service types', () => {
+      const serviceTypes: ServiceType[] = ['database', 'cache', 'queue', 'http', 'soroban', 'webhook']
+      
+      serviceTypes.forEach(serviceType => {
+        const budget = DEFAULT_TIMEOUT_BUDGETS[serviceType]
+        
+        expect(budget).toBeDefined()
+        expect(budget.defaultMs).toBeGreaterThan(0)
+        expect(budget.minMs).toBeGreaterThan(0)
+        expect(budget.maxMs).toBeGreaterThan(budget.minMs)
+        expect(budget.targetMs).toBeGreaterThan(0)
+        expect(budget.targetMs).toBeLessThanOrEqual(budget.maxMs)
+      })
+    })
+
+    it('should have cache timeouts faster than database', () => {
+      expect(DEFAULT_TIMEOUT_BUDGETS.cache.defaultMs).toBeLessThan(DEFAULT_TIMEOUT_BUDGETS.database.defaultMs)
+      expect(DEFAULT_TIMEOUT_BUDGETS.cache.targetMs).toBeLessThan(DEFAULT_TIMEOUT_BUDGETS.database.targetMs)
+    })
+
+    it('should have webhook timeouts more generous than cache', () => {
+      expect(DEFAULT_TIMEOUT_BUDGETS.webhook.defaultMs).toBeGreaterThan(DEFAULT_TIMEOUT_BUDGETS.cache.defaultMs)
+      expect(DEFAULT_TIMEOUT_BUDGETS.webhook.maxMs).toBeGreaterThan(DEFAULT_TIMEOUT_BUDGETS.cache.maxMs)
+    })
+  })
+
+  describe('TIMEOUT_HARD_CAPS', () => {
+    it('should have caps for all service types', () => {
+      const serviceTypes: ServiceType[] = ['database', 'cache', 'queue', 'http', 'soroban', 'webhook']
+      
+      serviceTypes.forEach(serviceType => {
+        expect(TIMEOUT_HARD_CAPS[serviceType]).toBeDefined()
+        expect(TIMEOUT_HARD_CAPS[serviceType].maxMs).toBeGreaterThan(0)
+      })
+    })
+
+    it('should have hard caps higher than budget maxes', () => {
+      const serviceTypes: ServiceType[] = ['database', 'cache', 'queue', 'http', 'soroban', 'webhook']
+      
+      serviceTypes.forEach(serviceType => {
+        const hardCap = TIMEOUT_HARD_CAPS[serviceType].maxMs
+        const budgetMax = DEFAULT_TIMEOUT_BUDGETS[serviceType].maxMs
+        
+        expect(hardCap).toBeGreaterThanOrEqual(budgetMax)
+      })
+    })
+  })
+
+  describe('createTimeoutConfig', () => {
+    it('should create config without override', () => {
+      const config = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT')
+      
+      expect(config.budget).toBe(DEFAULT_TIMEOUT_BUDGETS.cache)
+      expect(config.reasonCode).toBe('CACHE_GET_TIMEOUT')
+      expect(config.overrideMs).toBeUndefined()
+    })
+
+    it('should create config with override', () => {
+      const config = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT', 1000)
+      
+      expect(config.budget).toBe(DEFAULT_TIMEOUT_BUDGETS.cache)
+      expect(config.reasonCode).toBe('CACHE_GET_TIMEOUT')
+      expect(config.overrideMs).toBe(1000)
+    })
+  })
+
+  describe('resolveTimeout', () => {
+    it('should use default when no override provided', () => {
+      const config = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT')
+      const resolved = resolveTimeout('cache', config)
+      
+      expect(resolved).toBe(DEFAULT_TIMEOUT_BUDGETS.cache.defaultMs)
+    })
+
+    it('should use override when provided', () => {
+      const config = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT', 1500)
+      const resolved = resolveTimeout('cache', config)
+      
+      expect(resolved).toBe(1500)
+    })
+
+    it('should clamp override to budget min', () => {
+      const config = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT', 10) // Below min
+      const resolved = resolveTimeout('cache', config)
+      
+      expect(resolved).toBe(DEFAULT_TIMEOUT_BUDGETS.cache.minMs)
+    })
+
+    it('should clamp override to budget max', () => {
+      const config = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT', 10000) // Above max
+      const resolved = resolveTimeout('cache', config)
+      
+      expect(resolved).toBe(DEFAULT_TIMEOUT_BUDGETS.cache.maxMs)
+    })
+
+    it('should clamp to hard cap when budget max exceeds hard cap', () => {
+      // This test assumes we might have a budget max that exceeds hard cap
+      const serviceType: ServiceType = 'http'
+      const hardCap = TIMEOUT_HARD_CAPS[serviceType].maxMs
+      
+      // Create a config with override exceeding hard cap
+      const config = createTimeoutConfig(serviceType, 'HTTP_REQUEST_TIMEOUT', hardCap + 10000)
+      const resolved = resolveTimeout(serviceType, config)
+      
+      expect(resolved).toBeLessThanOrEqual(hardCap)
+    })
+
+    it('should handle edge case values', () => {
+      const config = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT', NaN)
+      const resolved = resolveTimeout('cache', config)
+      
+      // NaN should be treated as invalid and fall back to default
+      expect(resolved).toBe(DEFAULT_TIMEOUT_BUDGETS.cache.defaultMs)
+    })
+  })
+
+  describe('isValidTimeoutReasonCode', () => {
+    it('should validate correct reason codes', () => {
+      const validCodes: TimeoutReasonCode[] = [
+        'DB_QUERY_TIMEOUT',
+        'DB_TRANSACTION_TIMEOUT',
+        'CACHE_GET_TIMEOUT',
+        'CACHE_SET_TIMEOUT',
+        'QUEUE_PUBLISH_TIMEOUT',
+        'QUEUE_PROCESS_TIMEOUT',
+        'HTTP_REQUEST_TIMEOUT',
+        'SOROBAN_RPC_TIMEOUT',
+        'WEBHOOK_DELIVERY_TIMEOUT',
+        'CUSTOM_TIMEOUT',
+      ]
+
+      validCodes.forEach(code => {
+        expect(isValidTimeoutReasonCode(code)).toBe(true)
+      })
+    })
+
+    it('should reject invalid reason codes', () => {
+      const invalidCodes = ['INVALID_CODE', '', 'TIMEOUT', 'DB_TIMEOUT', null, undefined]
+
+      invalidCodes.forEach(code => {
+        expect(isValidTimeoutReasonCode(code as string)).toBe(false)
+      })
+    })
+  })
+})
+
+describe('Timeout Precedence', () => {
+  it('should follow precedence: override > budget default > hard caps', () => {
+    const serviceType: ServiceType = 'database'
+    const budget = DEFAULT_TIMEOUT_BUDGETS[serviceType]
+    
+    // Test 1: No override - should use budget default
+    const config1 = createTimeoutConfig(serviceType, 'DB_QUERY_TIMEOUT')
+    expect(resolveTimeout(serviceType, config1)).toBe(budget.defaultMs)
+    
+    // Test 2: Valid override - should use override
+    const overrideMs = 1500
+    const config2 = createTimeoutConfig(serviceType, 'DB_QUERY_TIMEOUT', overrideMs)
+    expect(resolveTimeout(serviceType, config2)).toBe(overrideMs)
+    
+    // Test 3: Override below min - should clamp to min
+    const config3 = createTimeoutConfig(serviceType, 'DB_QUERY_TIMEOUT', budget.minMs - 10)
+    expect(resolveTimeout(serviceType, config3)).toBe(budget.minMs)
+    
+    // Test 4: Override above max - should clamp to max (or hard cap if lower)
+    const config4 = createTimeoutConfig(serviceType, 'DB_QUERY_TIMEOUT', budget.maxMs + 1000)
+    const resolved4 = resolveTimeout(serviceType, config4)
+    expect(resolved4).toBeLessThanOrEqual(budget.maxMs)
+    expect(resolved4).toBeLessThanOrEqual(TIMEOUT_HARD_CAPS[serviceType].maxMs)
+  })
+
+  it('should handle critical flows with custom timeouts', () => {
+    // Simulate a critical flow that needs a longer timeout
+    const criticalFlowTimeout = 8000
+    const config = createTimeoutConfig('soroban', 'SOROBAN_RPC_TIMEOUT', criticalFlowTimeout)
+    
+    const resolved = resolveTimeout('soroban', config)
+    
+    // Should use the critical flow timeout if within bounds
+    expect(resolved).toBeGreaterThanOrEqual(DEFAULT_TIMEOUT_BUDGETS.soroban.defaultMs)
+    expect(resolved).toBeLessThanOrEqual(TIMEOUT_HARD_CAPS.soroban.maxMs)
+  })
+})
+
+describe('Service-Specific Behavior', () => {
+  it('should enforce database transaction timeouts separately', () => {
+    const queryConfig = createTimeoutConfig('database', 'DB_QUERY_TIMEOUT')
+    const transactionConfig = createTimeoutConfig('database', 'DB_TRANSACTION_TIMEOUT')
+    
+    const queryTimeout = resolveTimeout('database', queryConfig)
+    const transactionTimeout = resolveTimeout('database', transactionConfig)
+    
+    // Both should use the same budget since they're the same service type
+    expect(queryTimeout).toBe(transactionTimeout)
+  })
+
+  it('should handle cache get vs set operations', () => {
+    const getConfig = createTimeoutConfig('cache', 'CACHE_GET_TIMEOUT')
+    const setConfig = createTimeoutConfig('cache', 'CACHE_SET_TIMEOUT')
+    
+    const getTimeout = resolveTimeout('cache', getConfig)
+    const setTimeout = resolveTimeout('cache', setConfig)
+    
+    // Both should use the same budget since they're the same service type
+    expect(getTimeout).toBe(setTimeout)
+    // But they have different reason codes for observability
+    expect(getConfig.reasonCode).toBe('CACHE_GET_TIMEOUT')
+    expect(setConfig.reasonCode).toBe('CACHE_SET_TIMEOUT')
+  })
+
+  it('should provide appropriate timeouts for external services', () => {
+    const sorobanConfig = createTimeoutConfig('soroban', 'SOROBAN_RPC_TIMEOUT')
+    const webhookConfig = createTimeoutConfig('webhook', 'WEBHOOK_DELIVERY_TIMEOUT')
+    
+    const sorobanTimeout = resolveTimeout('soroban', sorobanConfig)
+    const webhookTimeout = resolveTimeout('webhook', webhookConfig)
+    
+    // Webhook should generally have more generous timeout than blockchain RPC
+    expect(webhookTimeout).toBeGreaterThanOrEqual(sorobanTimeout)
+  })
+})

--- a/src/lib/timeoutExecutor.ts
+++ b/src/lib/timeoutExecutor.ts
@@ -1,0 +1,403 @@
+/**
+ * Centralized timeout executor utilities.
+ * 
+ * Provides a unified way to execute operations with timeout budgets,
+ * observability, and proper error handling for all service dependencies.
+ */
+
+import { 
+  TimeoutConfig, 
+  TimeoutReasonCode, 
+  ServiceType, 
+  resolveTimeout,
+  createTimeoutConfig,
+  isValidTimeoutReasonCode,
+  DEFAULT_TIMEOUT_BUDGETS
+} from './timeouts.js'
+import type { TimeoutMetricsCollector, TimeoutEvent, SuccessEvent } from '../observability/timeoutMetrics.js'
+import { createTimeoutEvent, createSuccessEvent } from '../observability/timeoutMetrics.js'
+
+/**
+ * Error thrown when an operation exceeds its timeout budget.
+ */
+export class TimeoutExceededError extends Error {
+  public readonly serviceType: ServiceType
+  public readonly reasonCode: TimeoutReasonCode
+  public readonly timeoutMs: number
+  public readonly operation: string
+
+  constructor(params: {
+    serviceType: ServiceType
+    reasonCode: TimeoutReasonCode
+    timeoutMs: number
+    operation: string
+    cause?: unknown
+  }) {
+    const message = `Operation '${params.operation}' on ${params.serviceType} timed out after ${params.timeoutMs}ms (${params.reasonCode})`
+    super(message, { cause: params.cause })
+    
+    this.name = 'TimeoutExceededError'
+    this.serviceType = params.serviceType
+    this.reasonCode = params.reasonCode
+    this.timeoutMs = params.timeoutMs
+    this.operation = params.operation
+  }
+}
+
+/**
+ * Metrics interface for observability hooks.
+ * Implementations can log timeout events, update counters, etc.
+ */
+export interface TimeoutMetrics {
+  onTimeout?: (params: {
+    serviceType: ServiceType
+    reasonCode: TimeoutReasonCode
+    timeoutMs: number
+    operation: string
+    durationMs: number
+  }) => void
+  onSuccess?: (params: {
+    serviceType: ServiceType
+    reasonCode: TimeoutReasonCode
+    timeoutMs: number
+    operation: string
+    durationMs: number
+  }) => void
+}
+
+/**
+ * Adapter to bridge TimeoutMetricsCollector to TimeoutMetrics interface.
+ */
+export function createMetricsAdapter(collector: TimeoutMetricsCollector): TimeoutMetrics {
+  return {
+    onTimeout: (params) => {
+      collector.onTimeout?.(createTimeoutEvent({
+        serviceType: params.serviceType,
+        reasonCode: params.reasonCode,
+        operation: params.operation,
+        timeoutMs: params.timeoutMs,
+        actualDurationMs: params.durationMs,
+      }))
+    },
+    onSuccess: (params) => {
+      collector.onSuccess?.(createSuccessEvent({
+        serviceType: params.serviceType,
+        reasonCode: params.reasonCode,
+        operation: params.operation,
+        timeoutMs: params.timeoutMs,
+        actualDurationMs: params.durationMs,
+      }))
+    },
+  }
+}
+
+/**
+ * Options for executing an operation with timeout.
+ */
+export interface TimeoutExecutorOptions {
+  /** Metrics collector for observability */
+  metrics?: TimeoutMetrics
+  /** Custom error handler */
+  onError?: (error: Error, context: TimeoutContext) => Error
+}
+
+/**
+ * Context provided to timeout operations.
+ */
+export interface TimeoutContext {
+  serviceType: ServiceType
+  reasonCode: TimeoutReasonCode
+  timeoutMs: number
+  operation: string
+  startTime: number
+}
+
+/**
+ * Executes an async function with timeout enforcement and observability.
+ * 
+ * @param fn - Async function to execute
+ * @param serviceType - Type of service being called
+ * @param reasonCode - Timeout reason code for observability
+ * @param options - Additional options
+ * @returns Result of the function execution
+ */
+export async function executeWithTimeout<T>(
+  fn: (context: TimeoutContext) => Promise<T>,
+  serviceType: ServiceType,
+  reasonCode: TimeoutReasonCode,
+  options: TimeoutExecutorOptions & { overrideMs?: number } = {}
+): Promise<T> {
+  const config = createTimeoutConfig(serviceType, reasonCode, options.overrideMs)
+  return executeWithTimeoutConfig(fn, config, options)
+}
+
+/**
+ * Executes an async function with timeout configuration.
+ * 
+ * @param fn - Async function to execute
+ * @param config - Timeout configuration
+ * @param options - Additional options
+ * @returns Result of the function execution
+ */
+export async function executeWithTimeoutConfig<T>(
+  fn: (context: TimeoutContext) => Promise<T>,
+  config: TimeoutConfig,
+  options: TimeoutExecutorOptions = {}
+): Promise<T> {
+  // Extract service type from the budget object
+  const serviceType = Object.entries(DEFAULT_TIMEOUT_BUDGETS).find(
+    ([, budget]) => budget === config.budget
+  )?.[0] as ServiceType
+  
+  const timeoutMs = resolveTimeout(serviceType, config)
+  const startTime = Date.now()
+  
+  const context: TimeoutContext = {
+    serviceType,
+    reasonCode: config.reasonCode,
+    timeoutMs,
+    operation: 'unknown',
+    startTime,
+  }
+
+  // Create abort controller for timeout
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    // Execute the function with timeout
+    const result = await Promise.race([
+      fn(context),
+      createAbortPromise(controller.signal, timeoutMs)
+    ])
+
+    const durationMs = Date.now() - startTime
+    options.metrics?.onSuccess?.({
+      serviceType: context.serviceType,
+      reasonCode: context.reasonCode,
+      timeoutMs,
+      operation: context.operation,
+      durationMs,
+    })
+
+    return result
+  } catch (error) {
+    const durationMs = Date.now() - startTime
+    
+    // Handle timeout specifically
+    if (isAbortError(error)) {
+      const timeoutError = new TimeoutExceededError({
+        serviceType: context.serviceType,
+        reasonCode: context.reasonCode,
+        timeoutMs,
+        operation: context.operation,
+        cause: error,
+      })
+
+      options.metrics?.onTimeout?.({
+        serviceType: context.serviceType,
+        reasonCode: context.reasonCode,
+        timeoutMs,
+        operation: context.operation,
+        durationMs,
+      })
+
+      throw options.onError ? options.onError(timeoutError, context) : timeoutError
+    }
+
+    // Handle other errors
+    throw options.onError ? options.onError(error as Error, context) : error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * Executes a database operation with appropriate timeout.
+ */
+export async function executeDbOperation<T>(
+  operation: string,
+  fn: () => Promise<T>,
+  options: { overrideMs?: number; metrics?: TimeoutMetrics } = {}
+): Promise<T> {
+  return executeWithTimeout(
+    async (context) => {
+      // Update operation name in context
+      context.operation = operation
+      return fn()
+    },
+    'database',
+    operation.includes('transaction') ? 'DB_TRANSACTION_TIMEOUT' : 'DB_QUERY_TIMEOUT',
+    options
+  )
+}
+
+/**
+ * Executes a cache operation with appropriate timeout.
+ */
+export async function executeCacheOperation<T>(
+  operation: string,
+  fn: () => Promise<T>,
+  options: { overrideMs?: number; metrics?: TimeoutMetrics } = {}
+): Promise<T> {
+  return executeWithTimeout(
+    async (context) => {
+      context.operation = operation
+      return fn()
+    },
+    'cache',
+    operation.includes('set') ? 'CACHE_SET_TIMEOUT' : 'CACHE_GET_TIMEOUT',
+    options
+  )
+}
+
+/**
+ * Executes an HTTP request with appropriate timeout.
+ */
+export async function executeHttpRequest<T>(
+  url: string,
+  fn: (signal: AbortSignal) => Promise<T>,
+  options: { overrideMs?: number; metrics?: TimeoutMetrics } = {}
+): Promise<T> {
+  return executeWithTimeout(
+    async (context) => {
+      context.operation = `HTTP ${url}`
+      // Create a new abort signal for this specific request
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), context.timeoutMs)
+      
+      try {
+        const result = await fn(controller.signal)
+        clearTimeout(timeoutId)
+        return result
+      } catch (error) {
+        clearTimeout(timeoutId)
+        throw error
+      }
+    },
+    'http',
+    'HTTP_REQUEST_TIMEOUT',
+    options
+  )
+}
+
+/**
+ * Executes a Soroban RPC operation with appropriate timeout.
+ */
+export async function executeSorobanOperation<T>(
+  method: string,
+  fn: (signal: AbortSignal) => Promise<T>,
+  options: { overrideMs?: number; metrics?: TimeoutMetrics } = {}
+): Promise<T> {
+  return executeWithTimeout(
+    async (context) => {
+      context.operation = `SOROBAN_${method}`
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), context.timeoutMs)
+      
+      try {
+        const result = await fn(controller.signal)
+        clearTimeout(timeoutId)
+        return result
+      } catch (error) {
+        clearTimeout(timeoutId)
+        throw error
+      }
+    },
+    'soroban',
+    'SOROBAN_RPC_TIMEOUT',
+    options
+  )
+}
+
+/**
+ * Executes a webhook delivery with appropriate timeout.
+ */
+export async function executeWebhookDelivery<T>(
+  url: string,
+  fn: (signal: AbortSignal) => Promise<T>,
+  options: { overrideMs?: number; metrics?: TimeoutMetrics } = {}
+): Promise<T> {
+  return executeWithTimeout(
+    async (context) => {
+      context.operation = `WEBHOOK_${url}`
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), context.timeoutMs)
+      
+      try {
+        const result = await fn(controller.signal)
+        clearTimeout(timeoutId)
+        return result
+      } catch (error) {
+        clearTimeout(timeoutId)
+        throw error
+      }
+    },
+    'webhook',
+    'WEBHOOK_DELIVERY_TIMEOUT',
+    options
+  )
+}
+
+/**
+ * Creates a promise that rejects when the signal is aborted.
+ */
+function createAbortPromise(signal: AbortSignal, timeoutMs: number): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(new Error('Operation aborted'))
+      return
+    }
+
+    const handleAbort = () => {
+      reject(new Error(`Operation timed out after ${timeoutMs}ms`))
+    }
+
+    signal.addEventListener('abort', handleAbort, { once: true })
+  })
+}
+
+/**
+ * Checks if an error is an abort error (timeout or cancellation).
+ */
+function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') return true
+  if (error instanceof Error && error.name === 'AbortError') return true
+  // Unwrap one level of cause-chain (undici / Node.js fetch wrapping)
+  if (error instanceof Error && error.cause != null && isAbortError(error.cause)) return true
+  return false
+}
+
+/**
+ * Default metrics collector that logs to console.
+ * In production, this would be replaced with proper metrics/observability.
+ */
+export const consoleMetrics: TimeoutMetrics = {
+  onTimeout: ({ serviceType, reasonCode, timeoutMs, operation, durationMs }) => {
+    console.warn(`[TIMEOUT] ${serviceType} ${operation} - ${reasonCode} after ${durationMs}ms (limit: ${timeoutMs}ms)`)
+  },
+  onSuccess: ({ serviceType, reasonCode, timeoutMs, operation, durationMs }) => {
+    if (durationMs > timeoutMs * 0.8) {
+      console.warn(`[SLOW] ${serviceType} ${operation} - ${reasonCode} took ${durationMs}ms (limit: ${timeoutMs}ms)`)
+    }
+  },
+}
+
+/**
+ * Utility to wrap existing functions with timeout enforcement.
+ */
+export function withTimeout<T extends (...args: any[]) => Promise<any>>(
+  fn: T,
+  serviceType: ServiceType,
+  reasonCode: TimeoutReasonCode,
+  options: { overrideMs?: number; metrics?: TimeoutMetrics } = {}
+): T {
+  return (async (...args: Parameters<T>) => {
+    return executeWithTimeout(
+      async () => fn(...args),
+      serviceType,
+      reasonCode,
+      options
+    )
+  }) as T
+}

--- a/src/lib/timeouts.ts
+++ b/src/lib/timeouts.ts
@@ -1,0 +1,197 @@
+/**
+ * Centralized timeout budget management for service dependencies.
+ * 
+ * Defines sensible default timeout budgets per service type with support for
+ * per-call overrides and observability through reason codes.
+ */
+
+export type ServiceType = 'database' | 'cache' | 'queue' | 'http' | 'soroban' | 'webhook'
+
+export type TimeoutReasonCode = 
+  | 'DB_QUERY_TIMEOUT'
+  | 'DB_TRANSACTION_TIMEOUT'
+  | 'CACHE_GET_TIMEOUT'
+  | 'CACHE_SET_TIMEOUT'
+  | 'QUEUE_PUBLISH_TIMEOUT'
+  | 'QUEUE_PROCESS_TIMEOUT'
+  | 'HTTP_REQUEST_TIMEOUT'
+  | 'SOROBAN_RPC_TIMEOUT'
+  | 'WEBHOOK_DELIVERY_TIMEOUT'
+  | 'CUSTOM_TIMEOUT'
+
+export interface TimeoutBudget {
+  /** Default timeout in milliseconds for this service type */
+  defaultMs: number
+  /** Minimum allowed timeout in milliseconds */
+  minMs: number
+  /** Maximum allowed timeout in milliseconds */
+  maxMs: number
+  /** SLO-aligned timeout target in milliseconds */
+  targetMs: number
+}
+
+export interface TimeoutConfig {
+  budget: TimeoutBudget
+  /** Optional override for this specific call */
+  overrideMs?: number
+  /** Reason code for observability */
+  reasonCode: TimeoutReasonCode
+}
+
+/**
+ * Default timeout budgets aligned with SLO targets.
+ * These are conservative defaults that balance reliability with responsiveness.
+ */
+export const DEFAULT_TIMEOUT_BUDGETS: Record<ServiceType, TimeoutBudget> = {
+  // Database operations - SQLite is fast but transactions can take longer
+  database: {
+    defaultMs: 2000,      // 2s default for queries
+    minMs: 100,           // 100ms minimum
+    maxMs: 10000,         // 10s maximum for complex transactions
+    targetMs: 1000,       // 1s SLO target
+  },
+
+  // Cache operations - Redis should be very fast
+  cache: {
+    defaultMs: 500,       // 500ms default
+    minMs: 50,            // 50ms minimum
+    maxMs: 2000,          // 2s maximum for network issues
+    targetMs: 200,        // 200ms SLO target
+  },
+
+  // Queue operations - should be fast but allow for batching
+  queue: {
+    defaultMs: 1000,      // 1s default
+    minMs: 100,           // 100ms minimum
+    maxMs: 5000,          // 5s maximum for batch operations
+    targetMs: 500,        // 500ms SLO target
+  },
+
+  // HTTP requests - external services can be slower
+  http: {
+    defaultMs: 5000,      // 5s default
+    minMs: 1000,          // 1s minimum
+    maxMs: 30000,         // 30s maximum for slow services
+    targetMs: 3000,       // 3s SLO target
+  },
+
+  // Soroban RPC - blockchain operations can be variable
+  soroban: {
+    defaultMs: 5000,      // 5s default (matches current)
+    minMs: 2000,          // 2s minimum
+    maxMs: 15000,         // 15s maximum for network congestion
+    targetMs: 4000,       // 4s SLO target
+  },
+
+  // Webhook delivery - external endpoints can be slow
+  webhook: {
+    defaultMs: 10000,     // 10s default (generous for external services)
+    minMs: 2000,          // 2s minimum
+    maxMs: 30000,         // 30s maximum
+    targetMs: 8000,       // 8s SLO target
+  },
+}
+
+/**
+ * Hard caps for timeout budgets to prevent excessive values.
+ * These ensure system stability even with misconfigured overrides.
+ */
+export const TIMEOUT_HARD_CAPS = {
+  database: { maxMs: 30000 },    // 30s absolute max
+  cache: { maxMs: 10000 },       // 10s absolute max
+  queue: { maxMs: 15000 },       // 15s absolute max
+  http: { maxMs: 60000 },        // 60s absolute max
+  soroban: { maxMs: 45000 },     // 45s absolute max
+  webhook: { maxMs: 60000 },     // 60s absolute max
+} as const
+
+/**
+ * Validates and clamps a timeout value within budget constraints.
+ */
+function clampTimeout(
+  timeoutMs: number,
+  budget: TimeoutBudget,
+  serviceType: ServiceType
+): number {
+  const hardCap = TIMEOUT_HARD_CAPS[serviceType].maxMs
+  
+  // Apply budget constraints first
+  const budgetClamped = Math.max(
+    budget.minMs,
+    Math.min(timeoutMs, budget.maxMs)
+  )
+  
+  // Then apply hard caps
+  return Math.min(budgetClamped, hardCap)
+}
+
+/**
+ * Resolves the final timeout value for a service call.
+ * 
+ * Priority order:
+ * 1. Per-call override (if provided and valid)
+ * 2. Service default budget
+ * 3. Hard caps (always applied)
+ * 
+ * @param serviceType - Type of service being called
+ * @param config - Timeout configuration with optional override
+ * @returns Final timeout value in milliseconds
+ */
+export function resolveTimeout(
+  serviceType: ServiceType,
+  config: TimeoutConfig
+): number {
+  const budget = DEFAULT_TIMEOUT_BUDGETS[serviceType]
+  
+  // Use override if provided, otherwise use budget default
+  const requestedTimeout = config.overrideMs ?? budget.defaultMs
+  
+  // Validate and clamp the timeout
+  return clampTimeout(requestedTimeout, budget, serviceType)
+}
+
+/**
+ * Creates a timeout configuration for a specific service call.
+ * 
+ * @param serviceType - Type of service being called
+ * @param reasonCode - Observability reason code
+ * @param overrideMs - Optional per-call timeout override
+ * @returns Timeout configuration object
+ */
+export function createTimeoutConfig(
+  serviceType: ServiceType,
+  reasonCode: TimeoutReasonCode,
+  overrideMs?: number
+): TimeoutConfig {
+  return {
+    budget: DEFAULT_TIMEOUT_BUDGETS[serviceType],
+    overrideMs,
+    reasonCode,
+  }
+}
+
+/**
+ * Utility to extract timeout value from config, useful for existing APIs.
+ */
+export function getTimeoutMs(config: TimeoutConfig, serviceType: ServiceType): number {
+  return resolveTimeout(serviceType, config)
+}
+
+/**
+ * Type guard to check if a value is a valid timeout reason code.
+ */
+export function isValidTimeoutReasonCode(code: string): code is TimeoutReasonCode {
+  const validCodes: TimeoutReasonCode[] = [
+    'DB_QUERY_TIMEOUT',
+    'DB_TRANSACTION_TIMEOUT',
+    'CACHE_GET_TIMEOUT',
+    'CACHE_SET_TIMEOUT',
+    'QUEUE_PUBLISH_TIMEOUT',
+    'QUEUE_PROCESS_TIMEOUT',
+    'HTTP_REQUEST_TIMEOUT',
+    'SOROBAN_RPC_TIMEOUT',
+    'WEBHOOK_DELIVERY_TIMEOUT',
+    'CUSTOM_TIMEOUT',
+  ]
+  return validCodes.includes(code as TimeoutReasonCode)
+}

--- a/src/observability/__tests__/timeoutMetrics.test.ts
+++ b/src/observability/__tests__/timeoutMetrics.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Tests for timeout metrics collection and observability.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  ConsoleTimeoutMetrics,
+  ProductionTimeoutMetrics,
+  createDefaultMetricsCollector,
+  createTimeoutEvent,
+  createSlowOperationEvent,
+  createSuccessEvent,
+  type TimeoutEvent,
+  type SlowOperationEvent,
+  type SuccessEvent,
+} from '../timeoutMetrics.js'
+
+describe('Timeout Metrics', () => {
+  let consoleSpy: {
+    error: ReturnType<typeof vi.spyOn>
+    warn: ReturnType<typeof vi.spyOn>
+    info: ReturnType<typeof vi.spyOn>
+    debug: ReturnType<typeof vi.spyOn>
+  }
+
+  beforeEach(() => {
+    consoleSpy = {
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+      debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('ConsoleTimeoutMetrics', () => {
+    let metrics: ConsoleTimeoutMetrics
+
+    beforeEach(() => {
+      metrics = new ConsoleTimeoutMetrics()
+    })
+
+    describe('onTimeout', () => {
+      it('should log timeout events to console.error', () => {
+        const event: TimeoutEvent = createTimeoutEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'cache.get.user.123',
+          timeoutMs: 500,
+          actualDurationMs: 500,
+        })
+
+        metrics.onTimeout(event)
+
+        expect(consoleSpy.error).toHaveBeenCalledWith(
+          '🔴 TIMEOUT [cache] cache.get.user.123'
+        )
+        expect(consoleSpy.error).toHaveBeenCalledWith('   Reason: CACHE_GET_TIMEOUT')
+        expect(consoleSpy.error).toHaveBeenCalledWith('   Duration: 500ms / 500ms')
+        expect(consoleSpy.error).toHaveBeenCalledWith(
+          expect.stringContaining('Timestamp:')
+        )
+      })
+
+      it('should include context in timeout logs', () => {
+        const event: TimeoutEvent = createTimeoutEvent({
+          serviceType: 'soroban',
+          reasonCode: 'SOROBAN_RPC_TIMEOUT',
+          operation: 'SOROBAN_getContractData',
+          timeoutMs: 5000,
+          actualDurationMs: 5000,
+          context: { contractId: 'abc123', address: '0x123...' },
+        })
+
+        metrics.onTimeout(event)
+
+        expect(consoleSpy.error).toHaveBeenCalledWith('   Context:', {
+          contractId: 'abc123',
+          address: '0x123...',
+        })
+      })
+    })
+
+    describe('onSlowOperation', () => {
+      it('should log slow operations to console.warn', () => {
+        const event: SlowOperationEvent = createSlowOperationEvent({
+          serviceType: 'database',
+          reasonCode: 'DB_QUERY_TIMEOUT',
+          operation: 'SELECT * FROM users',
+          timeoutMs: 2000,
+          actualDurationMs: 1800,
+        })
+
+        metrics.onSlowOperation(event)
+
+        expect(consoleSpy.warn).toHaveBeenCalledWith(
+          '🟡 SLOW [database] SELECT * FROM users'
+        )
+        expect(consoleSpy.warn).toHaveBeenCalledWith('   Reason: DB_QUERY_TIMEOUT')
+        expect(consoleSpy.warn).toHaveBeenCalledWith('   Duration: 1800ms / 2000ms (90.0%)')
+        expect(consoleSpy.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Timestamp:')
+        )
+      })
+
+      it('should calculate percentage correctly', () => {
+        const event: SlowOperationEvent = createSlowOperationEvent({
+          serviceType: 'http',
+          reasonCode: 'HTTP_REQUEST_TIMEOUT',
+          operation: 'HTTP https://api.example.com',
+          timeoutMs: 10000,
+          actualDurationMs: 8500,
+        })
+
+        metrics.onSlowOperation(event)
+
+        expect(consoleSpy.warn).toHaveBeenCalledWith(
+          '   Duration: 8500ms / 10000ms (85.0%)'
+        )
+      })
+    })
+
+    describe('onSuccess', () => {
+      it('should log operations close to timeout', () => {
+        const event: SuccessEvent = createSuccessEvent({
+          serviceType: 'webhook',
+          reasonCode: 'WEBHOOK_DELIVERY_TIMEOUT',
+          operation: 'WEBHOOK https://webhook.example.com',
+          timeoutMs: 10000,
+          actualDurationMs: 7500, // 75% of timeout
+        })
+
+        metrics.onSuccess(event)
+
+        expect(consoleSpy.info).toHaveBeenCalledWith(
+          '🟠 NEAR_TIMEOUT [webhook] WEBHOOK https://webhook.example.com'
+        )
+        expect(consoleSpy.info).toHaveBeenCalledWith('   Reason: WEBHOOK_DELIVERY_TIMEOUT')
+        expect(consoleSpy.info).toHaveBeenCalledWith('   Duration: 7500ms / 10000ms')
+      })
+
+      it('should not log fast operations', () => {
+        const event: SuccessEvent = createSuccessEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'cache.get.config',
+          timeoutMs: 500,
+          actualDurationMs: 100, // Only 20% of timeout
+        })
+
+        metrics.onSuccess(event)
+
+        expect(consoleSpy.info).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('getSummary', () => {
+      beforeEach(() => {
+        metrics.clear()
+      })
+
+      it('should provide comprehensive summary', () => {
+        // Add some test events
+        metrics.onTimeout(createTimeoutEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'cache.get.test1',
+          timeoutMs: 500,
+          actualDurationMs: 500,
+        }))
+
+        metrics.onSlowOperation(createSlowOperationEvent({
+          serviceType: 'database',
+          reasonCode: 'DB_QUERY_TIMEOUT',
+          operation: 'SELECT * FROM test',
+          timeoutMs: 2000,
+          actualDurationMs: 1800,
+        }))
+
+        metrics.onSuccess(createSuccessEvent({
+          serviceType: 'http',
+          reasonCode: 'HTTP_REQUEST_TIMEOUT',
+          operation: 'HTTP https://api.test.com',
+          timeoutMs: 5000,
+          actualDurationMs: 1000,
+        }))
+
+        const summary = metrics.getSummary()
+
+        expect(summary.totalOperations).toBe(3)
+        expect(summary.timeouts.count).toBe(1)
+        expect(summary.slowOperations.count).toBe(1)
+        expect(summary.successOperations.count).toBe(1)
+        expect(summary.timeouts.byServiceType.cache).toBe(1)
+        expect(summary.slowOperations.byServiceType.database).toBe(1)
+        expect(summary.successOperations.byServiceType.http.count).toBe(1)
+      })
+
+      it('should filter by period when provided', () => {
+        const now = new Date()
+        const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
+
+        // Add event outside period
+        metrics.onSuccess(createSuccessEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'old_operation',
+          timeoutMs: 500,
+          actualDurationMs: 100,
+        }))
+
+        // Mock timestamp to be outside period
+        vi.spyOn(Date, 'now').mockReturnValue(oneHourAgo.getTime())
+
+        metrics.onSuccess(createSuccessEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'new_operation',
+          timeoutMs: 500,
+          actualDurationMs: 100,
+        }))
+
+        vi.restoreAllMocks()
+
+        const summary = metrics.getSummary({
+          start: now,
+          end: new Date(now.getTime() + 60000),
+        })
+
+        // Should only include events within the period
+        expect(summary.totalOperations).toBe(1)
+      })
+    })
+
+    describe('clear', () => {
+      it('should clear all collected events', () => {
+        // Add events
+        metrics.onTimeout(createTimeoutEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'test',
+          timeoutMs: 500,
+          actualDurationMs: 500,
+        }))
+
+        expect(metrics.getSummary().totalOperations).toBe(1)
+
+        metrics.clear()
+
+        expect(metrics.getSummary().totalOperations).toBe(0)
+      })
+    })
+  })
+
+  describe('ProductionTimeoutMetrics', () => {
+    let metrics: ProductionTimeoutMetrics
+
+    beforeEach(() => {
+      metrics = new ProductionTimeoutMetrics('test_prefix')
+    })
+
+    it('should log timeout events to debug', () => {
+      const event: TimeoutEvent = createTimeoutEvent({
+        serviceType: 'cache',
+        reasonCode: 'CACHE_GET_TIMEOUT',
+        operation: 'cache.get.test',
+        timeoutMs: 500,
+        actualDurationMs: 500,
+      })
+
+      metrics.onTimeout(event)
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        '[test_prefix] timeout: cache cache.get.test (CACHE_GET_TIMEOUT)'
+      )
+    })
+
+    it('should log slow operations to debug', () => {
+      const event: SlowOperationEvent = createSlowOperationEvent({
+        serviceType: 'database',
+        reasonCode: 'DB_QUERY_TIMEOUT',
+        operation: 'SELECT * FROM test',
+        timeoutMs: 2000,
+        actualDurationMs: 1800,
+      })
+
+      metrics.onSlowOperation(event)
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        '[test_prefix] slow: database SELECT * FROM test (DB_QUERY_TIMEOUT)'
+      )
+    })
+
+    it('should log success events to debug', () => {
+      const event: SuccessEvent = createSuccessEvent({
+        serviceType: 'http',
+        reasonCode: 'HTTP_REQUEST_TIMEOUT',
+        operation: 'HTTP https://api.test.com',
+        timeoutMs: 5000,
+        actualDurationMs: 1000,
+      })
+
+      metrics.onSuccess(event)
+
+      expect(consoleSpy.debug).toHaveBeenCalledWith(
+        '[test_prefix] success: http HTTP https://api.test.com (HTTP_REQUEST_TIMEOUT)'
+      )
+    })
+  })
+
+  describe('createDefaultMetricsCollector', () => {
+    it('should return console metrics in development', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'development'
+
+      const collector = createDefaultMetricsCollector()
+
+      expect(collector).toBeInstanceOf(ConsoleTimeoutMetrics)
+
+      process.env.NODE_ENV = originalEnv
+    })
+
+    it('should return console metrics in test', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'test'
+
+      const collector = createDefaultMetricsCollector()
+
+      expect(collector).toBeInstanceOf(ConsoleTimeoutMetrics)
+
+      process.env.NODE_ENV = originalEnv
+    })
+
+    it('should return production metrics in production', () => {
+      const originalEnv = process.env.NODE_ENV
+      process.env.NODE_ENV = 'production'
+
+      const collector = createDefaultMetricsCollector()
+
+      expect(collector).toBeInstanceOf(ProductionTimeoutMetrics)
+
+      process.env.NODE_ENV = originalEnv
+    })
+  })
+
+  describe('Event Creation Utilities', () => {
+    describe('createTimeoutEvent', () => {
+      it('should create timeout event with timestamp', () => {
+        const before = new Date()
+        const event = createTimeoutEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'cache.get.test',
+          timeoutMs: 500,
+          actualDurationMs: 500,
+        })
+        const after = new Date()
+
+        expect(event.timestamp).toBeInstanceOf(Date)
+        expect(event.timestamp.getTime()).toBeGreaterThanOrEqual(before.getTime())
+        expect(event.timestamp.getTime()).toBeLessThanOrEqual(after.getTime())
+        expect(event.serviceType).toBe('cache')
+        expect(event.reasonCode).toBe('CACHE_GET_TIMEOUT')
+        expect(event.operation).toBe('cache.get.test')
+        expect(event.timeoutMs).toBe(500)
+        expect(event.actualDurationMs).toBe(500)
+      })
+
+      it('should include error when provided', () => {
+        const error = new Error('Test error')
+        const event = createTimeoutEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'cache.get.test',
+          timeoutMs: 500,
+          actualDurationMs: 500,
+          error,
+        })
+
+        expect(event.error).toBe(error)
+      })
+    })
+
+    describe('createSlowOperationEvent', () => {
+      it('should calculate percentage of timeout', () => {
+        const event = createSlowOperationEvent({
+          serviceType: 'database',
+          reasonCode: 'DB_QUERY_TIMEOUT',
+          operation: 'SELECT * FROM test',
+          timeoutMs: 2000,
+          actualDurationMs: 1500,
+        })
+
+        expect(event.percentageOfTimeout).toBe(75)
+      })
+
+      it('should handle edge case percentages', () => {
+        const event1 = createSlowOperationEvent({
+          serviceType: 'cache',
+          reasonCode: 'CACHE_GET_TIMEOUT',
+          operation: 'cache.get.test',
+          timeoutMs: 500,
+          actualDurationMs: 0,
+        })
+
+        expect(event1.percentageOfTimeout).toBe(0)
+
+        const event2 = createSlowOperationEvent({
+          serviceType: 'http',
+          reasonCode: 'HTTP_REQUEST_TIMEOUT',
+          operation: 'HTTP https://api.test.com',
+          timeoutMs: 1000,
+          actualDurationMs: 1000,
+        })
+
+        expect(event2.percentageOfTimeout).toBe(100)
+      })
+    })
+
+    describe('createSuccessEvent', () => {
+      it('should create success event with timestamp', () => {
+        const before = new Date()
+        const event = createSuccessEvent({
+          serviceType: 'webhook',
+          reasonCode: 'WEBHOOK_DELIVERY_TIMEOUT',
+          operation: 'WEBHOOK https://webhook.test.com',
+          timeoutMs: 10000,
+          actualDurationMs: 2000,
+        })
+        const after = new Date()
+
+        expect(event.timestamp).toBeInstanceOf(Date)
+        expect(event.timestamp.getTime()).toBeGreaterThanOrEqual(before.getTime())
+        expect(event.timestamp.getTime()).toBeLessThanOrEqual(after.getTime())
+        expect(event.serviceType).toBe('webhook')
+        expect(event.reasonCode).toBe('WEBHOOK_DELIVERY_TIMEOUT')
+        expect(event.operation).toBe('WEBHOOK https://webhook.test.com')
+        expect(event.timeoutMs).toBe(10000)
+        expect(event.actualDurationMs).toBe(2000)
+      })
+    })
+  })
+})

--- a/src/observability/timeoutMetrics.ts
+++ b/src/observability/timeoutMetrics.ts
@@ -1,0 +1,310 @@
+/**
+ * Timeout observability and metrics collection.
+ * 
+ * Provides structured logging and metrics collection for timeout events
+ * across all service dependencies with reason codes for debugging and SLO monitoring.
+ */
+
+import { TimeoutReasonCode, ServiceType } from '../lib/timeouts.js'
+
+/**
+ * Timeout event metadata for observability.
+ */
+export interface TimeoutEvent {
+  timestamp: Date
+  serviceType: ServiceType
+  reasonCode: TimeoutReasonCode
+  operation: string
+  timeoutMs: number
+  actualDurationMs: number
+  error?: Error
+  context?: Record<string, unknown>
+}
+
+/**
+ * Slow operation warning metadata.
+ */
+export interface SlowOperationEvent {
+  timestamp: Date
+  serviceType: ServiceType
+  reasonCode: TimeoutReasonCode
+  operation: string
+  timeoutMs: number
+  actualDurationMs: number
+  percentageOfTimeout: number
+  context?: Record<string, unknown>
+}
+
+/**
+ * Success operation metrics.
+ */
+export interface SuccessEvent {
+  timestamp: Date
+  serviceType: ServiceType
+  reasonCode: TimeoutReasonCode
+  operation: string
+  timeoutMs: number
+  actualDurationMs: number
+  context?: Record<string, unknown>
+}
+
+/**
+ * Aggregated timeout metrics for reporting.
+ */
+export interface TimeoutMetricsSummary {
+  period: {
+    start: Date
+    end: Date
+  }
+  totalOperations: number
+  timeouts: {
+    count: number
+    byServiceType: Record<ServiceType, number>
+    byReasonCode: Record<TimeoutReasonCode, number>
+  }
+  slowOperations: {
+    count: number
+    byServiceType: Record<ServiceType, number>
+    byReasonCode: Record<TimeoutReasonCode, number>
+  }
+  successOperations: {
+    count: number
+    averageDurationMs: number
+    byServiceType: Record<ServiceType, { count: number; avgDurationMs: number }>
+  }
+}
+
+/**
+ * Interface for timeout metrics collectors.
+ */
+export interface TimeoutMetricsCollector {
+  onTimeout(event: TimeoutEvent): void
+  onSlowOperation(event: SlowOperationEvent): void
+  onSuccess(event: SuccessEvent): void
+  getSummary?(period?: { start: Date; end: Date }): TimeoutMetricsSummary | undefined
+}
+
+/**
+ * Console-based metrics collector for development.
+ */
+export class ConsoleTimeoutMetrics implements TimeoutMetricsCollector {
+  private events: {
+    timeouts: TimeoutEvent[]
+    slowOps: SlowOperationEvent[]
+    successes: SuccessEvent[]
+  } = {
+    timeouts: [],
+    slowOps: [],
+    successes: [],
+  }
+
+  onTimeout(event: TimeoutEvent): void {
+    this.events.timeouts.push(event)
+    
+    console.error(`🔴 TIMEOUT [${event.serviceType}] ${event.operation}`)
+    console.error(`   Reason: ${event.reasonCode}`)
+    console.error(`   Duration: ${event.actualDurationMs}ms / ${event.timeoutMs}ms`)
+    console.error(`   Timestamp: ${event.timestamp.toISOString()}`)
+    if (event.context) {
+      console.error(`   Context:`, event.context)
+    }
+    console.error('')
+  }
+
+  onSlowOperation(event: SlowOperationEvent): void {
+    this.events.slowOps.push(event)
+    
+    console.warn(`🟡 SLOW [${event.serviceType}] ${event.operation}`)
+    console.warn(`   Reason: ${event.reasonCode}`)
+    console.warn(`   Duration: ${event.actualDurationMs}ms / ${event.timeoutMs}ms (${event.percentageOfTimeout.toFixed(1)}%)`)
+    console.warn(`   Timestamp: ${event.timestamp.toISOString()}`)
+    if (event.context) {
+      console.warn(`   Context:`, event.context)
+    }
+    console.warn('')
+  }
+
+  onSuccess(event: SuccessEvent): void {
+    this.events.successes.push(event)
+    
+    // Only log successful operations that are close to timeout
+    if (event.actualDurationMs > event.timeoutMs * 0.7) {
+      console.info(`🟠 NEAR_TIMEOUT [${event.serviceType}] ${event.operation}`)
+      console.info(`   Reason: ${event.reasonCode}`)
+      console.info(`   Duration: ${event.actualDurationMs}ms / ${event.timeoutMs}ms`)
+      console.info(`   Timestamp: ${event.timestamp.toISOString()}`)
+      console.info('')
+    }
+  }
+
+  getSummary(period?: { start: Date; end: Date }): TimeoutMetricsSummary {
+    const filterEvents = <T extends { timestamp: Date }>(events: T[]): T[] => {
+      if (!period) return events
+      return events.filter(e => e.timestamp >= period.start && e.timestamp <= period.end)
+    }
+
+    const timeouts = filterEvents(this.events.timeouts)
+    const slowOps = filterEvents(this.events.slowOps)
+    const successes = filterEvents(this.events.successes)
+
+    const groupByServiceType = <T extends { serviceType: ServiceType }>(events: T[]): Record<ServiceType, number> => {
+      const groups: Partial<Record<ServiceType, number>> = {}
+      for (const event of events) {
+        groups[event.serviceType] = (groups[event.serviceType] || 0) + 1
+      }
+      return groups as Record<ServiceType, number>
+    }
+
+    const groupByReasonCode = <T extends { reasonCode: TimeoutReasonCode }>(events: T[]): Record<TimeoutReasonCode, number> => {
+      const groups: Partial<Record<TimeoutReasonCode, number>> = {}
+      for (const event of events) {
+        groups[event.reasonCode] = (groups[event.reasonCode] || 0) + 1
+      }
+      return groups as Record<TimeoutReasonCode, number>
+    }
+
+    const successByService = successes.reduce((acc, event) => {
+      if (!acc[event.serviceType]) {
+        acc[event.serviceType] = { count: 0, totalDurationMs: 0 }
+      }
+      acc[event.serviceType].count++
+      acc[event.serviceType].totalDurationMs += event.actualDurationMs
+      return acc
+    }, {} as Record<ServiceType, { count: number; totalDurationMs: number }>)
+
+    const successByServiceType: Record<ServiceType, { count: number; avgDurationMs: number }> = {} as any
+    for (const [serviceType, data] of Object.entries(successByService)) {
+      successByServiceType[serviceType as ServiceType] = {
+        count: data.count,
+        avgDurationMs: data.totalDurationMs / data.count,
+      }
+    }
+
+    return {
+      period: {
+        start: period?.start || new Date(0),
+        end: period?.end || new Date(),
+      },
+      totalOperations: timeouts.length + slowOps.length + successes.length,
+      timeouts: {
+        count: timeouts.length,
+        byServiceType: groupByServiceType(timeouts),
+        byReasonCode: groupByReasonCode(timeouts),
+      },
+      slowOperations: {
+        count: slowOps.length,
+        byServiceType: groupByServiceType(slowOps),
+        byReasonCode: groupByReasonCode(slowOps),
+      },
+      successOperations: {
+        count: successes.length,
+        averageDurationMs: successes.length > 0 
+          ? successes.reduce((sum, e) => sum + e.actualDurationMs, 0) / successes.length 
+          : 0,
+        byServiceType: successByServiceType,
+      },
+    }
+  }
+
+  /**
+   * Clears all collected events. Useful for testing or memory management.
+   */
+  clear(): void {
+    this.events.timeouts = []
+    this.events.slowOps = []
+    this.events.successes = []
+  }
+}
+
+/**
+ * Production-ready metrics collector that integrates with monitoring systems.
+ * This is a placeholder for integration with Prometheus, Datadog, etc.
+ */
+export class ProductionTimeoutMetrics implements TimeoutMetricsCollector {
+  constructor(private prefix: string = 'credence_timeouts') {}
+
+  onTimeout(event: TimeoutEvent): void {
+    // In production, this would emit metrics to your monitoring system
+    // Example: prometheusCounter.inc({ service_type: event.serviceType, reason_code: event.reasonCode })
+    console.debug(`[${this.prefix}] timeout: ${event.serviceType} ${event.operation} (${event.reasonCode})`)
+  }
+
+  onSlowOperation(event: SlowOperationEvent): void {
+    // In production, this would emit metrics to your monitoring system
+    console.debug(`[${this.prefix}] slow: ${event.serviceType} ${event.operation} (${event.reasonCode})`)
+  }
+
+  onSuccess(event: SuccessEvent): void {
+    // In production, this would emit metrics to your monitoring system
+    console.debug(`[${this.prefix}] success: ${event.serviceType} ${event.operation} (${event.reasonCode})`)
+  }
+}
+
+/**
+ * Default metrics collector instance.
+ * Uses console metrics in development, production metrics in production.
+ */
+export function createDefaultMetricsCollector(): TimeoutMetricsCollector {
+  const nodeEnv = process.env.NODE_ENV || 'development'
+  
+  if (nodeEnv === 'development' || nodeEnv === 'test') {
+    return new ConsoleTimeoutMetrics()
+  }
+  
+  return new ProductionTimeoutMetrics()
+}
+
+/**
+ * Utility to create enriched timeout events with context.
+ */
+export function createTimeoutEvent(params: {
+  serviceType: ServiceType
+  reasonCode: TimeoutReasonCode
+  operation: string
+  timeoutMs: number
+  actualDurationMs: number
+  error?: Error
+  context?: Record<string, unknown>
+}): TimeoutEvent {
+  return {
+    timestamp: new Date(),
+    ...params,
+  }
+}
+
+/**
+ * Utility to create slow operation events.
+ */
+export function createSlowOperationEvent(params: {
+  serviceType: ServiceType
+  reasonCode: TimeoutReasonCode
+  operation: string
+  timeoutMs: number
+  actualDurationMs: number
+  context?: Record<string, unknown>
+}): SlowOperationEvent {
+  const percentageOfTimeout = (params.actualDurationMs / params.timeoutMs) * 100
+  
+  return {
+    timestamp: new Date(),
+    percentageOfTimeout,
+    ...params,
+  }
+}
+
+/**
+ * Utility to create success events.
+ */
+export function createSuccessEvent(params: {
+  serviceType: ServiceType
+  reasonCode: TimeoutReasonCode
+  operation: string
+  timeoutMs: number
+  actualDurationMs: number
+  context?: Record<string, unknown>
+}): SuccessEvent {
+  return {
+    timestamp: new Date(),
+    ...params,
+  }
+}


### PR DESCRIPTION
- Add standardized timeout budgets per service dependency (DB, cache, queue, HTTP)
- Implement centralized timeout executor with observability and reason codes
- Refactor Redis cache and Soroban client to use centralized timeout management
- Add comprehensive tests for timeout enforcement and override precedence
- Expose timeout reason codes for observability and SLO monitoring
- Support per-call timeout overrides for critical flows
- Enforce hard caps to prevent excessive timeout values
- Add metrics collection for timeout events and slow operations
closes #165 