### PR TITLE
#242  fresh 2026 04] backend] db  rollback nested service failures (no partial state)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -596,7 +595,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
@@ -609,7 +607,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1835,7 +1832,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2121,7 +2117,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2812,7 +2807,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -2996,7 +2990,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -3656,7 +3649,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4364,7 +4356,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5424,7 +5415,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6793,7 +6783,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8645,7 +8634,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10590,7 +10578,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10693,7 +10680,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10883,7 +10869,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10962,7 +10947,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",

--- a/src/db/transaction.ts
+++ b/src/db/transaction.ts
@@ -1,0 +1,144 @@
+import type { Pool, PoolClient } from 'pg'
+
+/** PostgreSQL error code emitted when lock_timeout fires (lock_not_available). */
+export const PG_LOCK_TIMEOUT_CODE = '55P03'
+
+/**
+ * Named timeout policies that map to pre-configured millisecond values.
+ * Choose the least-permissive policy that still meets the operation's SLA
+ * to bound contention impact on other callers.
+ */
+export enum LockTimeoutPolicy {
+  READONLY = 'readonly',
+  DEFAULT = 'default',
+  CRITICAL = 'critical',
+}
+
+/** Thrown when a row lock cannot be acquired within the configured window. */
+export class LockTimeoutError extends Error {
+  constructor(
+    /** The named policy active at the time of the timeout, if any. */
+    public readonly policy: LockTimeoutPolicy | undefined,
+    /** Effective timeout in milliseconds that was applied. */
+    public readonly timeoutMs: number
+  ) {
+    super(`Lock timeout after ${timeoutMs}ms (policy: ${policy ?? 'custom'})`)
+    this.name = 'LockTimeoutError'
+  }
+}
+
+export interface LockTimeoutConfig {
+  readonly: number
+  default: number
+  critical: number
+}
+
+export interface TransactionOptions {
+  policy?: LockTimeoutPolicy
+  timeoutMs?: number
+  isolationLevel?: 'READ COMMITTED' | 'REPEATABLE READ' | 'SERIALIZABLE'
+  retryOnLockTimeout?: boolean
+  maxRetries?: number
+  retryDelayMs?: number
+}
+
+const FALLBACK_TIMEOUTS: LockTimeoutConfig = {
+  readonly: 2_000,
+  default: 5_000,
+  critical: 10_000,
+}
+
+/**
+ * Manages PostgreSQL transactions with configurable lock-timeout policies
+ * and optional exponential-backoff retry on contention.
+ *
+ * Pass the PoolClient received by the withTransaction callback to every
+ * repository that must participate in the same atomic unit. All writes share
+ * one client connection under a single BEGIN...COMMIT block. Any uncaught
+ * error triggers an immediate ROLLBACK so partial state is never committed,
+ * even across multiple nested service calls.
+ */
+export class TransactionManager {
+  private readonly timeouts: LockTimeoutConfig
+
+  constructor(
+    private readonly pool: Pool,
+    timeouts?: Partial<LockTimeoutConfig>
+  ) {
+    this.timeouts = { ...FALLBACK_TIMEOUTS, ...timeouts }
+  }
+
+  /**
+   * Execute fn atomically inside a PostgreSQL transaction.
+   *
+   * Forward the supplied PoolClient to every repository participating in
+   * this transaction so nested calls share the same BEGIN...COMMIT block and
+   * roll back together on any error.
+   *
+   * @param fn      - Callback receiving an exclusive PoolClient.
+   * @param options - Timeout policy, isolation level, and retry config.
+   * @returns The value returned by fn after a successful commit.
+   * @throws {LockTimeoutError} when a row lock cannot be acquired in time.
+   */
+  async withTransaction<T>(
+    fn: (client: PoolClient) => Promise<T>,
+    options: TransactionOptions = {}
+  ): Promise<T> {
+    const {
+      policy,
+      timeoutMs,
+      isolationLevel,
+      retryOnLockTimeout = false,
+      maxRetries = 3,
+      retryDelayMs = 100,
+    } = options
+
+    const effectiveTimeoutMs =
+      timeoutMs ?? (policy !== undefined ? this.timeouts[policy] : this.timeouts.default)
+
+    let attempts = 0
+
+    while (true) {
+      const client = await this.pool.connect()
+
+      try {
+        const beginSql = isolationLevel
+          ? `BEGIN ISOLATION LEVEL ${isolationLevel}`
+          : 'BEGIN'
+
+        await client.query(beginSql)
+        await client.query(`SET LOCAL lock_timeout = '${effectiveTimeoutMs}ms'`)
+
+        const result = await fn(client)
+
+        await client.query('COMMIT')
+        return result
+      } catch (err: unknown) {
+        await client.query('ROLLBACK').catch(() => {
+          // Swallowed: connection may be dead, pg will recycle on release.
+        })
+
+        const pgCode = (err as { code?: string }).code
+
+        if (pgCode === PG_LOCK_TIMEOUT_CODE) {
+          if (retryOnLockTimeout && attempts < maxRetries) {
+            const delay = retryDelayMs * Math.pow(2, attempts)
+            attempts++
+            await sleep(delay)
+            continue
+          }
+
+          throw new LockTimeoutError(policy, effectiveTimeoutMs)
+        }
+
+        throw err
+      } finally {
+        client.release()
+      }
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/tests/integration/nestedServiceRollback.test.ts
+++ b/tests/integration/nestedServiceRollback.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Integration tests for nested-service transaction rollback.
+ *
+ * Verifies that when multiple repository (or service) operations run inside a
+ * single `TransactionManager.withTransaction()` call, any failure — whether an
+ * explicit throw or a DB constraint violation — rolls back every write made
+ * earlier in the same callback. No partial state should survive.
+ *
+ * Run against a real PostgreSQL instance:
+ *   TEST_DATABASE_URL=postgres://... node --test tests/integration/nestedServiceRollback.test.ts
+ * or let the suite spin up a Testcontainer automatically:
+ *   node --test tests/integration/nestedServiceRollback.test.ts
+ */
+
+import assert from 'node:assert/strict'
+import { after, before, beforeEach, describe, it } from 'node:test'
+
+import {
+  AttestationsRepository,
+  BondsRepository,
+  IdentitiesRepository,
+  ScoreHistoryRepository,
+} from '../../src/db/repositories/index.js'
+import { createSchema, dropSchema, resetDatabase } from '../../src/db/schema.js'
+import {
+  LockTimeoutError,
+  LockTimeoutPolicy,
+  TransactionManager,
+} from '../../src/db/transaction.js'
+import { createTestDatabase, type TestDatabase } from './testDatabase.js'
+
+describe('nested service rollback', () => {
+  let database: TestDatabase
+  let txManager: TransactionManager
+
+  // Pool-backed repositories used to inspect state *after* a transaction.
+  let identitiesRepo: IdentitiesRepository
+  let bondsRepo: BondsRepository
+  let attestationsRepo: AttestationsRepository
+  let scoreHistoryRepo: ScoreHistoryRepository
+
+  before(async () => {
+    database = await createTestDatabase()
+    await createSchema(database.pool)
+
+    txManager = new TransactionManager(database.pool, {
+      readonly: 1_000,
+      default: 3_000,
+      critical: 8_000,
+    })
+
+    identitiesRepo = new IdentitiesRepository(database.pool)
+    bondsRepo = new BondsRepository(database.pool)
+    attestationsRepo = new AttestationsRepository(database.pool)
+    scoreHistoryRepo = new ScoreHistoryRepository(database.pool)
+  })
+
+  beforeEach(async () => {
+    await resetDatabase(database.pool)
+  })
+
+  after(async () => {
+    await dropSchema(database.pool)
+    await database.close()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Core rollback guarantee
+  // ---------------------------------------------------------------------------
+
+  it('rolls back all writes when a later step throws an application error', async () => {
+    // Simulate a three-step service: create identity → create bond → score entry,
+    // then deliberately throw before returning.
+    await assert.rejects(
+      () =>
+        txManager.withTransaction(async (client) => {
+          const idRepo = new IdentitiesRepository(client)
+          const bRepo = new BondsRepository(client)
+          const sRepo = new ScoreHistoryRepository(client)
+
+          await idRepo.create({ address: 'GROLLBACK_ADDR_1' })
+
+          await bRepo.create({
+            identityAddress: 'GROLLBACK_ADDR_1',
+            amount: '100',
+            startTime: new Date('2025-01-01T00:00:00.000Z'),
+            durationDays: 30,
+          })
+
+          await sRepo.create({
+            identityAddress: 'GROLLBACK_ADDR_1',
+            score: 75,
+            source: 'bond',
+          })
+
+          // Simulate a failure in a downstream service call.
+          throw new Error('downstream service failure')
+        }),
+      /downstream service failure/
+    )
+
+    // Nothing should have been persisted.
+    assert.equal(
+      await identitiesRepo.findByAddress('GROLLBACK_ADDR_1'),
+      null,
+      'identity must not be persisted after rollback'
+    )
+    assert.deepEqual(
+      await bondsRepo.listByIdentity('GROLLBACK_ADDR_1'),
+      [],
+      'bonds must not be persisted after rollback'
+    )
+    assert.deepEqual(
+      await scoreHistoryRepo.listByIdentity('GROLLBACK_ADDR_1'),
+      [],
+      'score history must not be persisted after rollback'
+    )
+  })
+
+  it('rolls back partial writes caused by a DB constraint violation', async () => {
+    // Pre-insert an identity so the duplicate-address constraint fires mid-transaction.
+    await identitiesRepo.create({ address: 'GROLLBACK_DUPLICATE' })
+
+    await assert.rejects(
+      () =>
+        txManager.withTransaction(async (client) => {
+          const idRepo = new IdentitiesRepository(client)
+          const sRepo = new ScoreHistoryRepository(client)
+
+          // This first write succeeds inside the transaction…
+          await idRepo.create({ address: 'GROLLBACK_SIBLING' })
+
+          // …but this violates the unique constraint and aborts the transaction.
+          await idRepo.create({ address: 'GROLLBACK_DUPLICATE' })
+
+          // This line should never execute.
+          await sRepo.create({
+            identityAddress: 'GROLLBACK_SIBLING',
+            score: 50,
+            source: 'manual',
+          })
+        }),
+      // PostgreSQL unique violation
+      (err: unknown) => (err as { code?: string }).code === '23505'
+    )
+
+    // The sibling identity written before the violation must not survive.
+    assert.equal(
+      await identitiesRepo.findByAddress('GROLLBACK_SIBLING'),
+      null,
+      'sibling identity written before constraint violation must be rolled back'
+    )
+
+    // The pre-existing identity must still be intact.
+    assert.notEqual(
+      await identitiesRepo.findByAddress('GROLLBACK_DUPLICATE'),
+      null,
+      'pre-existing identity must remain untouched'
+    )
+  })
+
+  it('commits successfully when all steps complete without error', async () => {
+    const committed = await txManager.withTransaction(async (client) => {
+      const idRepo = new IdentitiesRepository(client)
+      const bRepo = new BondsRepository(client)
+
+      const identity = await idRepo.create({
+        address: 'GROLLBACK_COMMIT',
+        displayName: 'Committed Alice',
+      })
+
+      const bond = await bRepo.create({
+        identityAddress: identity.address,
+        amount: '25',
+        startTime: new Date('2025-03-01T00:00:00.000Z'),
+        durationDays: 14,
+      })
+
+      return { identity, bond }
+    })
+
+    const persisted = await identitiesRepo.findByAddress('GROLLBACK_COMMIT')
+    assert.ok(persisted, 'identity must be visible after successful commit')
+    assert.equal(persisted.displayName, 'Committed Alice')
+
+    const bonds = await bondsRepo.listByIdentity('GROLLBACK_COMMIT')
+    assert.equal(bonds.length, 1)
+    assert.equal(bonds[0].id, committed.bond.id)
+  })
+
+  it('rolls back across three service layers (identity → bond → attestation)', async () => {
+    // Set up a pre-existing attester that lives outside the failing transaction.
+    await identitiesRepo.create({ address: 'GROLLBACK_ATTESTER' })
+
+    await assert.rejects(
+      () =>
+        txManager.withTransaction(async (client) => {
+          const idRepo = new IdentitiesRepository(client)
+          const bRepo = new BondsRepository(client)
+          const aRepo = new AttestationsRepository(client)
+
+          const identity = await idRepo.create({ address: 'GROLLBACK_SUBJECT' })
+
+          const bond = await bRepo.create({
+            identityAddress: identity.address,
+            amount: '10',
+            startTime: new Date('2025-06-01T00:00:00.000Z'),
+            durationDays: 7,
+          })
+
+          await aRepo.create({
+            bondId: bond.id,
+            attesterAddress: 'GROLLBACK_ATTESTER',
+            subjectAddress: identity.address,
+            score: 88,
+          })
+
+          throw new Error('third-layer failure')
+        }),
+      /third-layer failure/
+    )
+
+    assert.equal(
+      await identitiesRepo.findByAddress('GROLLBACK_SUBJECT'),
+      null,
+      'subject identity must be rolled back'
+    )
+    assert.deepEqual(
+      await bondsRepo.listByIdentity('GROLLBACK_SUBJECT'),
+      [],
+      'bond must be rolled back'
+    )
+
+    // The attester (created outside the transaction) must be unaffected.
+    assert.notEqual(
+      await identitiesRepo.findByAddress('GROLLBACK_ATTESTER'),
+      null,
+      'attester created outside the failing transaction must survive'
+    )
+  })
+
+  it('preserves isolation — in-flight writes are invisible to concurrent readers', async () => {
+    // Writes inside an uncommitted transaction must not be visible outside it.
+    let transactionRunning = false
+
+    const txPromise = txManager.withTransaction(async (client) => {
+      const idRepo = new IdentitiesRepository(client)
+      await idRepo.create({ address: 'GROLLBACK_INFLIGHT' })
+      transactionRunning = true
+
+      // Yield so the check below can run while the transaction is still open.
+      await sleep(50)
+
+      throw new Error('abort to test isolation')
+    })
+
+    // Poll briefly until the transaction has written but not yet committed.
+    while (!transactionRunning) {
+      await sleep(5)
+    }
+
+    // A pool query (outside the transaction) must not see the uncommitted row.
+    const snapshot = await identitiesRepo.findByAddress('GROLLBACK_INFLIGHT')
+    assert.equal(
+      snapshot,
+      null,
+      'uncommitted writes must not be visible to concurrent readers'
+    )
+
+    // Wait for the transaction to abort and confirm nothing was committed.
+    await assert.rejects(txPromise, /abort to test isolation/)
+
+    assert.equal(
+      await identitiesRepo.findByAddress('GROLLBACK_INFLIGHT'),
+      null,
+      'rolled-back write must not appear after transaction aborts'
+    )
+  })
+
+  // ---------------------------------------------------------------------------
+  // LockTimeoutError propagation
+  // ---------------------------------------------------------------------------
+
+  it('propagates LockTimeoutError when lock cannot be acquired', async () => {
+    // Create test data outside the transaction.
+    await identitiesRepo.create({ address: 'GROLLBACK_LOCK_OWNER' })
+    const bond = await bondsRepo.create({
+      identityAddress: 'GROLLBACK_LOCK_OWNER',
+      amount: '5',
+      startTime: new Date('2025-01-01T00:00:00.000Z'),
+      durationDays: 10,
+    })
+
+    // Hold a row lock in a separate client so the next transaction times out.
+    const holder = await database.pool.connect()
+    await holder.query('BEGIN')
+    await holder.query('SELECT id FROM bonds WHERE id = $1 FOR UPDATE', [bond.id])
+
+    try {
+      await assert.rejects(
+        () =>
+          txManager.withTransaction(
+            async (client) => {
+              await client.query('SELECT id FROM bonds WHERE id = $1 FOR UPDATE', [bond.id])
+            },
+            { policy: LockTimeoutPolicy.READONLY, timeoutMs: 100 }
+          ),
+        (err: unknown) => err instanceof LockTimeoutError
+      )
+    } finally {
+      await holder.query('ROLLBACK')
+      holder.release()
+    }
+
+    // Bond state must be intact — the failed transaction changed nothing.
+    const intact = await bondsRepo.findById(bond.id)
+    assert.ok(intact)
+    assert.equal(intact.amount, bond.amount)
+  })
+})
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
closes #242 

## fix(db): rollback nested service failures — no partial state

### Summary

Implements [src/db/transaction.ts](cci:7://file:///home/jayking/projects/Credence-Backend/src/db/transaction.ts:0:0-0:0), which was an empty stub. The file is the
single source of truth for PostgreSQL transaction management across all service
layers. Without it, [BondsRepository.debit()](cci:1://file:///home/jayking/projects/Credence-Backend/src/db/repositories/bondsRepository.ts:149:2-221:3) and any service that imports
[TransactionManager](cci:2://file:///home/jayking/projects/Credence-Backend/src/db/transaction.ts:60:0-139:1) were broken at runtime, and — more critically — there was
no mechanism to guarantee that nested service failures could not leave partial
state in the database.

The implementation ensures that every [withTransaction()](cci:1://file:///home/jayking/projects/Credence-Backend/src/db/transaction.ts:70:2-138:3) call wraps its work
in a single `BEGIN … COMMIT / ROLLBACK` block on a dedicated connection. Any
error thrown inside the callback — whether an application exception or a DB
constraint violation — triggers an immediate `ROLLBACK` before the error is
re-thrown. Callers propagate the `PoolClient` to all repository methods that
must participate, keeping them in the same atomic unit.

### Changes

- **Implemented [TransactionManager](cci:2://file:///home/jayking/projects/Credence-Backend/src/db/transaction.ts:60:0-139:1)** — [withTransaction<T>(fn, options)](cci:1://file:///home/jayking/projects/Credence-Backend/src/db/transaction.ts:70:2-138:3)
  acquires an exclusive `PoolClient`, opens a transaction with configurable
  isolation level and `lock_timeout`, commits on success, and rolls back on
  any failure; the client is always released in a `finally` block.

- **Added `LockTimeoutPolicy` enum** — `READONLY`, `DEFAULT`, and `CRITICAL`
  named tiers map to pre-configured millisecond values supplied at construction
  time, keeping timeout configuration centralised and testable.

- **Added [LockTimeoutError](cci:2://file:///home/jayking/projects/Credence-Backend/src/db/transaction.ts:17:0-27:1)** — typed error carrying the active policy and
  effective timeout, replacing opaque PostgreSQL error codes at the call site.

- **Added `PG_LOCK_TIMEOUT_CODE` constant** — `'55P03'` (lock_not_available)
  used to distinguish lock timeouts from other DB errors.

- **Implemented exponential-backoff retry** — when `retryOnLockTimeout: true`,
  the manager retries up to `maxRetries` times with doubling delay, releasing
  and re-acquiring a fresh client on each attempt.

- **Added integration test suite** ([tests/integration/nestedServiceRollback.test.ts](cci:7://file:///home/jayking/projects/Credence-Backend/tests/integration/nestedServiceRollback.test.ts:0:0-0:0))
  — six tests running against real PostgreSQL that verify:
  - Full rollback when a downstream step throws an application error
  - Rollback of partial writes interrupted by a DB constraint violation
  - Successful commit when all steps complete
  - Cross-layer rollback across identity, bond, and attestation writes
  - Read isolation: uncommitted writes are invisible to concurrent readers
  - [LockTimeoutError](cci:2://file:///home/jayking/projects/Credence-Backend/src/db/transaction.ts:17:0-27:1) propagation with no state mutation

### Testing

Unit tests in [src/db/transaction.test.ts](cci:7://file:///home/jayking/projects/Credence-Backend/src/db/transaction.test.ts:0:0-0:0) (pre-existing, covering commit,
rollback, lock-timeout policies, retry, concurrent serialisation, and client
release) all pass with the new implementation.

Integration tests are run with a real PostgreSQL instance (Testcontainers spun
up automatically, or a `TEST_DATABASE_URL` supplied externally):

```bash
node --test tests/integration/nestedServiceRollback.test.ts
# or the full integration suite:
TEST_DATABASE_URL=postgresql://... node --test tests/integration/

Closes #242 