### PR TITLE
chore(api): add stable validation error codes and contract tests

### DIFF
--- a/src/__tests__/validationContract.test.ts
+++ b/src/__tests__/validationContract.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import express, { type Express } from 'express'
+import { z } from 'zod'
+import { validate } from '../middleware/validate.js'
+import { errorHandler } from '../middleware/errorHandler.js'
+import { ErrorCode } from '../lib/errors.js'
+
+describe('Validation Error Codes Contract', () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = express()
+    app.use(express.json())
+  })
+
+  const setupRoute = (schema: any) => {
+    app.post('/test', validate({ body: schema }), (req, res) => {
+      res.status(200).json({ success: true })
+    })
+    app.use(errorHandler)
+  }
+
+  it('returns FIELD_REQUIRED when a required field is missing', async () => {
+    const schema = z.object({
+      name: z.string()
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({})
+
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe(ErrorCode.VALIDATION_FAILED)
+    expect(res.body.details[0].code).toBe(ErrorCode.FIELD_REQUIRED)
+    expect(res.body.details[0].path).toBe('name')
+  })
+
+  it('returns INVALID_TYPE when a field has wrong type', async () => {
+    const schema = z.object({
+      age: z.number()
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ age: 'not-a-number' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_TYPE)
+  })
+
+  it('returns INVALID_FORMAT for regex mismatches on non-address fields', async () => {
+    const schema = z.object({
+      id: z.string().regex(/^\d+$/)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ id: 'abc' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_FORMAT)
+  })
+
+  it('returns INVALID_ADDRESS for address regex mismatches', async () => {
+    const schema = z.object({
+      address: z.string().regex(/^0x[a-fA-F0-9]{40}$/)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ address: 'not-an-address' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_ADDRESS)
+  })
+
+  it('returns VALUE_TOO_SMALL for min constraints', async () => {
+    const schema = z.object({
+      count: z.number().min(10)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ count: 5 })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_SMALL)
+  })
+
+  it('returns VALUE_TOO_LARGE for max constraints', async () => {
+    const schema = z.object({
+      count: z.number().max(10)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ count: 15 })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_LARGE)
+  })
+
+  it('returns UNEXPECTED_FIELD for strict schema violations', async () => {
+    const schema = z.object({
+      name: z.string()
+    }).strict()
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', extra: 'field' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.UNEXPECTED_FIELD)
+  })
+})

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -5,6 +5,8 @@
  */
 export enum ErrorCode {
   VALIDATION_FAILED = 'validation_failed',
+  FIELD_REQUIRED = 'field_required',
+  INVALID_FORMAT = 'invalid_format',
   INVALID_ADDRESS = 'invalid_address',
   INSUFFICIENT_FUNDS = 'insufficient_funds',
   UNAUTHORIZED = 'unauthorized',
@@ -15,6 +17,10 @@ export enum ErrorCode {
   INTERNAL_SERVER_ERROR = 'internal_server_error',
   SERVICE_UNAVAILABLE = 'service_unavailable',
   RATE_LIMIT_EXCEEDED = 'rate_limit_exceeded',
+  VALUE_TOO_SMALL = 'value_too_small',
+  VALUE_TOO_LARGE = 'value_too_large',
+  UNEXPECTED_FIELD = 'unexpected_field',
+  INVALID_TYPE = 'invalid_type',
 }
 
 /**

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import type { ZodSchema, ZodError } from 'zod'
-import { ValidationError } from '../lib/errors.js'
+import { ValidationError, ErrorCode } from '../lib/errors.js'
 
 /**
  * Validated request payload.
@@ -37,13 +37,43 @@ export interface ValidateOptions {
 /**
  * Format Zod errors into a consistent structure.
  * @param error - ZodError from schema.safeParse()
- * @returns Array of { path, message } for client consumption
+ * @returns Array of { path, message, code } for client consumption
  */
-function formatZodErrors(error: ZodError): Array<{ path: string; message: string }> {
-  return error.issues.map((e) => ({
-    path: e.path?.length ? e.path.join('.') : '(root)',
-    message: e.message,
-  }))
+function formatZodErrors(error: ZodError): Array<{ path: string; message: string; code: string }> {
+  return error.issues.map((e) => {
+    let code: ErrorCode = ErrorCode.VALIDATION_FAILED
+
+    switch (e.code) {
+      case 'invalid_type':
+        // In Zod 4, the 'received' property is often missing from the issue object,
+        // so we check the message as a fallback to identify missing fields.
+        code = e.message.includes('received undefined')
+          ? ErrorCode.FIELD_REQUIRED
+          : ErrorCode.INVALID_TYPE
+        break
+      case 'invalid_string':
+      case 'invalid_format':
+        code = (e.path.join('.').toLowerCase().includes('address') || e.message.toLowerCase().includes('address'))
+          ? ErrorCode.INVALID_ADDRESS
+          : ErrorCode.INVALID_FORMAT
+        break
+      case 'too_small':
+        code = ErrorCode.VALUE_TOO_SMALL
+        break
+      case 'too_big':
+        code = ErrorCode.VALUE_TOO_LARGE
+        break
+      case 'unrecognized_keys':
+        code = ErrorCode.UNEXPECTED_FIELD
+        break
+    }
+
+    return {
+      path: e.path?.length ? e.path.join('.') : '(root)',
+      message: e.message,
+      code,
+    }
+  })
 }
 
 /**
@@ -62,7 +92,7 @@ export function validate<TParams = unknown, TQuery = unknown, TBody = unknown>(
 
   return (req: Request, res: Response, next: NextFunction) => {
     const validated: ValidatedRequest<TParams, TQuery, TBody> = {}
-    const errors: Array<{ path: string; message: string }> = []
+    const errors: Array<{ path: string; message: string; code: string }> = []
 
     if (paramsSchema) {
       const result = paramsSchema.safeParse(req.params)


### PR DESCRIPTION
- Closes: #254 

I have implemented stable validation error codes and added contract tests as requested for Issue #254.