### PR TITLE
feat: deep readiness probe including listener and outbox health

### DIFF
--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -69,6 +69,15 @@ The deployment uses the existing health endpoints:
 | **Readiness** | `GET /api/health/ready` | Remove from Service if dependencies are down |
 | **Startup** | `GET /api/health/live` | Allow time for container startup |
 
+Readiness now includes deep subsystem checks and returns a per-check JSON body:
+
+- `postgres`: validates PostgreSQL connectivity via the shared pool.
+- `redis`: validates Redis availability via the shared Redis connection manager.
+- `horizonListener`: validates listener running state and heartbeat staleness.
+- `outboxPublisher`: validates publisher running state and lease heartbeat staleness.
+
+Pods are marked not-ready when any of the above checks return `down`.
+
 ## Scaling
 
 ```bash

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -9,6 +9,15 @@ The monitoring stack consists of:
 - **Grafana** - Visualization and dashboards
 - **Application metrics** - Custom business and infrastructure metrics
 
+## Health Endpoints
+
+The health router separates liveness and readiness:
+
+- `GET /api/health/live`: process-level liveness only (always `200` while process is up).
+- `GET /api/health` and `GET /api/health/ready`: deep readiness checks for Postgres, Redis, Horizon listener heartbeat, and outbox publisher lease heartbeat.
+
+Readiness responses include per-check status (`up`, `down`, `not_configured`) and safe diagnostic fields (for example heartbeat age) without exposing secrets such as connection strings.
+
 ## Architecture
 
 ```

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -76,7 +76,8 @@ spec:
             failureThreshold: 3
 
           # ── Readiness probe ──
-          # Checks that dependencies (DB, Redis) are reachable.
+          # Checks dependencies (Postgres/Redis) and worker liveness
+          # (Horizon listener heartbeat + outbox publisher lease heartbeat).
           # Pod is removed from Service endpoints when not ready.
           readinessProbe:
             httpGet:

--- a/src/__tests__/envelopeContract.test.ts
+++ b/src/__tests__/envelopeContract.test.ts
@@ -84,8 +84,10 @@ describe('Response envelope contract — /api/health', () => {
 
   it('readiness success: { status: string, dependencies: object }', async () => {
     const app = makeApp({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     const { status, body } = await req(app, 'GET', '/api/health')
     expect(status).toBe(200)
@@ -95,7 +97,12 @@ describe('Response envelope contract — /api/health', () => {
   })
 
   it('readiness unhealthy: still returns { status, dependencies } with 503', async () => {
-    const app = makeApp({ db: async () => ({ status: 'down' }) })
+    const app = makeApp({
+      postgres: async () => ({ status: 'down' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
+    })
     const { status, body } = await req(app, 'GET', '/api/health')
     expect(status).toBe(503)
     expect(typeof body.status).toBe('string')
@@ -104,8 +111,10 @@ describe('Response envelope contract — /api/health', () => {
 
   it('readiness dependency entries each carry a { status: string }', async () => {
     const app = makeApp({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     const { body } = await req(app, 'GET', '/api/health')
     const deps = body.dependencies as Record<string, { status: string }>

--- a/src/db/outbox/publisher.ts
+++ b/src/db/outbox/publisher.ts
@@ -2,6 +2,10 @@ import { pool } from '../pool.js'
 import { OutboxRepository } from './repository.js'
 import type { OutboxEvent, OutboxCleanupConfig } from './types.js'
 import { randomUUID } from 'crypto'
+import {
+  recordOutboxPublisherHeartbeat,
+  setOutboxPublisherRunning,
+} from '../../services/health/runtimeState.js'
 
 /**
  * Event handler that processes published domain events.
@@ -73,6 +77,8 @@ export class OutboxPublisher {
     }
 
     this.running = true
+    setOutboxPublisherRunning(true)
+    recordOutboxPublisherHeartbeat()
     console.log('[OutboxPublisher] Starting with config:', {
       ...this.config,
       consumerId: this.consumerId,
@@ -113,6 +119,7 @@ export class OutboxPublisher {
     }
 
     this.running = false
+    setOutboxPublisherRunning(false)
 
     if (this.pollTimer) {
       clearInterval(this.pollTimer)
@@ -143,6 +150,7 @@ export class OutboxPublisher {
       return
     }
     const renewed = await this.repository.renewLease(pool, this.consumerId, this.leaseSeconds)
+    recordOutboxPublisherHeartbeat()
     if (renewed > 0) {
       console.debug(`[OutboxPublisher] Renewed lease for ${renewed} events`)
     }
@@ -164,6 +172,7 @@ export class OutboxPublisher {
     )
 
     if (events.length === 0) {
+      recordOutboxPublisherHeartbeat()
       return
     }
 

--- a/src/listeners/horizonWithdrawalEvents.ts
+++ b/src/listeners/horizonWithdrawalEvents.ts
@@ -1,4 +1,9 @@
 import { Horizon } from '@stellar/stellar-sdk'
+import {
+  recordHorizonListenerHeartbeat,
+  setHorizonListenerConfigured,
+  setHorizonListenerRunning,
+} from '../services/health/runtimeState.js'
 
 /**
  * Interface for bond withdrawal event data
@@ -72,11 +77,17 @@ export class HorizonWithdrawalListener {
   private lastCursor: string
   private replayService: { captureFailure: (type: string, data: any, reason: string) => Promise<any> }
 
-  constructor(config: HorizonListenerConfig, replayService: { captureFailure: (type: string, data: any, reason: string) => Promise<any> }) {
+  constructor(
+    config: HorizonListenerConfig,
+    replayService: { captureFailure: (type: string, data: any, reason: string) => Promise<any> } = {
+      captureFailure: async () => ({}),
+    },
+  ) {
     this.config = config
     this.server = new Horizon.Server(config.horizonUrl)
     this.lastCursor = config.lastCursor || 'now'
     this.replayService = replayService
+    setHorizonListenerConfigured(true)
   }
 
   /**
@@ -89,6 +100,8 @@ export class HorizonWithdrawalListener {
     }
 
     this.isRunning = true
+    setHorizonListenerRunning(true)
+    recordHorizonListenerHeartbeat(this.lastCursor)
     console.log(`Starting Horizon withdrawal listener for ${this.config.horizonUrl}`)
 
     // Start polling for events
@@ -104,6 +117,7 @@ export class HorizonWithdrawalListener {
     }
 
     this.isRunning = false
+    setHorizonListenerRunning(false)
     
     if (this.pollTimer) {
       clearTimeout(this.pollTimer)
@@ -157,6 +171,9 @@ export class HorizonWithdrawalListener {
       if (events.length > 0) {
         this.lastCursor = events[events.length - 1].pagingToken
       }
+
+      // Poll completed and cursor is current; mark heartbeat.
+      recordHorizonListenerHeartbeat(this.lastCursor)
 
     } catch (error) {
       console.error('Error polling for withdrawal events:', error)

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -13,75 +13,88 @@ describe('Health routes', () => {
   describe('GET /api/health (readiness)', () => {
     it('returns 200 and ok when all critical deps are up', async () => {
       const app = appWithHealth({
-        db: async () => ({ status: 'up' }),
-        cache: async () => ({ status: 'up' }),
-        queue: async () => ({ status: 'up' }),
+        postgres: async () => ({ status: 'up' }),
+        redis: async () => ({ status: 'up' }),
+        horizonListener: async () => ({ status: 'up' }),
+        outboxPublisher: async () => ({ status: 'up' }),
       })
       const res = await request(app).get('/api/health')
       expect(res.status).toBe(200)
       expect(res.body.status).toBe('ok')
-      expect(res.body.dependencies.db.status).toBe('up')
-      expect(res.body.dependencies.cache.status).toBe('up')
-      expect(res.body.dependencies.queue.status).toBe('up')
+      expect(res.body.dependencies.postgres.status).toBe('up')
+      expect(res.body.dependencies.redis.status).toBe('up')
+      expect(res.body.dependencies.horizonListener.status).toBe('up')
+      expect(res.body.dependencies.outboxPublisher.status).toBe('up')
     })
 
-    it('returns 200 when no deps configured', async () => {
+    it('returns 200 degraded when no deps configured', async () => {
       const app = appWithHealth({})
       const res = await request(app).get('/api/health')
       expect(res.status).toBe(200)
-      expect(res.body.status).toBe('ok')
-      expect(res.body.dependencies.db.status).toBe('not_configured')
-      expect(res.body.dependencies.cache.status).toBe('not_configured')
-      expect(res.body.dependencies.queue.status).toBe('not_configured')
-    })
-
-    it('returns 503 when db is down', async () => {
-      const app = appWithHealth({
-        db: async () => ({ status: 'down' }),
-        cache: async () => ({ status: 'up' }),
-      })
-      const res = await request(app).get('/api/health')
-      expect(res.status).toBe(503)
-      expect(res.body.status).toBe('unhealthy')
-    })
-
-    it('returns 503 when cache is down', async () => {
-      const app = appWithHealth({
-        db: async () => ({ status: 'up' }),
-        cache: async () => ({ status: 'down' }),
-      })
-      const res = await request(app).get('/api/health')
-      expect(res.status).toBe(503)
-      expect(res.body.status).toBe('unhealthy')
-    })
-
-    it('returns 503 when db, cache, and queue are down', async () => {
-      const app = appWithHealth({
-        db: async () => ({ status: 'down' }),
-        cache: async () => ({ status: 'down' }),
-        queue: async () => ({ status: 'down' }),
-      })
-      const res = await request(app).get('/api/health')
-      expect(res.status).toBe(503)
-    })
-
-    it('returns 200 when only gateway is down (degraded)', async () => {
-      const app = appWithHealth({
-        db: async () => ({ status: 'up' }),
-        cache: async () => ({ status: 'up' }),
-        gateway: async () => ({ status: 'down' }),
-      })
-      const res = await request(app).get('/api/health')
-      expect(res.status).toBe(200)
       expect(res.body.status).toBe('degraded')
+      expect(res.body.dependencies.postgres.status).toBe('not_configured')
+      expect(res.body.dependencies.redis.status).toBe('not_configured')
+      expect(res.body.dependencies.horizonListener.status).toBe('not_configured')
+      expect(res.body.dependencies.outboxPublisher.status).toBe('not_configured')
+    })
+
+    it('returns 503 when postgres is down', async () => {
+      const app = appWithHealth({
+        postgres: async () => ({ status: 'down' }),
+        redis: async () => ({ status: 'up' }),
+        horizonListener: async () => ({ status: 'up' }),
+        outboxPublisher: async () => ({ status: 'up' }),
+      })
+      const res = await request(app).get('/api/health')
+      expect(res.status).toBe(503)
+      expect(res.body.status).toBe('unhealthy')
+    })
+
+    it('returns 503 when redis is down', async () => {
+      const app = appWithHealth({
+        postgres: async () => ({ status: 'up' }),
+        redis: async () => ({ status: 'down' }),
+        horizonListener: async () => ({ status: 'up' }),
+        outboxPublisher: async () => ({ status: 'up' }),
+      })
+      const res = await request(app).get('/api/health')
+      expect(res.status).toBe(503)
+      expect(res.body.status).toBe('unhealthy')
+    })
+
+    it('returns 503 when horizon listener heartbeat is stale', async () => {
+      const app = appWithHealth({
+        postgres: async () => ({ status: 'up' }),
+        redis: async () => ({ status: 'up' }),
+        horizonListener: async () => ({ status: 'down', reason: 'stale_heartbeat' }),
+        outboxPublisher: async () => ({ status: 'up' }),
+      })
+      const res = await request(app).get('/api/health')
+      expect(res.status).toBe(503)
+      expect(res.body.dependencies.horizonListener.reason).toBe('stale_heartbeat')
+    })
+
+    it('returns 503 when outbox publisher is not running', async () => {
+      const app = appWithHealth({
+        postgres: async () => ({ status: 'up' }),
+        redis: async () => ({ status: 'up' }),
+        horizonListener: async () => ({ status: 'up' }),
+        outboxPublisher: async () => ({ status: 'down', reason: 'not_running' }),
+      })
+      const res = await request(app).get('/api/health')
+      expect(res.status).toBe(503)
+      expect(res.body.status).toBe('unhealthy')
+      expect(res.body.dependencies.outboxPublisher.reason).toBe('not_running')
     })
   })
 
   describe('GET /api/health/ready', () => {
     it('behaves like GET /api/health', async () => {
       const app = appWithHealth({
-        db: async () => ({ status: 'down' }),
-        cache: async () => ({ status: 'up' }),
+        postgres: async () => ({ status: 'down' }),
+        redis: async () => ({ status: 'up' }),
+        horizonListener: async () => ({ status: 'up' }),
+        outboxPublisher: async () => ({ status: 'up' }),
       })
       const res = await request(app).get('/api/health/ready')
       expect(res.status).toBe(503)
@@ -92,8 +105,10 @@ describe('Health routes', () => {
   describe('GET /api/health/live (liveness)', () => {
     it('returns 200 always', async () => {
       const app = appWithHealth({
-        db: async () => ({ status: 'down' }),
-        cache: async () => ({ status: 'down' }),
+        postgres: async () => ({ status: 'down' }),
+        redis: async () => ({ status: 'down' }),
+        horizonListener: async () => ({ status: 'down' }),
+        outboxPublisher: async () => ({ status: 'down' }),
       })
       const res = await request(app).get('/api/health/live')
       expect(res.status).toBe(200)

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -3,14 +3,14 @@ import { runHealthChecks } from '../services/health/index.js'
 import type { HealthProbe } from '../services/health/index.js'
 
 export interface HealthRouterOptions {
-  /** DB probe; when omitted, db is reported as not_configured. */
-  db?: HealthProbe
-  /** Cache probe; when omitted, cache is reported as not_configured. */
-  cache?: HealthProbe
-  /** Queue probe; when omitted, queue is reported as not_configured. */
-  queue?: HealthProbe
-  /** Optional gateway (e.g. Horizon); failure does not cause 503. */
-  gateway?: HealthProbe
+  /** Postgres probe; when omitted, postgres is reported as not_configured. */
+  postgres?: HealthProbe
+  /** Redis probe; when omitted, redis is reported as not_configured. */
+  redis?: HealthProbe
+  /** Horizon listener heartbeat probe; omitted means not_configured. */
+  horizonListener?: HealthProbe
+  /** Outbox publisher lease/running probe; omitted means not_configured. */
+  outboxPublisher?: HealthProbe
 }
 
 /**
@@ -28,10 +28,10 @@ export function createHealthRouter(options: HealthRouterOptions = {}): Router {
 
   const runChecks = async () =>
     runHealthChecks({
-      db: options.db,
-      cache: options.cache,
-      queue: options.queue,
-      gateway: options.gateway,
+      postgres: options.postgres,
+      redis: options.redis,
+      horizonListener: options.horizonListener,
+      outboxPublisher: options.outboxPublisher,
     })
 
   /**

--- a/src/services/health/checks.test.ts
+++ b/src/services/health/checks.test.ts
@@ -2,86 +2,96 @@ import { describe, it, expect } from 'vitest'
 import { runHealthChecks } from './checks.js'
 
 describe('runHealthChecks', () => {
-  it('returns ok when no probes are configured (all not_configured)', async () => {
+  it('returns degraded when no probes are configured (all not_configured)', async () => {
     const result = await runHealthChecks({})
-    expect(result.status).toBe('ok')
+    expect(result.status).toBe('degraded')
     expect(result.service).toBe('credence-backend')
-    expect(result.dependencies.db).toEqual({ status: 'not_configured' })
-    expect(result.dependencies.cache).toEqual({ status: 'not_configured' })
-    expect(result.dependencies.queue).toEqual({ status: 'not_configured' })
-    expect(result.dependencies.gateway).toEqual({ status: 'not_configured' })
+    expect(result.dependencies.postgres).toEqual({ status: 'not_configured' })
+    expect(result.dependencies.redis).toEqual({ status: 'not_configured' })
+    expect(result.dependencies.horizonListener).toEqual({ status: 'not_configured' })
+    expect(result.dependencies.outboxPublisher).toEqual({ status: 'not_configured' })
   })
 
-  it('returns ok when db, cache, and queue are up', async () => {
+  it('returns ok when postgres, redis, horizon listener, and outbox are up', async () => {
     const result = await runHealthChecks({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
-      queue: async () => ({ status: 'up' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     expect(result.status).toBe('ok')
-    expect(result.dependencies.db).toEqual({ status: 'up' })
-    expect(result.dependencies.cache).toEqual({ status: 'up' })
-    expect(result.dependencies.queue).toEqual({ status: 'up' })
+    expect(result.dependencies.postgres).toEqual({ status: 'up' })
+    expect(result.dependencies.redis).toEqual({ status: 'up' })
+    expect(result.dependencies.horizonListener).toEqual({ status: 'up' })
+    expect(result.dependencies.outboxPublisher).toEqual({ status: 'up' })
   })
 
-  it('returns unhealthy and 503 when db is down', async () => {
+  it('returns unhealthy when postgres is down', async () => {
     const result = await runHealthChecks({
-      db: async () => ({ status: 'down' }),
-      cache: async () => ({ status: 'up' }),
+      postgres: async () => ({ status: 'down' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     expect(result.status).toBe('unhealthy')
-    expect(result.dependencies.db).toEqual({ status: 'down' })
-    expect(result.dependencies.cache).toEqual({ status: 'up' })
+    expect(result.dependencies.postgres).toEqual({ status: 'down' })
+    expect(result.dependencies.redis).toEqual({ status: 'up' })
   })
 
-  it('returns unhealthy when cache is down', async () => {
+  it('returns unhealthy when redis is down', async () => {
     const result = await runHealthChecks({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'down' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'down' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     expect(result.status).toBe('unhealthy')
-    expect(result.dependencies.cache).toEqual({ status: 'down' })
+    expect(result.dependencies.redis).toEqual({ status: 'down' })
   })
 
-  it('returns unhealthy when queue is down', async () => {
+  it('returns unhealthy when horizon listener is down', async () => {
     const result = await runHealthChecks({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
-      queue: async () => ({ status: 'down' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'down', reason: 'stale_heartbeat' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     expect(result.status).toBe('unhealthy')
-    expect(result.dependencies.queue).toEqual({ status: 'down' })
+    expect(result.dependencies.horizonListener).toEqual({ status: 'down', reason: 'stale_heartbeat' })
   })
 
-  it('returns degraded (not unhealthy) when gateway is down', async () => {
+  it('returns unhealthy when outbox publisher is down', async () => {
     const result = await runHealthChecks({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
-      queue: async () => ({ status: 'up' }),
-      gateway: async () => ({ status: 'down' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'down', reason: 'not_running' }),
+    })
+    expect(result.status).toBe('unhealthy')
+    expect(result.dependencies.outboxPublisher).toEqual({ status: 'down', reason: 'not_running' })
+  })
+
+  it('returns degraded when any dependency is not configured', async () => {
+    const result = await runHealthChecks({
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'not_configured' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     expect(result.status).toBe('degraded')
-    expect(result.dependencies.gateway).toEqual({ status: 'down' })
-  })
-
-  it('returns ok when gateway is up', async () => {
-    const result = await runHealthChecks({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
-      gateway: async () => ({ status: 'up' }),
-    })
-    expect(result.status).toBe('ok')
-    expect(result.dependencies.gateway).toEqual({ status: 'up' })
+    expect(result.dependencies.horizonListener).toEqual({ status: 'not_configured' })
   })
 
   it('does not expose internal details in response', async () => {
     const result = await runHealthChecks({
-      db: async () => ({ status: 'down' }),
-      cache: async () => ({ status: 'down' }),
+      postgres: async () => ({ status: 'down' }),
+      redis: async () => ({ status: 'down' }),
+      horizonListener: async () => ({ status: 'down' }),
+      outboxPublisher: async () => ({ status: 'down' }),
     })
     const body = JSON.stringify(result)
     expect(body).not.toMatch(/error|message|stack|connection|url|host/i)
-    expect(result.dependencies.db).toEqual({ status: 'down' })
-    expect(Object.keys(result.dependencies.db)).toEqual(['status'])
+    expect(result.dependencies.postgres).toEqual({ status: 'down' })
+    expect(Object.keys(result.dependencies.postgres)).toEqual(['status'])
   })
 })

--- a/src/services/health/checks.ts
+++ b/src/services/health/checks.ts
@@ -4,49 +4,55 @@ const SERVICE_NAME = 'credence-backend'
 
 /**
  * Runs all health probes and computes overall status.
- * Returns 503-level "unhealthy" only when a critical dependency (db, cache, queue) is down.
- * Optional gateway dependency does not cause unhealthy, but degraded.
+ * Returns "unhealthy" when any critical dependency or background worker is down.
+ * Returns "degraded" when one or more checks are not configured.
  *
- * @param probes - Object with optional probes for db, cache, queue, and gateway
+ * @param probes - Object with optional probes for postgres, redis, horizon listener, and outbox publisher
  * @returns Aggregated health result (no internal details exposed)
  */
 export async function runHealthChecks(probes: {
-  db?: HealthProbe
-  cache?: HealthProbe
-  queue?: HealthProbe
-  gateway?: HealthProbe
+  postgres?: HealthProbe
+  redis?: HealthProbe
+  horizonListener?: HealthProbe
+  outboxPublisher?: HealthProbe
 }): Promise<{
   status: 'ok' | 'degraded' | 'unhealthy'
   service: string
   dependencies: {
-    db: DependencyHealth
-    cache: DependencyHealth
-    queue: DependencyHealth
-    gateway: DependencyHealth
+    postgres: DependencyHealth
+    redis: DependencyHealth
+    horizonListener: DependencyHealth
+    outboxPublisher: DependencyHealth
   }
 }> {
-  const [db, cache, queue, gateway] = await Promise.all([
-    probes.db ? probes.db() : Promise.resolve({ status: 'not_configured' as const }),
-    probes.cache ? probes.cache() : Promise.resolve({ status: 'not_configured' as const }),
-    probes.queue ? probes.queue() : Promise.resolve({ status: 'not_configured' as const }),
-    probes.gateway ? probes.gateway() : Promise.resolve({ status: 'not_configured' as const }),
+  const [postgres, redis, horizonListener, outboxPublisher] = await Promise.all([
+    probes.postgres ? probes.postgres() : Promise.resolve({ status: 'not_configured' as const }),
+    probes.redis ? probes.redis() : Promise.resolve({ status: 'not_configured' as const }),
+    probes.horizonListener
+      ? probes.horizonListener()
+      : Promise.resolve({ status: 'not_configured' as const }),
+    probes.outboxPublisher
+      ? probes.outboxPublisher()
+      : Promise.resolve({ status: 'not_configured' as const }),
   ])
 
-  const deps = { db, cache, queue, gateway }
+  const deps = { postgres, redis, horizonListener, outboxPublisher }
 
   const criticalDown =
-    (db.status === 'down') ||
-    (cache.status === 'down') ||
-    (queue.status === 'down')
-  const anyCriticalConfigured =
-    (db.status !== 'not_configured') ||
-    (cache.status !== 'not_configured') ||
-    (queue.status !== 'not_configured')
+    (postgres.status === 'down') ||
+    (redis.status === 'down') ||
+    (horizonListener.status === 'down') ||
+    (outboxPublisher.status === 'down')
+  const anyNotConfigured =
+    (postgres.status === 'not_configured') ||
+    (redis.status === 'not_configured') ||
+    (horizonListener.status === 'not_configured') ||
+    (outboxPublisher.status === 'not_configured')
 
   let status: 'ok' | 'degraded' | 'unhealthy'
-  if (criticalDown && anyCriticalConfigured) {
+  if (criticalDown) {
     status = 'unhealthy'
-  } else if (gateway.status === 'down') {
+  } else if (anyNotConfigured) {
     status = 'degraded'
   } else {
     status = 'ok'

--- a/src/services/health/probes.ts
+++ b/src/services/health/probes.ts
@@ -1,7 +1,18 @@
 import type { HealthProbe } from "./types.js";
+import { pool } from "../../db/pool.js";
+import { RedisConnection } from "../../cache/redis.js";
+import {
+  getHorizonListenerState,
+  getOutboxPublisherState,
+  setHorizonListenerConfigured,
+  setOutboxPublisherConfigured,
+} from "./runtimeState.js";
 
 /** Default timeout (ms) for each dependency check to avoid hanging. */
 const CHECK_TIMEOUT_MS = 5000;
+const WORKER_HEARTBEAT_STALE_MS = Number(
+  process.env.HEALTH_WORKER_STALE_MS ?? "60000",
+);
 
 function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
   return Promise.race([
@@ -27,20 +38,13 @@ export interface DbProbeOptions {
 export function createDbProbe(
   options: DbProbeOptions = {},
 ): HealthProbe | undefined {
-  const url = process.env.DATABASE_URL;
-  if (!url && !options.runQuery) return undefined;
-
-  let pool: import("pg").Pool | null = null;
+  if (!process.env.DB_URL && !options.runQuery) return undefined;
 
   return async () => {
     try {
       if (options.runQuery) {
         await withTimeout(options.runQuery(), CHECK_TIMEOUT_MS);
         return { status: "up" };
-      }
-      if (!pool) {
-        const pg = (await import("pg")).default;
-        pool = new pg.Pool({ connectionString: url });
       }
       await withTimeout(pool.query("SELECT 1"), CHECK_TIMEOUT_MS);
       return { status: "up" };
@@ -73,23 +77,19 @@ function createGenericRedisProbe(
   const url = process.env[urlEnvVar];
   if (!url && !options.ping) return undefined;
 
-  let client: {
-    ping: () => Promise<string>;
-    quit: () => Promise<string>;
-  } | null = null;
-
   return async () => {
     try {
       if (options.ping) {
         await withTimeout(options.ping(), CHECK_TIMEOUT_MS);
         return { status: "up" };
       }
-      if (!client) {
-        const ioredis = await import("ioredis");
-        const Redis = ioredis.default as any;
-        client = new Redis(url!, { maxRetriesPerRequest: 1 });
+
+      const redis = RedisConnection.getInstance();
+      await withTimeout(redis.connect(), CHECK_TIMEOUT_MS);
+      const healthy = await withTimeout(redis.isHealthy(), CHECK_TIMEOUT_MS);
+      if (!healthy) {
+        return { status: "down", reason: "connection_refused" };
       }
-      await withTimeout(client!.ping(), CHECK_TIMEOUT_MS);
       return { status: "up" };
     } catch (err) {
       const reason =
@@ -119,50 +119,109 @@ export function createQueueProbe(
   return createGenericRedisProbe("QUEUE_URL", options);
 }
 
-/**
- * Optional gateway (e.g. Horizon/contract) probe.
- * When provided, failure is reported as degraded, not unhealthy.
- */
-export function createGatewayProbe(
-  check?: () => Promise<boolean>,
-): HealthProbe | undefined {
-  if (!check) return undefined;
-  
+export function createHorizonListenerProbe(
+  maxStaleMs: number = WORKER_HEARTBEAT_STALE_MS,
+): HealthProbe {
   return async () => {
-    try {
-      const ok = await withTimeout(check(), CHECK_TIMEOUT_MS);
-      return ok ? { status: "up" } : { status: "down", reason: "unhealthy_response" };
-    } catch (err) {
-      const reason =
-        err instanceof Error && err.message === "timeout"
-          ? "timeout"
-          : "connection_refused";
-      return { status: "down", reason };
+    const state = getHorizonListenerState();
+    if (!state.configured) {
+      return { status: "not_configured" };
     }
+    if (!state.running) {
+      return { status: "down", reason: "not_running" };
+    }
+    if (state.lastHeartbeatAt === null) {
+      return { status: "down", reason: "no_heartbeat" };
+    }
+
+    const ageMs = Date.now() - state.lastHeartbeatAt;
+    if (ageMs > maxStaleMs) {
+      return {
+        status: "down",
+        reason: "stale_heartbeat",
+        details: {
+          heartbeatAgeMs: ageMs,
+          maxHeartbeatAgeMs: maxStaleMs,
+          lastCursor: state.lastCursor,
+        },
+      };
+    }
+
+    return {
+      status: "up",
+      details: {
+        heartbeatAgeMs: ageMs,
+        maxHeartbeatAgeMs: maxStaleMs,
+        lastCursor: state.lastCursor,
+      },
+    };
+  };
+}
+
+export function createOutboxPublisherProbe(
+  maxStaleMs: number = WORKER_HEARTBEAT_STALE_MS,
+): HealthProbe {
+  return async () => {
+    const state = getOutboxPublisherState();
+    if (!state.configured) {
+      return { status: "not_configured" };
+    }
+    if (!state.running) {
+      return { status: "down", reason: "not_running" };
+    }
+    if (state.lastHeartbeatAt === null) {
+      return { status: "down", reason: "no_heartbeat" };
+    }
+
+    const ageMs = Date.now() - state.lastHeartbeatAt;
+    if (ageMs > maxStaleMs) {
+      return {
+        status: "down",
+        reason: "stale_heartbeat",
+        details: {
+          heartbeatAgeMs: ageMs,
+          maxHeartbeatAgeMs: maxStaleMs,
+        },
+      };
+    }
+
+    return {
+      status: "up",
+      details: {
+        heartbeatAgeMs: ageMs,
+        maxHeartbeatAgeMs: maxStaleMs,
+      },
+    };
   };
 }
 
 /**
- * Builds default probes from environment (DATABASE_URL, REDIS_URL, QUEUE_URL).
+ * Builds default probes from environment and runtime worker state.
  * When not configured, skips that probe (reported as not_configured).
  */
 export function createDefaultProbes(): {
-  db?: HealthProbe;
-  cache?: HealthProbe;
-  queue?: HealthProbe;
-  gateway?: HealthProbe;
+  postgres?: HealthProbe;
+  redis?: HealthProbe;
+  horizonListener?: HealthProbe;
+  outboxPublisher?: HealthProbe;
 } {
-  const out: { db?: HealthProbe; cache?: HealthProbe; queue?: HealthProbe; gateway?: HealthProbe } =
+  const out: {
+    postgres?: HealthProbe;
+    redis?: HealthProbe;
+    horizonListener?: HealthProbe;
+    outboxPublisher?: HealthProbe;
+  } =
     {};
-  if (process.env.DATABASE_URL) out.db = createDbProbe();
-  if (process.env.REDIS_URL) out.cache = createCacheProbe();
-  if (process.env.QUEUE_URL) out.queue = createQueueProbe();
-  // Gateway could have a default check if GATEWAY_URL is provided, but currently it's externally provided
-  if (process.env.GATEWAY_URL) {
-    out.gateway = createGatewayProbe(async () => {
-      const res = await fetch(process.env.GATEWAY_URL!);
-      return res.ok;
-    });
-  }
+
+  if (process.env.DB_URL) out.postgres = createDbProbe();
+  if (process.env.REDIS_URL) out.redis = createCacheProbe();
+
+  setHorizonListenerConfigured(Boolean(process.env.HORIZON_URL));
+  out.horizonListener = createHorizonListenerProbe();
+
+  const outboxEnabled = (process.env.OUTBOX_ENABLED ?? "true") === "true";
+  setOutboxPublisherConfigured(outboxEnabled);
+  out.outboxPublisher = createOutboxPublisherProbe();
+
   return out;
 }

--- a/src/services/health/runtimeState.ts
+++ b/src/services/health/runtimeState.ts
@@ -1,0 +1,80 @@
+interface WorkerHealthState {
+  configured: boolean
+  running: boolean
+  lastHeartbeatAt: number | null
+  lastCursor: string | null
+}
+
+export interface WorkerHealthSnapshot {
+  configured: boolean
+  running: boolean
+  lastHeartbeatAt: number | null
+  lastCursor: string | null
+}
+
+const horizonState: WorkerHealthState = {
+  configured: false,
+  running: false,
+  lastHeartbeatAt: null,
+  lastCursor: null,
+}
+
+const outboxState: WorkerHealthState = {
+  configured: false,
+  running: false,
+  lastHeartbeatAt: null,
+  lastCursor: null,
+}
+
+export function setHorizonListenerConfigured(configured: boolean): void {
+  horizonState.configured = configured
+}
+
+export function setHorizonListenerRunning(running: boolean): void {
+  horizonState.running = running
+  if (!running) {
+    horizonState.lastHeartbeatAt = null
+  }
+}
+
+export function recordHorizonListenerHeartbeat(cursor?: string): void {
+  horizonState.lastHeartbeatAt = Date.now()
+  if (cursor !== undefined) {
+    horizonState.lastCursor = cursor
+  }
+}
+
+export function getHorizonListenerState(): WorkerHealthSnapshot {
+  return { ...horizonState }
+}
+
+export function setOutboxPublisherConfigured(configured: boolean): void {
+  outboxState.configured = configured
+}
+
+export function setOutboxPublisherRunning(running: boolean): void {
+  outboxState.running = running
+  if (!running) {
+    outboxState.lastHeartbeatAt = null
+  }
+}
+
+export function recordOutboxPublisherHeartbeat(): void {
+  outboxState.lastHeartbeatAt = Date.now()
+}
+
+export function getOutboxPublisherState(): WorkerHealthSnapshot {
+  return { ...outboxState }
+}
+
+export function resetWorkerHealthState(): void {
+  horizonState.configured = false
+  horizonState.running = false
+  horizonState.lastHeartbeatAt = null
+  horizonState.lastCursor = null
+
+  outboxState.configured = false
+  outboxState.running = false
+  outboxState.lastHeartbeatAt = null
+  outboxState.lastCursor = null
+}

--- a/src/services/health/types.ts
+++ b/src/services/health/types.ts
@@ -8,16 +8,18 @@ export interface DependencyHealth {
   status: DependencyStatus
   /** Human-readable reason for non-'up' status. Omitted when status is 'up'. */
   reason?: string
+  /** Optional safe metadata for debugging readiness (no secrets). */
+  details?: Record<string, string | number | boolean | null>
 }
 
 export interface HealthResult {
   status: 'ok' | 'degraded' | 'unhealthy'
   service: string
   dependencies: {
-    db: DependencyHealth
-    cache: DependencyHealth
-    queue: DependencyHealth
-    gateway: DependencyHealth
+    postgres: DependencyHealth
+    redis: DependencyHealth
+    horizonListener: DependencyHealth
+    outboxPublisher: DependencyHealth
   }
 }
 

--- a/tests/routes/health.test.ts
+++ b/tests/routes/health.test.ts
@@ -10,58 +10,68 @@ function appWithHealth(probes: Parameters<typeof createHealthRouter>[0] = {}) {
 }
 
 describe('Health route – dependency-aware checks with degradation reasons', () => {
-  it('includes reason when db is down', async () => {
+  it('includes reason when postgres is down', async () => {
     const app = appWithHealth({
-      db: async () => ({ status: 'down', reason: 'connection_refused' }),
-      cache: async () => ({ status: 'up' }),
+      postgres: async () => ({ status: 'down', reason: 'connection_refused' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     const res = await request(app).get('/api/health')
     expect(res.status).toBe(503)
     expect(res.body.status).toBe('unhealthy')
-    expect(res.body.dependencies.db.status).toBe('down')
-    expect(res.body.dependencies.db.reason).toBe('connection_refused')
+    expect(res.body.dependencies.postgres.status).toBe('down')
+    expect(res.body.dependencies.postgres.reason).toBe('connection_refused')
   })
 
-  it('includes reason when cache is down', async () => {
+  it('includes reason when redis is down', async () => {
     const app = appWithHealth({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'down', reason: 'timeout' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'down', reason: 'timeout' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     const res = await request(app).get('/api/health')
     expect(res.status).toBe(503)
-    expect(res.body.dependencies.cache.reason).toBe('timeout')
+    expect(res.body.dependencies.redis.reason).toBe('timeout')
   })
 
-  it('includes reason when queue is down', async () => {
+  it('includes reason when horizon listener heartbeat is stale', async () => {
     const app = appWithHealth({
-      queue: async () => ({ status: 'down', reason: 'connection_refused' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'down', reason: 'stale_heartbeat' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     const res = await request(app).get('/api/health')
     expect(res.status).toBe(503)
-    expect(res.body.dependencies.queue.reason).toBe('connection_refused')
+    expect(res.body.dependencies.horizonListener.reason).toBe('stale_heartbeat')
   })
 
-  it('includes reason when gateway is down (degraded)', async () => {
+  it('includes reason when outbox publisher is down', async () => {
     const app = appWithHealth({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
-      gateway: async () => ({ status: 'down', reason: 'unhealthy_response' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'down', reason: 'not_running' }),
     })
     const res = await request(app).get('/api/health')
-    expect(res.status).toBe(200)
-    expect(res.body.status).toBe('degraded')
-    expect(res.body.dependencies.gateway.reason).toBe('unhealthy_response')
+    expect(res.status).toBe(503)
+    expect(res.body.status).toBe('unhealthy')
+    expect(res.body.dependencies.outboxPublisher.reason).toBe('not_running')
   })
 
   it('omits reason when dependency is up', async () => {
     const app = appWithHealth({
-      db: async () => ({ status: 'up' }),
-      cache: async () => ({ status: 'up' }),
+      postgres: async () => ({ status: 'up' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     const res = await request(app).get('/api/health')
     expect(res.status).toBe(200)
-    expect(res.body.dependencies.db.reason).toBeUndefined()
-    expect(res.body.dependencies.cache.reason).toBeUndefined()
+    expect(res.body.dependencies.postgres.reason).toBeUndefined()
+    expect(res.body.dependencies.redis.reason).toBeUndefined()
   })
 
   it('schema is stable: always has status, service, dependencies keys', async () => {
@@ -71,24 +81,30 @@ describe('Health route – dependency-aware checks with degradation reasons', ()
     expect(res.body).toHaveProperty('status')
     expect(res.body).toHaveProperty('service', 'credence-backend')
     expect(res.body).toHaveProperty('dependencies')
-    expect(res.body.dependencies).toHaveProperty('db')
-    expect(res.body.dependencies).toHaveProperty('cache')
-    expect(res.body.dependencies).toHaveProperty('queue')
-    expect(res.body.dependencies).toHaveProperty('gateway')
+    expect(res.body.dependencies).toHaveProperty('postgres')
+    expect(res.body.dependencies).toHaveProperty('redis')
+    expect(res.body.dependencies).toHaveProperty('horizonListener')
+    expect(res.body.dependencies).toHaveProperty('outboxPublisher')
   })
 
   it('/ready also propagates reason', async () => {
     const app = appWithHealth({
-      db: async () => ({ status: 'down', reason: 'timeout' }),
+      postgres: async () => ({ status: 'down', reason: 'timeout' }),
+      redis: async () => ({ status: 'up' }),
+      horizonListener: async () => ({ status: 'up' }),
+      outboxPublisher: async () => ({ status: 'up' }),
     })
     const res = await request(app).get('/api/health/ready')
     expect(res.status).toBe(503)
-    expect(res.body.dependencies.db.reason).toBe('timeout')
+    expect(res.body.dependencies.postgres.reason).toBe('timeout')
   })
 
   it('/live never includes dependency details', async () => {
     const app = appWithHealth({
-      db: async () => ({ status: 'down', reason: 'connection_refused' }),
+      postgres: async () => ({ status: 'down', reason: 'connection_refused' }),
+      redis: async () => ({ status: 'down', reason: 'timeout' }),
+      horizonListener: async () => ({ status: 'down', reason: 'stale_heartbeat' }),
+      outboxPublisher: async () => ({ status: 'down', reason: 'not_running' }),
     })
     const res = await request(app).get('/api/health/live')
     expect(res.status).toBe(200)


### PR DESCRIPTION
Closes #336

---

## Summary
- implement deep readiness checks for , , , and 
- separate liveness () from readiness ( and ) with worker-aware health evaluation
- expose safe per-check status details (including heartbeat age) without leaking connection internals
- add runtime health state tracking for Horizon listener and outbox publisher lease heartbeats
- wire outbox publisher and horizon withdrawal listener to emit running-state and heartbeat updates
- update docs for Kubernetes probe behavior and monitoring expectations

## Behavior
- readiness is  (HTTP 503) when any deep dependency/worker is down
- readiness is  (HTTP 200) when checks are not configured
- liveness remains process-level and always returns HTTP 200 while process is up

## Testing
- 
> credence-backend@0.1.0 test
> vitest run


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.6 [39m[90m/workspaces/Credence-Backend[39m

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2minitialize()[2m > [22m[2mgenerates one active key on first call
[22m[39m{"timestamp":"2026-05-26T16:32:35.897Z","event":"KEY_CREATED","kid":"5f89d3d1-3f2b-401b-89b2-ea6bc90f3094"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2minitialize()[2m > [22m[2massigns a UUID kid to the generated key
[22m[39m{"timestamp":"2026-05-26T16:32:35.945Z","event":"KEY_CREATED","kid":"ab449b90-ea4a-4c4c-8f22-7a338a19fc96"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2minitialize()[2m > [22m[2mis idempotent — calling twice does not create a second key
[22m[39m{"timestamp":"2026-05-26T16:32:36.040Z","event":"KEY_CREATED","kid":"dfb445b4-5c76-4347-89da-3e5d59084b39"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetCurrentKey()[2m > [22m[2mreturns the active key after initialize()
[22m[39m{"timestamp":"2026-05-26T16:32:36.110Z","event":"KEY_CREATED","kid":"a531a1fe-fd61-42a3-82b9-6d9568af6022"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mcreates a new active key
[22m[39m{"timestamp":"2026-05-26T16:32:36.135Z","event":"KEY_CREATED","kid":"6fbe7fd5-abda-48e1-baba-0f2e0bfc907b"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mcreates a new active key
[22m[39m{"timestamp":"2026-05-26T16:32:36.135Z","event":"KEY_RETIRED","kid":"6fbe7fd5-abda-48e1-baba-0f2e0bfc907b"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mcreates a new active key
[22m[39m{"timestamp":"2026-05-26T16:32:36.204Z","event":"KEY_ROTATED","kid":"9caaa7eb-284b-4d62-bfd9-3fcf3b8fc26e","previousActiveKid":"6fbe7fd5-abda-48e1-baba-0f2e0bfc907b"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mretires the previous active key with retiredAt set
[22m[39m{"timestamp":"2026-05-26T16:32:36.227Z","event":"KEY_CREATED","kid":"eb9cb11d-c44b-4c1c-baf5-f84827d0af3c"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mretires the previous active key with retiredAt set
[22m[39m{"timestamp":"2026-05-26T16:32:36.228Z","event":"KEY_RETIRED","kid":"eb9cb11d-c44b-4c1c-baf5-f84827d0af3c"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mretires the previous active key with retiredAt set
[22m[39m{"timestamp":"2026-05-26T16:32:36.241Z","event":"KEY_ROTATED","kid":"b4ab3031-1c89-49e4-be1a-a1ee01f77a2b","previousActiveKid":"eb9cb11d-c44b-4c1c-baf5-f84827d0af3c"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mreturns { newKid, retiredKid }
[22m[39m{"timestamp":"2026-05-26T16:32:36.290Z","event":"KEY_CREATED","kid":"1793de4e-8190-40d5-ba80-29e0472fc5d2"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mreturns { newKid, retiredKid }
[22m[39m{"timestamp":"2026-05-26T16:32:36.290Z","event":"KEY_RETIRED","kid":"1793de4e-8190-40d5-ba80-29e0472fc5d2"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mreturns { newKid, retiredKid }
[22m[39m{"timestamp":"2026-05-26T16:32:36.344Z","event":"KEY_ROTATED","kid":"9bbe5c14-2de3-4d7b-a916-1298f234b5aa","previousActiveKid":"1793de4e-8190-40d5-ba80-29e0472fc5d2"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mnew kid differs from retired kid
[22m[39m{"timestamp":"2026-05-26T16:32:36.362Z","event":"KEY_CREATED","kid":"2aadb916-53dd-4ef3-b99d-0ca51b9c97d4"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mnew kid differs from retired kid
[22m[39m{"timestamp":"2026-05-26T16:32:36.362Z","event":"KEY_RETIRED","kid":"2aadb916-53dd-4ef3-b99d-0ca51b9c97d4"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mrotate()[2m > [22m[2mnew kid differs from retired kid
[22m[39m{"timestamp":"2026-05-26T16:32:36.386Z","event":"KEY_ROTATED","kid":"ce42cae2-4b1b-45f2-b431-b1002699d57c","previousActiveKid":"2aadb916-53dd-4ef3-b99d-0ca51b9c97d4"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAllVerificationKeys()[2m > [22m[2mreturns only the active key before any rotation
[22m[39m{"timestamp":"2026-05-26T16:32:36.436Z","event":"KEY_CREATED","kid":"49f93011-5e77-432a-af43-ee93bd311884"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAllVerificationKeys()[2m > [22m[2mreturns active + retired key immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:36.459Z","event":"KEY_CREATED","kid":"a8f36d41-9e01-48e7-976b-7aa02a369875"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAllVerificationKeys()[2m > [22m[2mreturns active + retired key immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:36.459Z","event":"KEY_RETIRED","kid":"a8f36d41-9e01-48e7-976b-7aa02a369875"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAllVerificationKeys()[2m > [22m[2mreturns active + retired key immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:36.522Z","event":"KEY_ROTATED","kid":"fa55cf2b-8bc6-44ff-b0d1-a7bd3ebdb338","previousActiveKid":"a8f36d41-9e01-48e7-976b-7aa02a369875"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2mreturns { keys: [] } shape
[22m[39m{"timestamp":"2026-05-26T16:32:36.546Z","event":"KEY_CREATED","kid":"cd3faa05-8b4b-4ef3-9df7-3d00168c4e64"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2mreturns one entry after initialize()
[22m[39m{"timestamp":"2026-05-26T16:32:36.585Z","event":"KEY_CREATED","kid":"f371da34-1b60-4060-a8bd-398206819059"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2mreturns two entries immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:36.619Z","event":"KEY_CREATED","kid":"4ee2efc2-da92-49f2-bd96-d6a4336bfba5"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2mreturns two entries immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:36.620Z","event":"KEY_RETIRED","kid":"4ee2efc2-da92-49f2-bd96-d6a4336bfba5"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2mreturns two entries immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:36.643Z","event":"KEY_ROTATED","kid":"300be7f8-5a55-4d93-b76a-996f2c2660ed","previousActiveKid":"4ee2efc2-da92-49f2-bd96-d6a4336bfba5"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2meach JWK has kid, kty, alg, and use === sig
[22m[39m{"timestamp":"2026-05-26T16:32:36.692Z","event":"KEY_CREATED","kid":"edd05539-3e91-463a-ab8d-7f06380c35bc"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2mdoes not expose private key material (no d, p, q, dp, dq, qi)
[22m[39m{"timestamp":"2026-05-26T16:32:36.735Z","event":"KEY_CREATED","kid":"d597a180-2c17-4eaf-87bd-71c1456d96ae"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetPublicJwks()[2m > [22m[2mJWK kid matches the active key kid
[22m[39m{"timestamp":"2026-05-26T16:32:36.864Z","event":"KEY_CREATED","kid":"1ae8a4db-c855-427c-b82e-76f88035768b"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2msignToken()[2m > [22m[2mreturns a compact JWT string (three dot-separated segments)
[22m[39m{"timestamp":"2026-05-26T16:32:36.938Z","event":"KEY_CREATED","kid":"f7f31bec-74e6-4d88-b369-65a3418bfd69"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2msignToken()[2m > [22m[2mJWT protected header contains kid matching the active key
[22m[39m{"timestamp":"2026-05-26T16:32:36.959Z","event":"KEY_CREATED","kid":"8514fc7b-9308-4554-885e-6e4e02e84cd9"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2msignToken()[2m > [22m[2mJWT protected header contains alg: PS256
[22m[39m{"timestamp":"2026-05-26T16:32:37.069Z","event":"KEY_CREATED","kid":"2463a5e1-e378-48f5-9990-d3c276cdb727"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mverifyToken()[2m > [22m[2mverifies a token signed with the active key
[22m[39m{"timestamp":"2026-05-26T16:32:37.114Z","event":"KEY_CREATED","kid":"3703277c-542c-400c-bca5-3f0f1b51e199"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mverifyToken()[2m > [22m[2mrejects a tampered token
[22m[39m{"timestamp":"2026-05-26T16:32:37.146Z","event":"KEY_CREATED","kid":"58e1682d-ec49-42b2-a5e0-69e3391a9171"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mverifyToken()[2m > [22m[2mrejects a token with unknown kid
[22m[39m{"timestamp":"2026-05-26T16:32:37.237Z","event":"KEY_CREATED","kid":"74ac17ad-3ed2-41ec-a627-e3b3386ea2c5"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mverifyToken()[2m > [22m[2mrejects a token with unknown kid
[22m[39m{"timestamp":"2026-05-26T16:32:37.276Z","event":"KEY_CREATED","kid":"0a63eaaa-c1ef-40f9-809f-0d7ab1eeb2cb"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mverifyToken()[2m > [22m[2mrejects a JWT with no kid in header
[22m[39m{"timestamp":"2026-05-26T16:32:37.362Z","event":"KEY_CREATED","kid":"8a111438-d5e3-4ead-9a40-df4846fa4225"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mrecords KEY_CREATED on initialize()
[22m[39m{"timestamp":"2026-05-26T16:32:37.412Z","event":"KEY_CREATED","kid":"6f242726-a5b0-4d2e-a709-e83cebd29807"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mrecords KEY_RETIRED and KEY_ROTATED on rotate()
[22m[39m{"timestamp":"2026-05-26T16:32:37.515Z","event":"KEY_CREATED","kid":"2aefd303-392e-4388-b406-5b241730d064"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mrecords KEY_RETIRED and KEY_ROTATED on rotate()
[22m[39m{"timestamp":"2026-05-26T16:32:37.516Z","event":"KEY_RETIRED","kid":"2aefd303-392e-4388-b406-5b241730d064"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mrecords KEY_RETIRED and KEY_ROTATED on rotate()
[22m[39m{"timestamp":"2026-05-26T16:32:37.612Z","event":"KEY_ROTATED","kid":"e0c213c6-298f-4032-ae2b-fee5aa50cda5","previousActiveKid":"2aefd303-392e-4388-b406-5b241730d064"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mKEY_ROTATED event has previousActiveKid set
[22m[39m{"timestamp":"2026-05-26T16:32:37.710Z","event":"KEY_CREATED","kid":"9c3b8579-5bde-4d01-80ee-a3eacefb3461"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mKEY_ROTATED event has previousActiveKid set
[22m[39m{"timestamp":"2026-05-26T16:32:37.710Z","event":"KEY_RETIRED","kid":"9c3b8579-5bde-4d01-80ee-a3eacefb3461"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mKEY_ROTATED event has previousActiveKid set
[22m[39m{"timestamp":"2026-05-26T16:32:37.732Z","event":"KEY_ROTATED","kid":"899fe735-4878-4a29-bb9a-2ddbd87949de","previousActiveKid":"9c3b8579-5bde-4d01-80ee-a3eacefb3461"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2mgetAuditLog()[2m > [22m[2mreturns a copy — mutations do not affect internal state
[22m[39m{"timestamp":"2026-05-26T16:32:37.762Z","event":"KEY_CREATED","kid":"345409a2-14d5-4b52-b470-e6f3be274ff5"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2m_resetStore()[2m > [22m[2mclears all keys
[22m[39m{"timestamp":"2026-05-26T16:32:37.774Z","event":"KEY_CREATED","kid":"b5c5a0e7-3ef2-4a56-8252-4b8ad5d1c937"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager (singleton)[2m > [22m[2m_resetStore()[2m > [22m[2mclears the audit log
[22m[39m{"timestamp":"2026-05-26T16:32:37.795Z","event":"KEY_CREATED","kid":"2d776721-b44d-4fdd-8ca4-bac69860768c"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mtoken signed before rotation verifies during grace period
[22m[39m{"timestamp":"2026-05-26T16:32:37.865Z","event":"KEY_CREATED","kid":"5de7a56f-18a7-41b9-8e7f-dff57810616c"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mtoken signed before rotation verifies during grace period
[22m[39m{"timestamp":"2026-05-26T16:32:37.866Z","event":"KEY_RETIRED","kid":"5de7a56f-18a7-41b9-8e7f-dff57810616c"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mtoken signed before rotation verifies during grace period
[22m[39m{"timestamp":"2026-05-26T16:32:37.932Z","event":"KEY_ROTATED","kid":"b8738de0-13f7-4e1a-bdc8-7c2277801deb","previousActiveKid":"5de7a56f-18a7-41b9-8e7f-dff57810616c"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mtoken signed with new key after rotation verifies
[22m[39m{"timestamp":"2026-05-26T16:32:38.000Z","event":"KEY_CREATED","kid":"7d825dbf-b392-46d0-9ed0-204ba6fc9278"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mtoken signed with new key after rotation verifies
[22m[39m{"timestamp":"2026-05-26T16:32:38.000Z","event":"KEY_RETIRED","kid":"7d825dbf-b392-46d0-9ed0-204ba6fc9278"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mtoken signed with new key after rotation verifies
[22m[39m{"timestamp":"2026-05-26T16:32:38.033Z","event":"KEY_ROTATED","kid":"c7095273-7246-4dd9-88d1-e63bbe3ca87a","previousActiveKid":"7d825dbf-b392-46d0-9ed0-204ba6fc9278"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mboth old and new tokens verify immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:38.069Z","event":"KEY_CREATED","kid":"80a057d2-190d-4a46-8bb5-62b2f022692e"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mboth old and new tokens verify immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:38.072Z","event":"KEY_RETIRED","kid":"80a057d2-190d-4a46-8bb5-62b2f022692e"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — rotation boundary tests[2m > [22m[2mboth old and new tokens verify immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:38.181Z","event":"KEY_ROTATED","kid":"1643a469-6577-41d6-8752-bf3f70bbd4a7","previousActiveKid":"80a057d2-190d-4a46-8bb5-62b2f022692e"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mdoes not prune a retired key within the grace + skew window
[22m[39m{"timestamp":"2026-05-26T16:32:38.201Z","event":"KEY_CREATED","kid":"a7ed73fc-9510-494b-b5f7-f0f912400fce"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mdoes not prune a retired key within the grace + skew window
[22m[39m{"timestamp":"2026-05-26T16:32:38.202Z","event":"KEY_RETIRED","kid":"a7ed73fc-9510-494b-b5f7-f0f912400fce"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mdoes not prune a retired key within the grace + skew window
[22m[39m{"timestamp":"2026-05-26T16:32:38.273Z","event":"KEY_ROTATED","kid":"1d918850-583b-40b9-a767-37860ba18b56","previousActiveKid":"a7ed73fc-9510-494b-b5f7-f0f912400fce"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mprunes a retired key after grace + skew window has elapsed
[22m[39m{"timestamp":"2026-05-26T16:32:38.349Z","event":"KEY_CREATED","kid":"9477f59c-0580-4b98-a27c-c38bf1477415"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mprunes a retired key after grace + skew window has elapsed
[22m[39m{"timestamp":"2026-05-26T16:32:38.349Z","event":"KEY_RETIRED","kid":"9477f59c-0580-4b98-a27c-c38bf1477415"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mprunes a retired key after grace + skew window has elapsed
[22m[39m{"timestamp":"2026-05-26T16:32:38.374Z","event":"KEY_ROTATED","kid":"b669e546-1662-42b8-a819-05d93972b5a7","previousActiveKid":"9477f59c-0580-4b98-a27c-c38bf1477415"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mprunes a retired key after grace + skew window has elapsed
[22m[39m{"timestamp":"2026-05-26T16:33:49.374Z","event":"KEY_PRUNED","kid":"9477f59c-0580-4b98-a27c-c38bf1477415"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2memits KEY_PRUNED audit event for each pruned key
[22m[39m{"timestamp":"2026-05-26T16:32:38.405Z","event":"KEY_CREATED","kid":"12e09920-264a-489e-aff2-580e740d33a7"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2memits KEY_PRUNED audit event for each pruned key
[22m[39m{"timestamp":"2026-05-26T16:32:38.406Z","event":"KEY_RETIRED","kid":"12e09920-264a-489e-aff2-580e740d33a7"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2memits KEY_PRUNED audit event for each pruned key
[22m[39m{"timestamp":"2026-05-26T16:32:38.445Z","event":"KEY_ROTATED","kid":"f1536043-53ec-42a4-aa41-9cb52eaf389b","previousActiveKid":"12e09920-264a-489e-aff2-580e740d33a7"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2memits KEY_PRUNED audit event for each pruned key
[22m[39m{"timestamp":"2026-05-26T16:33:49.445Z","event":"KEY_PRUNED","kid":"12e09920-264a-489e-aff2-580e740d33a7"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mold token fails verification after its key is pruned
[22m[39m{"timestamp":"2026-05-26T16:32:38.492Z","event":"KEY_CREATED","kid":"efb4e159-708d-4064-8b31-0c4f58722cfa"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mold token fails verification after its key is pruned
[22m[39m{"timestamp":"2026-05-26T16:32:38.495Z","event":"KEY_RETIRED","kid":"efb4e159-708d-4064-8b31-0c4f58722cfa"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mold token fails verification after its key is pruned
[22m[39m{"timestamp":"2026-05-26T16:32:38.506Z","event":"KEY_ROTATED","kid":"7a9ee523-4d3a-4c02-b29d-f2dcc8e4c1de","previousActiveKid":"efb4e159-708d-4064-8b31-0c4f58722cfa"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mold token fails verification after its key is pruned
[22m[39m{"timestamp":"2026-05-26T16:33:49.506Z","event":"KEY_PRUNED","kid":"efb4e159-708d-4064-8b31-0c4f58722cfa"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mreturns array of pruned kids
[22m[39m{"timestamp":"2026-05-26T16:32:38.529Z","event":"KEY_CREATED","kid":"39fb5d40-9da1-49a7-b450-a23896944134"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mreturns array of pruned kids
[22m[39m{"timestamp":"2026-05-26T16:32:38.529Z","event":"KEY_RETIRED","kid":"39fb5d40-9da1-49a7-b450-a23896944134"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mreturns array of pruned kids
[22m[39m{"timestamp":"2026-05-26T16:32:38.569Z","event":"KEY_ROTATED","kid":"6410a988-15b1-4b72-b7e0-975014a4835d","previousActiveKid":"39fb5d40-9da1-49a7-b450-a23896944134"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — pruneExpiredKeys()[2m > [22m[2mreturns array of pruned kids
[22m[39m{"timestamp":"2026-05-26T16:33:49.569Z","event":"KEY_PRUNED","kid":"39fb5d40-9da1-49a7-b450-a23896944134"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2mloads key from PEM instead of generating a new one
[22m[39m{"timestamp":"2026-05-26T16:32:38.626Z","event":"KEY_CREATED","kid":"71671c76-7565-4102-91e0-924e7eade8bd"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2muses initialKid when provided alongside privateKeyPem
[22m[39m{"timestamp":"2026-05-26T16:32:38.627Z","event":"KEY_CREATED","kid":"my-stable-kid-v1"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2massigns a random UUID kid when initialKid is not provided
[22m[39m{"timestamp":"2026-05-26T16:32:38.627Z","event":"KEY_CREATED","kid":"f4e7bb7c-c4a1-4c8b-8492-4a0caf4b23d0"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2mcan sign and verify tokens after loading from PEM
[22m[39m{"timestamp":"2026-05-26T16:32:38.628Z","event":"KEY_CREATED","kid":"29329fe5-42e7-4ccb-8eaf-1c28ba2e93e1"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2mdoes not expose private key material in JWKS after PEM load
[22m[39m{"timestamp":"2026-05-26T16:32:38.630Z","event":"KEY_CREATED","kid":"d73bba44-9794-4a51-8d92-956b9eef9d33"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2memits KEY_CREATED audit event when loading from PEM
[22m[39m{"timestamp":"2026-05-26T16:32:38.631Z","event":"KEY_CREATED","kid":"97e9748e-e6bc-4c9c-9ea3-d95435d3a423"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2mis idempotent — second initialize() call is a no-op even with PEM
[22m[39m{"timestamp":"2026-05-26T16:32:38.632Z","event":"KEY_CREATED","kid":"stable-kid"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2mrotation still works after PEM-loaded key
[22m[39m{"timestamp":"2026-05-26T16:32:38.633Z","event":"KEY_CREATED","kid":"pem-key"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2mrotation still works after PEM-loaded key
[22m[39m{"timestamp":"2026-05-26T16:32:38.633Z","event":"KEY_RETIRED","kid":"pem-key"}

[90mstdout[2m | src/services/keyManager/keyManager.test.ts[2m > [22m[2mKeyManager — initialize() with privateKeyPem[2m > [22m[2mrotation still works after PEM-loaded key
[22m[39m{"timestamp":"2026-05-26T16:32:38.696Z","event":"KEY_ROTATED","kid":"60492eb7-73cc-4569-87ce-b771ef0ed60b","previousActiveKid":"pem-key"}

 [32m✓[39m src/services/keyManager/keyManager.test.ts [2m([22m[2m48 tests[22m[2m)[22m[33m 2894[2mms[22m[39m
 [32m✓[39m src/cache/__tests__/integration.test.ts [2m([22m[2m10 tests[22m[2m)[22m[33m 1108[2mms[22m[39m
       [33m[2m✓[22m[39m should respect TTL for cached data [33m 1100[2mms[22m[39m
[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mreturns 200
[22m[39m{"timestamp":"2026-05-26T16:32:40.443Z","event":"KEY_CREATED","kid":"8c14b8b5-173d-4c8a-ac9a-4bcaa43f0f41"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mContent-Type is application/json
[22m[39m{"timestamp":"2026-05-26T16:32:40.488Z","event":"KEY_CREATED","kid":"fe4e32a5-a5c2-49fb-9a6a-fa3f16a70380"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mresponse body has a keys array
[22m[39m{"timestamp":"2026-05-26T16:32:40.526Z","event":"KEY_CREATED","kid":"2e1f2063-a5e3-4b96-9df5-a5d1c89dc02f"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mkeys array has one entry after initialize()
[22m[39m{"timestamp":"2026-05-26T16:32:40.568Z","event":"KEY_CREATED","kid":"04e3fc56-12f8-4cd9-94b8-ed5bf528feba"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2meach key entry has kid, kty, alg, and use
[22m[39m{"timestamp":"2026-05-26T16:32:40.610Z","event":"KEY_CREATED","kid":"4db2eff8-3fbf-428e-87de-f146cd9839c0"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mreturns two keys immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:40.664Z","event":"KEY_CREATED","kid":"7847d359-f4d3-447e-98ad-663f2cbb87ff"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mreturns two keys immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:40.664Z","event":"KEY_RETIRED","kid":"7847d359-f4d3-447e-98ad-663f2cbb87ff"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mreturns two keys immediately after rotation
[22m[39m{"timestamp":"2026-05-26T16:32:40.685Z","event":"KEY_ROTATED","kid":"c3344540-6bd1-43b8-9a31-e5d8409b78a8","previousActiveKid":"7847d359-f4d3-447e-98ad-663f2cbb87ff"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mactive key kid matches the kid in the JWKS response
[22m[39m{"timestamp":"2026-05-26T16:32:40.717Z","event":"KEY_CREATED","kid":"4f68dae6-6f9b-4120-9b5c-9310e1a4e7fc"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mdoes not expose private key material in any entry
[22m[39m{"timestamp":"2026-05-26T16:32:40.787Z","event":"KEY_CREATED","kid":"4d8d4422-8d33-4f34-8fba-050d63b5502e"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2msets Cache-Control header with max-age=300
[22m[39m{"timestamp":"2026-05-26T16:32:40.815Z","event":"KEY_CREATED","kid":"6ebcab12-0589-45b5-86c0-27bc9dec3a6e"}

[90mstdout[2m | src/routes/jwks.test.ts[2m > [22m[2mGET /.well-known/jwks.json[2m > [22m[2mreturns 503 if keyManager.getPublicJwks throws
[22m[39m{"timestamp":"2026-05-26T16:32:40.870Z","event":"KEY_CREATED","kid":"4b1933cd-5930-4cdf-81ac-cafb56cbd124"}

 [32m✓[39m src/routes/jwks.test.ts [2m([22m[2m10 tests[22m[2m)[22m[33m 471[2mms[22m[39m
 [32m✓[39m src/jobs/invoiceDueDateWorker.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m src/services/notifications/service.test.ts [2m([22m[2m19 tests[22m[2m)[22m[33m 382[2mms[22m[39m
 [32m✓[39m src/middleware/__tests__/idempotency.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 265[2mms[22m[39m
 [32m✓[39m src/db/repositories/settlementsRepository.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 275[2mms[22m[39m
 [32m✓[39m src/jobs/scheduler.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 253[2mms[22m[39m
[90mstdout[2m | src/services/webhooks/service.test.ts
[22m[39m◇ injected env (0) from .env // tip: ◈ secrets for agents [www.dotenvx.com]

[90mstdout[2m | src/services/webhooks/service.test.ts[2m > [22m[2mWebhookService[2m > [22m[2mpasses delivery options to webhook delivery
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:43.395Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/2 delayMs=10 webhookId=wh_1 error=HTTP 500"}
{"level":"INFO","timestamp":"2026-05-26T16:32:43.395Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/2 delayMs=10 webhookId=wh_2 error=HTTP 500"}

 [32m✓[39m src/services/webhooks/service.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 225[2mms[22m[39m
 [32m✓[39m src/jobs/distributedLock.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 214[2mms[22m[39m
[90mstdout[2m | src/services/webhooks/__tests__/rotation.test.ts
[22m[39m◇ injected env (0) from .env // tip: ⌘ enable debugging { debug: true }

 [32m✓[39m src/services/webhooks/__tests__/rotation.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 131[2mms[22m[39m
 [32m✓[39m src/jobs/scoreSnapshot.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 92[2mms[22m[39m
 [32m✓[39m src/jobs/exportWorker.stress.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 84[2mms[22m[39m
 [32m✓[39m src/__tests__/envelopeContract.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 93[2mms[22m[39m
 [32m✓[39m src/__tests__/identityService.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 76[2mms[22m[39m
 [32m✓[39m src/__tests__/validationContract.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 48[2mms[22m[39m
 [32m✓[39m src/routes/health.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 44[2mms[22m[39m
 [32m✓[39m src/routes/bond.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 66[2mms[22m[39m
 [32m✓[39m src/__tests__/attestations.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/services/bond/paymentStatus.test.ts [2m([22m[2m34 tests[22m[2m)[22m[32m 41[2mms[22m[39m
[90mstdout[2m | src/routes/auditLog.test.ts
[22m[39m◇ injected env (0) from .env // tip: ⌁ auth for agents [www.vestauth.com]

 [32m✓[39m src/routes/auditLog.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 41[2mms[22m[39m
 [32m✓[39m src/services/rbac/policyEngine.test.ts [2m([22m[2m28 tests[22m[2m)[22m[32m 34[2mms[22m[39m
 [32m✓[39m src/__tests__/compression.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 38[2mms[22m[39m
 [32m✓[39m src/middleware/webhookSignature.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 32[2mms[22m[39m
 [32m✓[39m src/__tests__/slashEvents.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/services/analytics/service.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
[90mstdout[2m | src/db/repositories/auditLogsRepository.test.ts
[22m[39m◇ injected env (0) from .env // tip: ⌘ multiple files { path: ['.env.local', '.env'] }

 [32m✓[39m src/db/repositories/auditLogsRepository.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 24[2mms[22m[39m
 [32m✓[39m src/__tests__/sdk.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/listeners/__tests__/messageValidator.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 25[2mms[22m[39m
[90mstdout[2m | src/config/__tests__/config.test.ts
[22m[39m◇ injected env (0) from .env // tip: ◈ secrets for agents [www.dotenvx.com]

 [32m✓[39m src/config/__tests__/config.test.ts [2m([22m[2m29 tests[22m[2m)[22m[32m 25[2mms[22m[39m
 [32m✓[39m src/services/payment/orchestrator.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 21[2mms[22m[39m
[90mstdout[2m | src/services/webhooks/delivery.test.ts[2m > [22m[2mdeliverWebhook[2m > [22m[2mretries on 5xx errors with exponential backoff
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:49.836Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/4 delayMs=1000 webhookId=wh_123 error=HTTP 500"}

[90mstdout[2m | src/services/webhooks/delivery.test.ts[2m > [22m[2mdeliverWebhook[2m > [22m[2mretries on 5xx errors with exponential backoff
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:50.836Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=3/4 delayMs=2000 webhookId=wh_123 error=HTTP 503"}

[90mstdout[2m | src/services/webhooks/delivery.test.ts[2m > [22m[2mdeliverWebhook[2m > [22m[2mresolves retry policy from provider-specific overrides
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:49.839Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/2 delayMs=25 webhookId=wh_123 error=HTTP 500"}

[90mstdout[2m | src/services/webhooks/delivery.test.ts[2m > [22m[2mdeliverWebhook[2m > [22m[2mapplies jitter strategy to webhook retry backoff
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:49.840Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/2 delayMs=50 webhookId=wh_123 error=HTTP 500"}

[90mstdout[2m | src/services/webhooks/delivery.test.ts[2m > [22m[2mdeliverWebhook[2m > [22m[2mfails after max retries exhausted
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:49.842Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/3 delayMs=100 webhookId=wh_123 error=HTTP 500"}

[90mstdout[2m | src/services/webhooks/delivery.test.ts[2m > [22m[2mdeliverWebhook[2m > [22m[2mfails after max retries exhausted
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:49.942Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=3/3 delayMs=200 webhookId=wh_123 error=HTTP 500"}

[90mstdout[2m | src/services/webhooks/delivery.test.ts[2m > [22m[2mdeliverWebhook[2m > [22m[2mhandles network errors with retry
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:49.843Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/2 delayMs=100 webhookId=wh_123 error=Network error"}

 [32m✓[39m src/services/webhooks/delivery.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m src/lib/idempotencyGuard.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/jobs/analyticsRefreshWorker.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/services/governance/multisig.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m src/services/billing/feeEngine.test.ts [2m([22m[2m51 tests[22m[2m)[22m[32m 12[2mms[22m[39m
[90mstdout[2m | src/services/webhooks/dlq.test.ts
[22m[39m◇ injected env (0) from .env // tip: ⌘ custom filepath { path: '/custom/path/.env' }

[90mstdout[2m | src/services/webhooks/dlq.test.ts[2m > [22m[2mWebhookService DLQ integration[2m > [22m[2mpushes to DLQ after retry exhaustion
[22m[39m{"level":"INFO","timestamp":"2026-05-26T16:32:50.795Z","requestId":"N/A","correlationId":"N/A","route":"N/A","tenant":"N/A","actor":"N/A","message":"Retrying outbound request provider=webhook attempt=2/2 delayMs=10 webhookId=wh_test error=HTTP 500"}

 [32m✓[39m src/services/webhooks/dlq.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 22[2mms[22m[39m
 [32m✓[39m src/schemas/queue.test.ts [2m([22m[2m39 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/schemas/attestations.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 31[2mms[22m[39m
[90mstdout[2m | src/listeners/__tests__/horizonWithdrawalEvents.test.ts[2m > [22m[2mHorizonWithdrawalListener[2m > [22m[2mstart and stop[2m > [22m[2mstarts the listener
[22m[39mStarting Horizon withdrawal listener for https://horizon-testnet.stellar.org

[90mstdout[2m | src/listeners/__tests__/horizonWithdrawalEvents.test.ts[2m > [22m[2mHorizonWithdrawalListener[2m > [22m[2mstart and stop[2m > [22m[2mstarts the listener
[22m[39mStopped Horizon withdrawal listener

[90mstdout[2m | src/listeners/__tests__/horizonWithdrawalEvents.test.ts[2m > [22m[2mHorizonWithdrawalListener[2m > [22m[2mstart and stop[2m > [22m[2mstops the listener
[22m[39mStarting Horizon withdrawal listener for https://horizon-testnet.stellar.org

[90mstdout[2m | src/listeners/__tests__/horizonWithdrawalEvents.test.ts[2m > [22m[2mHorizonWithdrawalListener[2m > [22m[2mstart and stop[2m > [22m[2mstops the listener
[22m[39mStopped Horizon withdrawal listener

 [32m✓[39m src/listeners/__tests__/horizonWithdrawalEvents.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/clients/httpErrors.test.ts [2m([22m[2m56 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/services/governance/disputes.test.ts [2m([22m[2m35 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/migrations/006_add_hot_path_partial_indexes.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/jobs/exportWorker.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/services/reputation/score.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/services/reportService.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/services/governance/votes.test.ts [2m([22m[2m24 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/lib/decimalMath.test.ts [2m([22m[2m80 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m src/jobs/batchPayoutProcessor.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/migrations/002_add_composite_indexes.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/services/apiKeys.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/services/governance/slashingVotes.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/services/__tests__/attestationCacheService.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/__tests__/auth.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/jobs/dataRetentionJob.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/cache/__tests__/invalidation.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/listeners/identityStateSync.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/__tests__/migrations.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/services/governance/arbitration.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/services/__tests__/bondCacheService.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/__tests__/idempotentConsumer.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/services/settlementService.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/migrations/config.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 16[2mms[22m[39m
 [32m✓[39m src/services/replayService.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/lib/webhookVerifier.test.ts [2m([22m[2m27 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/listeners/horizon.listener.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/services/evidence/storage.spec.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m src/services/reputation/timeWeight.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/services/policy/__tests__/evaluator.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/services/governance/redisStorage.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/services/health/checks.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/jobs/scoreComputer.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/services/reputation/attestationScore.test.ts [2m([22m[2m28 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/listeners/webhookIntegration.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/__tests__/latencyMetrics.simple.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/services/bond/bondService.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/__tests__/horizonBondEvents.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/services/reputation/bondScore.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/schemas/address.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/schemas/bond.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/schemas/trust.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/lib/retryPolicy.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/__tests__/observability.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/__tests__/redaction.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m

[2m Test Files [22m [1m[32m84 passed[39m[22m[90m (84)[39m
[2m      Tests [22m [1m[32m1249 passed[39m[22m[90m (1249)[39m
[2m   Start at [22m 16:32:35
[2m   Duration [22m 23.45s[2m (transform 1.27s, setup 0ms, import 4.53s, tests 7.65s, environment 10ms)[22m (full suite): 84 files, 1249 tests passed

## Notes
- health response includes per-check status/reason/details only; no connection strings or internal stack traces are exposed