### PR TITLE
feat: idempotent settlements keyed on on-chain transaction hash

### DIFF
--- a/docs/DUPLICATE_SETTLEMENT_REMEDIATION.md
+++ b/docs/DUPLICATE_SETTLEMENT_REMEDIATION.md
@@ -1,32 +1,49 @@
 # Duplicate Settlement Remediation
 
-This document describes how to detect and clean up pre-existing duplicate
-settlement records before (or after) applying the
-`003_create_settlements` migration that adds the
-`UNIQUE (bond_id, transaction_hash)` constraint.
+This document describes settlement idempotency via transaction_hash uniqueness and how to
+detect and clean up pre-existing duplicate settlement records.
 
-## 1. Detect duplicates
+## Overview: Settlement Idempotency
 
-Run the following query to identify settlement rows that share the same
-`(bond_id, transaction_hash)` pair:
+Settlements are now idempotent on the on-chain `transaction_hash`. This means:
+
+- **Each on-chain transaction can produce at most one settlement record**, regardless of how many times
+  Horizon events are replayed or requests are retried
+- The unique constraint on `transaction_hash` ensures this globally across all bonds
+- Duplicate upsert attempts are automatically collapsed via `ON CONFLICT (transaction_hash)` semantics
+- A metric (`settlement_duplicates_detected_total`) tracks how often duplicates are collapsed
+
+### Example Scenario
+
+1. Horizon withdrawal event for transaction `0xabc123def` triggers settlement creation for Bond A
+2. Same event is replayed or request is retried → upsert attempt with same `transaction_hash`
+3. Database ON CONFLICT clause automatically updates the existing record (or leaves it unchanged)
+4. No new row is created
+5. Metric is incremented to signal the duplicate was detected and handled
+
+## 1. Detect pre-existing duplicates
+
+**Before applying migration 006**, run this query to identify settlement rows that share the same
+`transaction_hash` (across any bonds):
 
 ```sql
-SELECT bond_id,
-       transaction_hash,
-       COUNT(*)          AS duplicate_count,
-       ARRAY_AGG(id ORDER BY created_at ASC) AS ids
+SELECT transaction_hash,
+       COUNT(*)               AS duplicate_count,
+       ARRAY_AGG(id ORDER BY created_at ASC) AS ids,
+       ARRAY_AGG(bond_id ORDER BY created_at ASC) AS bond_ids
   FROM settlements
- GROUP BY bond_id, transaction_hash
+ GROUP BY transaction_hash
 HAVING COUNT(*) > 1
  ORDER BY duplicate_count DESC;
 ```
 
-If this query returns zero rows, no remediation is necessary.
+If this query returns zero rows, no remediation is necessary and you can proceed directly to
+applying migration 006.
 
 ## 2. Remove duplicates (keep earliest)
 
-For each duplicate group, keep the row with the smallest `created_at`
-(first ingested) and delete the rest:
+For each duplicate group, keep the row with the smallest `created_at` (first ingested) and delete
+the rest:
 
 ```sql
 DELETE FROM settlements
@@ -35,7 +52,7 @@ DELETE FROM settlements
      FROM (
        SELECT id,
               ROW_NUMBER() OVER (
-                PARTITION BY bond_id, transaction_hash
+                PARTITION BY transaction_hash
                 ORDER BY created_at ASC
               ) AS rn
          FROM settlements
@@ -44,8 +61,7 @@ DELETE FROM settlements
  );
 ```
 
-**Run this inside a transaction** so you can verify the affected row
-count before committing:
+**Run this inside a transaction** so you can verify the affected row count before committing:
 
 ```sql
 BEGIN;
@@ -58,7 +74,7 @@ SELECT COUNT(*) AS rows_to_delete
      FROM (
        SELECT id,
               ROW_NUMBER() OVER (
-                PARTITION BY bond_id, transaction_hash
+                PARTITION BY transaction_hash
                 ORDER BY created_at ASC
               ) AS rn
          FROM settlements
@@ -73,7 +89,7 @@ DELETE FROM settlements
      FROM (
        SELECT id,
               ROW_NUMBER() OVER (
-                PARTITION BY bond_id, transaction_hash
+                PARTITION BY transaction_hash
                 ORDER BY created_at ASC
               ) AS rn
          FROM settlements
@@ -86,8 +102,7 @@ COMMIT;
 
 ## 3. Apply the migration
 
-After removing duplicates, apply the migration that adds the unique
-constraint:
+After removing duplicates, apply the migration that adds the unique constraint on `transaction_hash`:
 
 ```bash
 npm run migrate:dev
@@ -96,8 +111,57 @@ npm run migrate:dev
 Or apply the raw SQL migration directly:
 
 ```bash
-psql "$DATABASE_URL" -f src/migration/003_create_settlements.sql
+psql "$DATABASE_URL" -f src/migrations/006_settlement_tx_idempotency.ts
 ```
+
+## 4. Monitoring duplicate detection
+
+Once deployed, monitor the `settlement_duplicates_detected_total` Prometheus metric to track:
+- How often replayed Horizon events are detected
+- How often client retries result in idempotent handling
+
+Query in Grafana or directly from Prometheus:
+
+```promql
+rate(settlement_duplicates_detected_total[1m])  # duplicates per minute
+increase(settlement_duplicates_detected_total[1h])  # duplicates in last hour
+```
+
+## Post-Migration Validation
+
+After applying migration 006, verify the constraint is in place:
+
+```sql
+SELECT constraint_name, constraint_type
+  FROM information_schema.table_constraints
+ WHERE table_name = 'settlements'
+   AND constraint_type = 'UNIQUE';
+```
+
+You should see:
+- `settlements_transaction_hash_unique` (new, on `transaction_hash`)
+
+The old `settlements_bond_tx_unique` constraint (on `bond_id, transaction_hash`) should no longer appear.
+
+## Security Considerations
+
+### Conflict Semantics
+
+The `ON CONFLICT (transaction_hash) DO UPDATE` clause:
+- **Updates** `amount`, `status`, `settled_at` from the new insert attempt
+- **Leaves unchanged** `bond_id` (preserves the bond from the first insert)
+- **Updates** `updated_at` timestamp
+
+This is intentional: a replayed event or retried request should not change which bond owns the settlement.
+However, the status and amount may reflect a corrected or more recent state.
+
+### Terminal Status Guard
+
+If you require that a "settled" status cannot be overwritten by a "pending" status:
+- Consider adding a `CASE` statement in the `ON CONFLICT DO UPDATE` clause
+- Example: `status = CASE WHEN existing.status = 'settled' THEN existing.status ELSE EXCLUDED.status END`
+
+Consult [VALIDATION.md](./VALIDATION.md) for settlement-specific validation rules.
 
 ## 4. Verify
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -592,7 +591,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -605,7 +603,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1846,7 +1843,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2132,7 +2128,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2829,7 +2824,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3013,7 +3007,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3494,7 +3487,6 @@
       "integrity": "sha512-lOt/VDh+sihAx3OUxCE5CC0qZfAhIzE3Dxw75NJ3P0C6ruUgT9b/jZKECE1ctpbxSVic9OkLdXz5UEX39ks4Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3520,7 +3512,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -3700,7 +3691,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4434,7 +4424,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5525,7 +5514,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6907,7 +6895,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8779,7 +8766,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10742,7 +10728,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10851,7 +10836,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11042,7 +11026,6 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11121,7 +11104,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",

--- a/src/db/repositories/settlementsRepository.test.ts
+++ b/src/db/repositories/settlementsRepository.test.ts
@@ -63,7 +63,7 @@ async function buildTestDb(): Promise<{ db: IMemoryDb; pool: Pool; proxiedPool: 
                                      CHECK (status IN ('pending', 'settled', 'failed')),
       created_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
       updated_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
-      CONSTRAINT settlements_bond_tx_unique UNIQUE (bond_id, transaction_hash)
+      CONSTRAINT settlements_transaction_hash_unique UNIQUE (transaction_hash)
     );
   `)
 
@@ -350,6 +350,118 @@ describe('SettlementsRepository', () => {
     it('returns false for a non-existent id', async () => {
       const deleted = await repo.delete(999999)
       expect(deleted).toBe(false)
+    })
+  })
+
+  describe('transaction_hash uniqueness (global idempotency)', () => {
+    it('prevents inserting settlement with same transaction_hash for different bonds', async () => {
+      // Create settlement for first bond
+      await repo.upsert({
+        bondId: bondId as unknown as number,
+        amount: '100',
+        transactionHash: 'tx_global_unique_001',
+        status: 'pending',
+      })
+
+      // Attempting to create settlement with same transaction_hash for different bond
+      // should update the existing one, not create a new one
+      const result = await repo.upsert({
+        bondId: unusedBondId as unknown as number,
+        amount: '200',
+        transactionHash: 'tx_global_unique_001',
+        status: 'settled',
+      })
+
+      // The existing settlement should be returned (updated)
+      expect(result.isDuplicate).toBe(true)
+      // The bondId should remain the original one (first insert)
+      expect(result.settlement.bondId).toBe(String(bondId))
+      expect(String(result.settlement.amount)).toBe('200') // amount was updated
+      expect(result.settlement.status).toBe('settled') // status was updated
+    })
+
+    it('produces only one row across all bonds for the same transaction_hash', async () => {
+      // Insert for first bond
+      const first = await repo.upsert({
+        bondId: bondId as unknown as number,
+        amount: '100',
+        transactionHash: 'tx_one_row_001',
+      })
+
+      // Insert for second bond with same transaction_hash
+      const second = await repo.upsert({
+        bondId: unusedBondId as unknown as number,
+        amount: '100',
+        transactionHash: 'tx_one_row_001',
+      })
+
+      // Both should return the same settlement ID
+      expect(first.settlement.id).toBe(second.settlement.id)
+      expect(second.isDuplicate).toBe(true)
+
+      // Verify only one row exists with this transaction_hash
+      const found = await repo.findByTransactionHash('tx_one_row_001')
+      expect(found).not.toBeNull()
+      expect(found!.transactionHash).toBe('tx_one_row_001')
+
+      // Verify bondId stayed with the first insert
+      expect(found!.bondId).toBe(String(bondId))
+    })
+
+    it('handles rapid concurrent inserts with same transaction_hash across different bonds', async () => {
+      const input1 = {
+        bondId: bondId as unknown as number,
+        amount: '100',
+        transactionHash: 'tx_concurrent_global_001',
+      }
+
+      const input2 = {
+        bondId: unusedBondId as unknown as number,
+        amount: '200',
+        transactionHash: 'tx_concurrent_global_001',
+      }
+
+      const results = await Promise.all([
+        repo.upsert(input1),
+        repo.upsert(input2),
+        repo.upsert(input1),
+        repo.upsert(input2),
+      ])
+
+      // All should return the same ID
+      const ids = new Set(results.map((r) => r.settlement.id))
+      expect(ids.size).toBe(1)
+
+      // Verify only one row exists
+      const count = await repo.countByBondId(bondId as unknown as number)
+      const count2 = await repo.countByBondId(unusedBondId as unknown as number)
+      expect(count + count2).toBe(1)
+    })
+
+    it('correctly marks duplicates across bonds', async () => {
+      // First insert
+      const first = await repo.upsert({
+        bondId: bondId as unknown as number,
+        amount: '100',
+        transactionHash: 'tx_dup_mark_001',
+      })
+      expect(first.isDuplicate).toBe(false)
+
+      // Second insert - different bond, same transaction_hash
+      const second = await repo.upsert({
+        bondId: unusedBondId as unknown as number,
+        amount: '100',
+        transactionHash: 'tx_dup_mark_001',
+      })
+      expect(second.isDuplicate).toBe(true)
+
+      // Third insert - first bond again, same transaction_hash
+      const third = await repo.upsert({
+        bondId: bondId as unknown as number,
+        amount: '100',
+        transactionHash: 'tx_dup_mark_001',
+      })
+      expect(third.isDuplicate).toBe(true)
     })
   })
 })

--- a/src/db/repositories/settlementsRepository.ts
+++ b/src/db/repositories/settlementsRepository.ts
@@ -63,7 +63,7 @@ export class SettlementsRepository {
       `
       INSERT INTO settlements (bond_id, amount, transaction_hash, settled_at, status)
       VALUES ($1, $2, $3, $4, $5)
-      ON CONFLICT (bond_id, transaction_hash)
+      ON CONFLICT (transaction_hash)
       DO UPDATE SET
         amount     = EXCLUDED.amount,
         status     = EXCLUDED.status,

--- a/src/middleware/metrics.ts
+++ b/src/middleware/metrics.ts
@@ -142,6 +142,16 @@ export const idempotencyDuplicatesDetected = new client.Counter({
 })
 
 // ============================================================================
+// Settlement Metrics
+// ============================================================================
+
+export const settlementDuplicatesDetected = new client.Counter({
+  name: 'settlement_duplicates_detected_total',
+  help: 'Total number of settlement duplicates detected and collapsed via transaction_hash idempotency',
+  registers: [register]
+})
+
+// ============================================================================
 // Middleware
 // ============================================================================
 
@@ -287,4 +297,21 @@ export function recordIdentitySync(
  */
 export function recordStaleCacheRead(namespace: string) {
   staleCacheReadsTotal.inc({ namespace })
+}
+
+/**
+ * Record settlement duplicate detection via transaction_hash idempotency
+ * 
+ * Usage:
+ * ```typescript
+ * import { recordSettlementDuplicate } from './middleware/metrics.js'
+ * 
+ * const result = await settlementService.upsertSettlementStatus(input)
+ * if (result.isDuplicate) {
+ *   recordSettlementDuplicate()
+ * }
+ * ```
+ */
+export function recordSettlementDuplicate() {
+  settlementDuplicatesDetected.inc()
 }

--- a/src/migrations/006_settlement_tx_idempotency.ts
+++ b/src/migrations/006_settlement_tx_idempotency.ts
@@ -1,0 +1,44 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export const shorthands = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  /**
+   * Drop the composite unique constraint on (bond_id, transaction_hash)
+   * and replace it with a unique constraint on transaction_hash alone.
+   * This ensures idempotency across all settlements for the same on-chain
+   * transaction, preventing duplicates even if Horizon events are replayed
+   * or requests are retried.
+   */
+  pgm.dropConstraint('settlements', 'settlements_bond_tx_unique')
+
+  // Add unique constraint on transaction_hash alone
+  pgm.addConstraint('settlements', 'settlements_transaction_hash_unique', {
+    unique: ['transaction_hash'],
+  })
+
+  /**
+   * Keep the composite index (bond_id, transaction_hash) for efficient
+   * queries filtering settlements by bond_id.
+   */
+  pgm.createIndex('settlements', ['bond_id', 'transaction_hash'], {
+    name: 'idx_settlements_bond_tx',
+    ifNotExists: true,
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Drop the transaction_hash unique constraint
+  pgm.dropConstraint('settlements', 'settlements_transaction_hash_unique')
+
+  // Drop the composite index
+  pgm.dropIndex('settlements', ['bond_id', 'transaction_hash'], {
+    name: 'idx_settlements_bond_tx',
+    ifNotExists: true,
+  })
+
+  // Restore the original composite unique constraint
+  pgm.addConstraint('settlements', 'settlements_bond_tx_unique', {
+    unique: ['bond_id', 'transaction_hash'],
+  })
+}

--- a/src/services/settlementService.test.ts
+++ b/src/services/settlementService.test.ts
@@ -14,7 +14,8 @@ vi.mock('../cache/redis.js', () => ({
 }))
 
 vi.mock('../middleware/metrics.js', () => ({
-  recordStaleCacheRead: vi.fn()
+  recordStaleCacheRead: vi.fn(),
+  recordSettlementDuplicate: vi.fn()
 }))
 
 describe('SettlementService', () => {
@@ -79,6 +80,51 @@ describe('SettlementService', () => {
   })
 
   describe('upsertSettlementStatus', () => {
+    it('should record settlement duplicate metric when isDuplicate is true', async () => {
+      const input: CreateSettlementInput = {
+        bondId: 100,
+        amount: '500',
+        transactionHash: '0x123abc',
+        status: 'settled'
+      }
+      
+      const updatedSettlement = { ...mockSettlement, status: 'settled' }
+      mockSettlementsRepository.upsert.mockResolvedValue({ 
+        settlement: updatedSettlement, 
+        isDuplicate: true 
+      })
+      
+      vi.mocked(cache.get).mockResolvedValue(null)
+
+      const result = await settlementService.upsertSettlementStatus(input)
+
+      expect(mockSettlementsRepository.upsert).toHaveBeenCalledWith(input)
+      expect(metrics.recordSettlementDuplicate).toHaveBeenCalled()
+      expect(result).toEqual(updatedSettlement)
+    })
+
+    it('should not record settlement duplicate metric when isDuplicate is false', async () => {
+      const input: CreateSettlementInput = {
+        bondId: 100,
+        amount: '500',
+        transactionHash: '0x123abc',
+        status: 'pending'
+      }
+      
+      mockSettlementsRepository.upsert.mockResolvedValue({ 
+        settlement: mockSettlement, 
+        isDuplicate: false 
+      })
+      
+      vi.mocked(cache.get).mockResolvedValue(null)
+
+      const result = await settlementService.upsertSettlementStatus(input)
+
+      expect(mockSettlementsRepository.upsert).toHaveBeenCalledWith(input)
+      expect(metrics.recordSettlementDuplicate).not.toHaveBeenCalled()
+      expect(result).toEqual(mockSettlement)
+    })
+
     it('should invalidate cache post-commit and not trigger stale read metric if cache deletes successfully', async () => {
       const input: CreateSettlementInput = {
         bondId: 100,
@@ -88,7 +134,10 @@ describe('SettlementService', () => {
       }
       
       const updatedSettlement = { ...mockSettlement, status: 'settled' }
-      mockSettlementsRepository.upsert.mockResolvedValue({ settlement: updatedSettlement })
+      mockSettlementsRepository.upsert.mockResolvedValue({ 
+        settlement: updatedSettlement,
+        isDuplicate: false 
+      })
       
       // Simulate cache deleting successfully (subsequent get returns null)
       vi.mocked(cache.get).mockResolvedValue(null)
@@ -111,7 +160,10 @@ describe('SettlementService', () => {
       }
       
       const updatedSettlement = { ...mockSettlement, status: 'settled' }
-      mockSettlementsRepository.upsert.mockResolvedValue({ settlement: updatedSettlement })
+      mockSettlementsRepository.upsert.mockResolvedValue({ 
+        settlement: updatedSettlement,
+        isDuplicate: false 
+      })
       
       // Simulate cache race condition where it still holds the old data
       const staleCachedData = { ...updatedSettlement, status: 'pending' }

--- a/src/services/settlementService.ts
+++ b/src/services/settlementService.ts
@@ -1,6 +1,7 @@
 import { SettlementsRepository, Settlement, CreateSettlementInput } from '../db/repositories/settlementsRepository.js'
 import { cache } from '../cache/redis.js'
 import { invalidateCache } from '../cache/invalidation.js'
+import { recordSettlementDuplicate } from '../middleware/metrics.js'
 
 export class SettlementService {
   constructor(private readonly repository: SettlementsRepository) {}
@@ -33,10 +34,16 @@ export class SettlementService {
 
   /**
    * Upserts the settlement (status mutation).
+   * Records duplicate detection metric when settlement is idempotent on transaction_hash.
    * Cache invalidation hook is executed post-commit (after DB update).
    */
   async upsertSettlementStatus(input: CreateSettlementInput): Promise<Settlement> {
-    const { settlement } = await this.repository.upsert(input)
+    const { settlement, isDuplicate } = await this.repository.upsert(input)
+    
+    // Record metric when duplicate settlement is detected and collapsed via transaction_hash idempotency
+    if (isDuplicate) {
+      recordSettlementDuplicate()
+    }
     
     // Post-commit hook: invalidate the cache immediately after status mutation with verification
     await invalidateCache(


### PR DESCRIPTION
**Problem**
Settlement records were vulnerable to duplicates when Horizon withdrawal events were replayed (network retries, service restarts) or client requests were retried. The prior unique constraint `(bond_id, transaction_hash)` allowed multiple settlements for the same transaction across different bonds, causing double-counting and reconciliation issues.

**Solution**
Settlements are now globally idempotent on `transaction_hash` alone:
- Each on-chain transaction can produce at most one settlement record.
- Duplicate attempts are collapsed at the DB level via `ON CONFLICT (transaction_hash)`.
- A Prometheus metric tracks duplicate collapses.

**Changes**
**1. Database Migration**
- Added migration `src/migrations/006_settlement_tx_idempotency.ts`
- Dropped composite unique constraint on `(bond_id, transaction_hash)`
- Added unique constraint on `transaction_hash`
- Kept composite index `(bond_id, transaction_hash)` for query performance

**2. Settlement Repository**
- `upsert()` now uses `ON CONFLICT (transaction_hash)`
- Preserves `bond_id` from first insert, updates `amount`, `status`, `settled_at`, `updated_at`
- Returns `isDuplicate: true` when a conflict is collapsed

**3. Settlement Service**
- Records `settlement_duplicates_detected_total` when `isDuplicate === true`
- Continues to invalidate cache post-upsert

**4. Metrics**
- Added `settlement_duplicates_detected_total` counter
- Added `recordSettlementDuplicate()` helper

**5. Tests**
- Added and updated tests covering:
  - Cross-bond duplicate prevention
  - Concurrent inserts with same `transaction_hash`
  - Duplicate detection and marking
  - Global uniqueness enforcement

**6. Documentation**
- Updated `docs/DUPLICATE_SETTLEMENT_REMEDIATION.md` with:
  - New idempotency semantics
  - Pre-migration duplicate detection queries
  - Remediation steps (keep earliest, delete rest)
  - Post-migration validation
  - Monitoring guidance for the new metric
  - Conflict semantics and security considerations

**Edge Cases Covered**
- Same `transaction_hash`, different bonds → single record, original `bond_id` preserved
- Concurrent inserts → database ensures exactly one row
- Horizon event replays and client retries → idempotent handling
- Status and amount updates on conflict while preserving original bond ownership

**Migration Path**
1. Detect pre-existing duplicates using the provided query in `docs/DUPLICATE_SETTLEMENT_REMEDIATION.md`.
2. Optionally remediate duplicates (keep earliest, delete rest).
3. Apply migration `006`.
4. Validate constraint and monitor `settlement_duplicates_detected_total`.

**Checklist**
- [x] Tests updated and passing
- [x] Migration added and documented
- [x] Metrics instrumentation added
- [x] Documentation updated
- [x] Edge cases covered

### Closes #341 