### PR TITLE
feat: externalize reputation scoring weights into versioned config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,3 +99,19 @@ ANALYTICS_STALENESS_SECONDS=300
 # ── Compression ──────────────────────────────────────────────────────────────
 # Minimum response size (in bytes) to trigger compression. Default: 1024 (1 KB).
 COMPRESSION_THRESHOLD=1024
+
+# ── Reputation Scoring Model ─────────────────────────────────────────────────
+# Version identifier for the scoring model (recorded in score snapshots)
+REPUTATION_MODEL_VERSION=1.0.0
+# Maximum points for bond amount component (default: 50, achieved at ≥ 1 ETH)
+REPUTATION_BOND_SCORE_MAX=50
+# Maximum points for bond duration component (default: 20, achieved at ≥ 365 days)
+REPUTATION_DURATION_SCORE_MAX=20
+# Maximum points for attestation component (default: 30, achieved at ≥ 5 attestations)
+REPUTATION_ATTESTATION_SCORE_MAX=30
+# 1 ETH in wei (default: 1000000000000000000)
+REPUTATION_ONE_ETH_WEI=1000000000000000000
+# Maximum duration in days for full duration score (default: 365)
+REPUTATION_MAX_DURATION_DAYS=365
+# Maximum attestation count for full attestation score (default: 5)
+REPUTATION_MAX_ATTESTATION_COUNT=5

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -159,6 +159,45 @@ export const envSchema = z.object({
     .string()
     .default('true')
     .transform((val: string) => val === 'true'),
+
+  // Reputation scoring model
+  REPUTATION_MODEL_VERSION: z.string().default('1.0.0'),
+  REPUTATION_BOND_SCORE_MAX: z
+    .string()
+    .default('50')
+    .transform(Number)
+    .pipe(z.number().min(0).max(100)),
+  REPUTATION_DURATION_SCORE_MAX: z
+    .string()
+    .default('20')
+    .transform(Number)
+    .pipe(z.number().min(0).max(100)),
+  REPUTATION_ATTESTATION_SCORE_MAX: z
+    .string()
+    .default('30')
+    .transform(Number)
+    .pipe(z.number().min(0).max(100)),
+  REPUTATION_ONE_ETH_WEI: z
+    .string()
+    .default('1000000000000000000')
+    .refine((val) => {
+      try {
+        BigInt(val)
+        return true
+      } catch {
+        return false
+      }
+    }, { message: 'REPUTATION_ONE_ETH_WEI must be a valid BigInt string' }),
+  REPUTATION_MAX_DURATION_DAYS: z
+    .string()
+    .default('365')
+    .transform(Number)
+    .pipe(z.number().int().min(1)),
+  REPUTATION_MAX_ATTESTATION_COUNT: z
+    .string()
+    .default('5')
+    .transform(Number)
+    .pipe(z.number().int().min(1)),
 })
 
 export type Env = z.infer<typeof envSchema>
@@ -224,6 +263,15 @@ export interface Config {
     maxPro: number
     maxEnterprise: number
     failOpen: boolean
+  }
+  reputation: {
+    scoringModelVersion: string
+    bondScoreMax: number
+    durationScoreMax: number
+    attestationScoreMax: number
+    oneEthWei: bigint
+    maxDurationDays: number
+    maxAttestationCount: number
   }
 }
 
@@ -344,6 +392,15 @@ function mapEnvToConfig(env: Env): Config {
       maxPro: env.RATE_LIMIT_MAX_PRO,
       maxEnterprise: env.RATE_LIMIT_MAX_ENTERPRISE,
       failOpen: env.RATE_LIMIT_FAIL_OPEN,
+    },
+    reputation: {
+      scoringModelVersion: env.REPUTATION_MODEL_VERSION,
+      bondScoreMax: env.REPUTATION_BOND_SCORE_MAX,
+      durationScoreMax: env.REPUTATION_DURATION_SCORE_MAX,
+      attestationScoreMax: env.REPUTATION_ATTESTATION_SCORE_MAX,
+      oneEthWei: BigInt(env.REPUTATION_ONE_ETH_WEI),
+      maxDurationDays: env.REPUTATION_MAX_DURATION_DAYS,
+      maxAttestationCount: env.REPUTATION_MAX_ATTESTATION_COUNT,
     },
   }
 

--- a/src/config/reputation.test.ts
+++ b/src/config/reputation.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for reputation scoring configuration
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { validateConfig, ConfigValidationError } from './index.js'
+
+describe('Reputation Config', () => {
+  let baseEnv: Record<string, string>
+
+  beforeEach(() => {
+    baseEnv = {
+      PORT: '3000',
+      NODE_ENV: 'test',
+      DB_URL: 'postgresql://test:test@localhost:5432/test',
+      REDIS_URL: 'redis://localhost:6379',
+      JWT_SECRET: 'test-secret-at-least-32-characters-long',
+    }
+  })
+
+  describe('default values', () => {
+    it('should use default reputation config when not provided', () => {
+      const config = validateConfig(baseEnv)
+
+      expect(config.reputation.scoringModelVersion).toBe('1.0.0')
+      expect(config.reputation.bondScoreMax).toBe(50)
+      expect(config.reputation.durationScoreMax).toBe(20)
+      expect(config.reputation.attestationScoreMax).toBe(30)
+      expect(config.reputation.oneEthWei).toBe(BigInt('1000000000000000000'))
+      expect(config.reputation.maxDurationDays).toBe(365)
+      expect(config.reputation.maxAttestationCount).toBe(5)
+    })
+
+    it('should ensure total max score equals 100 with defaults', () => {
+      const config = validateConfig(baseEnv)
+      const total =
+        config.reputation.bondScoreMax +
+        config.reputation.durationScoreMax +
+        config.reputation.attestationScoreMax
+
+      expect(total).toBe(100)
+    })
+  })
+
+  describe('custom values', () => {
+    it('should accept custom reputation config', () => {
+      const config = validateConfig({
+        ...baseEnv,
+        REPUTATION_MODEL_VERSION: '2.0.0',
+        REPUTATION_BOND_SCORE_MAX: '60',
+        REPUTATION_DURATION_SCORE_MAX: '25',
+        REPUTATION_ATTESTATION_SCORE_MAX: '15',
+        REPUTATION_ONE_ETH_WEI: '2000000000000000000',
+        REPUTATION_MAX_DURATION_DAYS: '180',
+        REPUTATION_MAX_ATTESTATION_COUNT: '10',
+      })
+
+      expect(config.reputation.scoringModelVersion).toBe('2.0.0')
+      expect(config.reputation.bondScoreMax).toBe(60)
+      expect(config.reputation.durationScoreMax).toBe(25)
+      expect(config.reputation.attestationScoreMax).toBe(15)
+      expect(config.reputation.oneEthWei).toBe(BigInt('2000000000000000000'))
+      expect(config.reputation.maxDurationDays).toBe(180)
+      expect(config.reputation.maxAttestationCount).toBe(10)
+    })
+
+    it('should allow zero values for score components', () => {
+      const config = validateConfig({
+        ...baseEnv,
+        REPUTATION_BOND_SCORE_MAX: '0',
+        REPUTATION_DURATION_SCORE_MAX: '0',
+        REPUTATION_ATTESTATION_SCORE_MAX: '100',
+      })
+
+      expect(config.reputation.bondScoreMax).toBe(0)
+      expect(config.reputation.durationScoreMax).toBe(0)
+      expect(config.reputation.attestationScoreMax).toBe(100)
+    })
+
+    it('should allow custom model versions', () => {
+      const config = validateConfig({
+        ...baseEnv,
+        REPUTATION_MODEL_VERSION: 'v3.1.4-beta',
+      })
+
+      expect(config.reputation.scoringModelVersion).toBe('v3.1.4-beta')
+    })
+  })
+
+  describe('validation', () => {
+    it('should reject negative bond score max', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_BOND_SCORE_MAX: '-10',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject bond score max > 100', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_BOND_SCORE_MAX: '101',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject negative duration score max', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_DURATION_SCORE_MAX: '-5',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject duration score max > 100', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_DURATION_SCORE_MAX: '150',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject negative attestation score max', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_ATTESTATION_SCORE_MAX: '-20',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject attestation score max > 100', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_ATTESTATION_SCORE_MAX: '200',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject invalid BigInt for ONE_ETH_WEI', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_ONE_ETH_WEI: 'not-a-number',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject zero max duration days', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_MAX_DURATION_DAYS: '0',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject negative max duration days', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_MAX_DURATION_DAYS: '-365',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject zero max attestation count', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_MAX_ATTESTATION_COUNT: '0',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject negative max attestation count', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_MAX_ATTESTATION_COUNT: '-5',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject fractional max duration days', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_MAX_DURATION_DAYS: '365.5',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+
+    it('should reject fractional max attestation count', () => {
+      expect(() =>
+        validateConfig({
+          ...baseEnv,
+          REPUTATION_MAX_ATTESTATION_COUNT: '5.5',
+        })
+      ).toThrow(ConfigValidationError)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle very large ONE_ETH_WEI values', () => {
+      const config = validateConfig({
+        ...baseEnv,
+        REPUTATION_ONE_ETH_WEI: '999999999999999999999999',
+      })
+
+      expect(config.reputation.oneEthWei).toBe(BigInt('999999999999999999999999'))
+    })
+
+    it('should handle very small ONE_ETH_WEI values', () => {
+      const config = validateConfig({
+        ...baseEnv,
+        REPUTATION_ONE_ETH_WEI: '1',
+      })
+
+      expect(config.reputation.oneEthWei).toBe(BigInt('1'))
+    })
+
+    it('should handle very large max duration days', () => {
+      const config = validateConfig({
+        ...baseEnv,
+        REPUTATION_MAX_DURATION_DAYS: '10000',
+      })
+
+      expect(config.reputation.maxDurationDays).toBe(10000)
+    })
+
+    it('should handle very large max attestation count', () => {
+      const config = validateConfig({
+        ...baseEnv,
+        REPUTATION_MAX_ATTESTATION_COUNT: '1000',
+      })
+
+      expect(config.reputation.maxAttestationCount).toBe(1000)
+    })
+  })
+
+  describe('regression - preserve current behavior', () => {
+    it('should match original hardcoded constants with defaults', () => {
+      const config = validateConfig(baseEnv)
+
+      // Original constants from reputationService.ts
+      const ORIGINAL_BOND_SCORE_MAX = 50
+      const ORIGINAL_DURATION_SCORE_MAX = 20
+      const ORIGINAL_ATTESTATION_SCORE_MAX = 30
+      const ORIGINAL_ONE_ETH_WEI = BigInt('1000000000000000000')
+      const ORIGINAL_MAX_DURATION_DAYS = 365
+      const ORIGINAL_MAX_ATTESTATION_COUNT = 5
+
+      expect(config.reputation.bondScoreMax).toBe(ORIGINAL_BOND_SCORE_MAX)
+      expect(config.reputation.durationScoreMax).toBe(ORIGINAL_DURATION_SCORE_MAX)
+      expect(config.reputation.attestationScoreMax).toBe(ORIGINAL_ATTESTATION_SCORE_MAX)
+      expect(config.reputation.oneEthWei).toBe(ORIGINAL_ONE_ETH_WEI)
+      expect(config.reputation.maxDurationDays).toBe(ORIGINAL_MAX_DURATION_DAYS)
+      expect(config.reputation.maxAttestationCount).toBe(ORIGINAL_MAX_ATTESTATION_COUNT)
+    })
+  })
+})

--- a/src/jobs/scoreSnapshot.ts
+++ b/src/jobs/scoreSnapshot.ts
@@ -6,6 +6,10 @@ import type {
   SnapshotJobResult,
   ScoreSnapshot,
 } from './types.js'
+import { loadConfig } from '../config/index.js'
+
+// Load config to get scoring model version
+const config = loadConfig()
 
 /**
  * Options for score snapshot job.
@@ -102,6 +106,7 @@ export class ScoreSnapshotJob {
                 bondedAmount: data.bondedAmount,
                 attestationCount: data.attestationCount,
                 timestamp: new Date().toISOString(),
+                scoringModelVersion: config.reputation.scoringModelVersion,
               }
 
               snapshots.push(snapshot)
@@ -136,6 +141,7 @@ export class ScoreSnapshotJob {
                 bondedAmount: data.bondedAmount,
                 attestationCount: data.attestationCount,
                 timestamp: new Date().toISOString(),
+                scoringModelVersion: config.reputation.scoringModelVersion,
               }
 
               snapshots.push(snapshot)

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -12,6 +12,8 @@ export interface ScoreSnapshot {
   attestationCount: number
   /** Timestamp when snapshot was taken (ISO string). */
   timestamp: string
+  /** Scoring model version used to compute this score. */
+  scoringModelVersion?: string
 }
 
 /**

--- a/src/services/reputation/README.md
+++ b/src/services/reputation/README.md
@@ -2,7 +2,51 @@
 
 ## Overview
 
-This module provides a comprehensive reputation scoring system based on bonded amounts, attestations, and time-weighted factors.
+This module provides a comprehensive reputation scoring system based on bonded amounts, attestations, and time-weighted factors. **All scoring weights and caps are externalized to configuration** and versioned via `REPUTATION_MODEL_VERSION` for audit trail and tuning flexibility.
+
+## Configuration
+
+Scoring parameters are configured via environment variables in `.env`:
+
+```bash
+# Scoring model version (recorded in snapshots for audit trail)
+REPUTATION_MODEL_VERSION=1.0.0
+
+# Maximum points for each component (must sum to ≤ 100)
+REPUTATION_BOND_SCORE_MAX=50
+REPUTATION_DURATION_SCORE_MAX=20
+REPUTATION_ATTESTATION_SCORE_MAX=30
+
+# Thresholds for maximum scores
+REPUTATION_ONE_ETH_WEI=1000000000000000000  # 1 ETH in wei
+REPUTATION_MAX_DURATION_DAYS=365             # Days for full duration score
+REPUTATION_MAX_ATTESTATION_COUNT=5           # Attestations for full score
+```
+
+### Configuration Validation
+
+- All score maxima are validated to be between 0 and 100
+- `REPUTATION_ONE_ETH_WEI` must be a valid BigInt string
+- Duration and attestation count must be positive integers
+- Invalid configuration will cause the application to fail at startup with a clear error message
+
+### Tuning the Model
+
+To adjust the trust model:
+
+1. Update the environment variables in `.env`
+2. Increment `REPUTATION_MODEL_VERSION` (e.g., `1.0.0` → `1.1.0`)
+3. Restart the application
+4. New scores will be computed with the updated weights
+5. Score snapshots will record the model version for audit trail
+
+**Example: Emphasize attestations over bond amount**
+```bash
+REPUTATION_MODEL_VERSION=1.1.0
+REPUTATION_BOND_SCORE_MAX=30
+REPUTATION_DURATION_SCORE_MAX=20
+REPUTATION_ATTESTATION_SCORE_MAX=50
+```
 
 ## Formula
 
@@ -12,20 +56,20 @@ totalScore = (bondScore + attestationScore) × timeWeight
 
 ### Components
 
-1. **Bond Score**: `min(bondedAmount × 0.01, 1000)`
+1. **Bond Score**: `min(bondedAmount × (bondScoreMax / oneEthWei), bondScoreMax)`
    - Based on the amount bonded by the user
-   - Capped at maximum of 1000
+   - Capped at configured maximum
    - Returns 0 if bond is slashed
 
-2. **Attestation Score**: `min(Σ(validAttestationWeights) × 0.1, 100)`
+2. **Attestation Score**: `min(Σ(validAttestationWeights) × 0.1, attestationScoreMax)`
    - Sum of all valid attestation weights
    - Multiplied by 0.1
-   - Capped at maximum of 100
+   - Capped at configured maximum
 
 3. **Time Weight**: `1 - e^(-0.5 × (duration/maxDuration) × 10)`
    - Exponential growth from 0 to 1
    - Based on bond duration
-   - Reaches 1.0 at 1 year (default max duration)
+   - Reaches 1.0 at configured max duration
 
 ## Usage
 

--- a/src/services/reputationService.test.ts
+++ b/src/services/reputationService.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for config-driven reputation service
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  computeBondScore,
+  computeDurationScore,
+  computeAttestationScore,
+  getScoringConfig,
+  type ScoringConfig,
+} from './reputationService.js'
+
+describe('reputationService with config', () => {
+  describe('getScoringConfig', () => {
+    it('should return current scoring configuration', () => {
+      const config = getScoringConfig()
+
+      expect(config).toHaveProperty('bondScoreMax')
+      expect(config).toHaveProperty('durationScoreMax')
+      expect(config).toHaveProperty('attestationScoreMax')
+      expect(config).toHaveProperty('oneEthWei')
+      expect(config).toHaveProperty('maxDurationDays')
+      expect(config).toHaveProperty('maxAttestationCount')
+      expect(config).toHaveProperty('scoringModelVersion')
+    })
+
+    it('should return a copy of the config', () => {
+      const config1 = getScoringConfig()
+      const config2 = getScoringConfig()
+
+      expect(config1).not.toBe(config2)
+      expect(config1).toEqual(config2)
+    })
+  })
+
+  describe('computeBondScore with default config', () => {
+    it('should compute score proportional to bonded amount', () => {
+      const halfEth = '500000000000000000' // 0.5 ETH
+      const score = computeBondScore(halfEth)
+
+      expect(score).toBe(25) // 50% of max (50)
+    })
+
+    it('should cap at bondScoreMax', () => {
+      const twoEth = '2000000000000000000' // 2 ETH
+      const score = computeBondScore(twoEth)
+
+      expect(score).toBe(50) // Capped at max
+    })
+
+    it('should return 0 for zero amount', () => {
+      expect(computeBondScore('0')).toBe(0)
+    })
+
+    it('should return 0 for invalid amount', () => {
+      expect(computeBondScore('invalid')).toBe(0)
+    })
+  })
+
+  describe('computeBondScore with custom config', () => {
+    const customConfig: ScoringConfig = {
+      bondScoreMax: 60,
+      durationScoreMax: 20,
+      attestationScoreMax: 20,
+      oneEthWei: BigInt('2000000000000000000'), // 2 ETH
+      maxDurationDays: 365,
+      maxAttestationCount: 5,
+      scoringModelVersion: '2.0.0',
+    }
+
+    it('should use custom bondScoreMax', () => {
+      const twoEth = '2000000000000000000'
+      const score = computeBondScore(twoEth, customConfig)
+
+      expect(score).toBe(60) // Custom max
+    })
+
+    it('should use custom oneEthWei threshold', () => {
+      const oneEth = '1000000000000000000' // 1 ETH
+      const score = computeBondScore(oneEth, customConfig)
+
+      expect(score).toBe(30) // 50% of 60 (since threshold is 2 ETH)
+    })
+  })
+
+  describe('computeDurationScore with default config', () => {
+    const now = Date.now()
+    const oneDay = 86_400_000
+
+    it('should compute score proportional to duration', () => {
+      const halfYear = new Date(now - 182.5 * oneDay).toISOString()
+      const score = computeDurationScore(halfYear, now)
+
+      expect(score).toBe(10) // ~50% of max (20)
+    })
+
+    it('should cap at durationScoreMax', () => {
+      const twoYears = new Date(now - 730 * oneDay).toISOString()
+      const score = computeDurationScore(twoYears, now)
+
+      expect(score).toBe(20) // Capped at max
+    })
+
+    it('should return 0 for null bondStart', () => {
+      expect(computeDurationScore(null, now)).toBe(0)
+    })
+
+    it('should return 0 for future bondStart', () => {
+      const future = new Date(now + oneDay).toISOString()
+      expect(computeDurationScore(future, now)).toBe(0)
+    })
+  })
+
+  describe('computeDurationScore with custom config', () => {
+    const now = Date.now()
+    const oneDay = 86_400_000
+
+    const customConfig: ScoringConfig = {
+      bondScoreMax: 50,
+      durationScoreMax: 25,
+      attestationScoreMax: 25,
+      oneEthWei: BigInt('1000000000000000000'),
+      maxDurationDays: 180, // 6 months
+      maxAttestationCount: 5,
+      scoringModelVersion: '2.0.0',
+    }
+
+    it('should use custom durationScoreMax', () => {
+      const sixMonths = new Date(now - 180 * oneDay).toISOString()
+      const score = computeDurationScore(sixMonths, now, customConfig)
+
+      expect(score).toBe(25) // Custom max
+    })
+
+    it('should use custom maxDurationDays', () => {
+      const threeMonths = new Date(now - 90 * oneDay).toISOString()
+      const score = computeDurationScore(threeMonths, now, customConfig)
+
+      expect(score).toBe(13) // ~50% of 25 (rounded)
+    })
+  })
+
+  describe('computeAttestationScore with default config', () => {
+    it('should compute score proportional to count', () => {
+      const score = computeAttestationScore(3)
+
+      expect(score).toBe(18) // 60% of max (30)
+    })
+
+    it('should cap at attestationScoreMax', () => {
+      const score = computeAttestationScore(10)
+
+      expect(score).toBe(30) // Capped at max
+    })
+
+    it('should return 0 for zero count', () => {
+      expect(computeAttestationScore(0)).toBe(0)
+    })
+
+    it('should return 0 for negative count', () => {
+      expect(computeAttestationScore(-5)).toBe(0)
+    })
+  })
+
+  describe('computeAttestationScore with custom config', () => {
+    const customConfig: ScoringConfig = {
+      bondScoreMax: 50,
+      durationScoreMax: 20,
+      attestationScoreMax: 40,
+      oneEthWei: BigInt('1000000000000000000'),
+      maxDurationDays: 365,
+      maxAttestationCount: 10, // 10 attestations for max
+      scoringModelVersion: '2.0.0',
+    }
+
+    it('should use custom attestationScoreMax', () => {
+      const score = computeAttestationScore(10, customConfig)
+
+      expect(score).toBe(40) // Custom max
+    })
+
+    it('should use custom maxAttestationCount', () => {
+      const score = computeAttestationScore(5, customConfig)
+
+      expect(score).toBe(20) // 50% of 40
+    })
+  })
+
+  describe('regression - default config matches original behavior', () => {
+    const now = Date.now()
+    const oneDay = 86_400_000
+
+    it('should match original bond score calculation', () => {
+      const oneEth = '1000000000000000000'
+      const halfEth = '500000000000000000'
+
+      expect(computeBondScore(oneEth)).toBe(50)
+      expect(computeBondScore(halfEth)).toBe(25)
+    })
+
+    it('should match original duration score calculation', () => {
+      const oneYear = new Date(now - 365 * oneDay).toISOString()
+      const halfYear = new Date(now - 182.5 * oneDay).toISOString()
+
+      expect(computeDurationScore(oneYear, now)).toBe(20)
+      expect(computeDurationScore(halfYear, now)).toBe(10)
+    })
+
+    it('should match original attestation score calculation', () => {
+      expect(computeAttestationScore(5)).toBe(30)
+      expect(computeAttestationScore(3)).toBe(18)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle very large bonded amounts', () => {
+      const huge = '999999999999999999999999'
+      const score = computeBondScore(huge)
+
+      expect(score).toBe(50) // Capped at max
+    })
+
+    it('should handle very long durations', () => {
+      const now = Date.now()
+      const tenYears = new Date(now - 3650 * 86_400_000).toISOString()
+      const score = computeDurationScore(tenYears, now)
+
+      expect(score).toBe(20) // Capped at max
+    })
+
+    it('should handle very large attestation counts', () => {
+      const score = computeAttestationScore(1000)
+
+      expect(score).toBe(30) // Capped at max
+    })
+
+    it('should handle zero-weight custom config', () => {
+      const zeroConfig: ScoringConfig = {
+        bondScoreMax: 0,
+        durationScoreMax: 0,
+        attestationScoreMax: 100,
+        oneEthWei: BigInt('1000000000000000000'),
+        maxDurationDays: 365,
+        maxAttestationCount: 5,
+        scoringModelVersion: '3.0.0',
+      }
+
+      expect(computeBondScore('1000000000000000000', zeroConfig)).toBe(0)
+      expect(computeDurationScore(new Date().toISOString(), Date.now(), zeroConfig)).toBe(0)
+      expect(computeAttestationScore(5, zeroConfig)).toBe(100)
+    })
+  })
+})

--- a/src/services/reputationService.ts
+++ b/src/services/reputationService.ts
@@ -2,13 +2,16 @@
  * Reputation engine – computes an off-chain trust score from bond data and
  * attestation history stored in the identity DB.
  *
- * Score breakdown (max 100):
- *   Bond amount  : up to 50 pts  (50 pts at ≥ 1 ETH)
- *   Bond duration: up to 20 pts  (20 pts at ≥ 365 days bonded)
- *   Attestations : up to 30 pts  (30 pts at ≥ 5 attestations)
+ * Score breakdown (max 100, configurable via environment):
+ *   Bond amount  : up to REPUTATION_BOND_SCORE_MAX pts (default: 50 pts at ≥ 1 ETH)
+ *   Bond duration: up to REPUTATION_DURATION_SCORE_MAX pts (default: 20 pts at ≥ 365 days bonded)
+ *   Attestations : up to REPUTATION_ATTESTATION_SCORE_MAX pts (default: 30 pts at ≥ 5 attestations)
+ *
+ * All scoring weights are externalized to config and versioned via REPUTATION_MODEL_VERSION.
  */
 
 import { getIdentity, type Identity } from '../db/store.js'
+import { loadConfig } from '../config/index.js'
 
 export interface TrustScore {
   address: string
@@ -17,49 +20,78 @@ export interface TrustScore {
   bondStart: string | null
   attestationCount: number
   agreedFields?: Record<string, string>
+  scoringModelVersion?: string
 }
 
-const BOND_SCORE_MAX = 50
-const DURATION_SCORE_MAX = 20
-const ATTESTATION_SCORE_MAX = 30
+export interface ScoringConfig {
+  bondScoreMax: number
+  durationScoreMax: number
+  attestationScoreMax: number
+  oneEthWei: bigint
+  maxDurationDays: number
+  maxAttestationCount: number
+  scoringModelVersion: string
+}
 
-/** 1 ETH expressed in wei. */
-const ONE_ETH_WEI = BigInt('1000000000000000000')
+// Load config once at module initialization
+const config = loadConfig()
+const scoringConfig: ScoringConfig = config.reputation
 
-/** Points proportional to bonded amount; maxes out at ONE_ETH_WEI. */
-export function computeBondScore(bondedAmountWei: string): number {
+/**
+ * Get the current scoring configuration.
+ * Useful for testing and introspection.
+ */
+export function getScoringConfig(): ScoringConfig {
+  return { ...scoringConfig }
+}
+
+/** Points proportional to bonded amount; maxes out at configured ONE_ETH_WEI. */
+export function computeBondScore(
+  bondedAmountWei: string,
+  cfg: ScoringConfig = scoringConfig
+): number {
   try {
     const amount = BigInt(bondedAmountWei)
     if (amount <= 0n) return 0
-    const score = Number((amount * BigInt(BOND_SCORE_MAX)) / ONE_ETH_WEI)
-    return Math.min(BOND_SCORE_MAX, score)
+    const score = Number((amount * BigInt(cfg.bondScoreMax)) / cfg.oneEthWei)
+    return Math.min(cfg.bondScoreMax, score)
   } catch {
     return 0
   }
 }
 
-/** Points proportional to days since bond start; maxes out at 365 days. */
-export function computeDurationScore(bondStart: string | null, now = Date.now()): number {
+/** Points proportional to days since bond start; maxes out at configured max duration. */
+export function computeDurationScore(
+  bondStart: string | null,
+  now = Date.now(),
+  cfg: ScoringConfig = scoringConfig
+): number {
   if (!bondStart) return 0
   const startMs = new Date(bondStart).getTime()
   if (isNaN(startMs) || startMs >= now) return 0
   const daysBonded = (now - startMs) / 86_400_000
-  const score = (daysBonded / 365) * DURATION_SCORE_MAX
-  return Math.min(DURATION_SCORE_MAX, Math.round(score))
+  const score = (daysBonded / cfg.maxDurationDays) * cfg.durationScoreMax
+  return Math.min(cfg.durationScoreMax, Math.round(score))
 }
 
-/** Points proportional to attestation count; maxes out at 5 attestations. */
-export function computeAttestationScore(count: number): number {
+/** Points proportional to attestation count; maxes out at configured max attestation count. */
+export function computeAttestationScore(
+  count: number,
+  cfg: ScoringConfig = scoringConfig
+): number {
   if (count <= 0) return 0
-  const score = (count / 5) * ATTESTATION_SCORE_MAX
-  return Math.min(ATTESTATION_SCORE_MAX, Math.round(score))
+  const score = (count / cfg.maxAttestationCount) * cfg.attestationScoreMax
+  return Math.min(cfg.attestationScoreMax, Math.round(score))
 }
 
 /** Compute a full TrustScore from an Identity record. */
-export function computeTrustScore(identity: Identity): TrustScore {
-  const bondScore = computeBondScore(identity.bondedAmount)
-  const durationScore = computeDurationScore(identity.bondStart)
-  const attestationScore = computeAttestationScore(identity.attestationCount)
+export function computeTrustScore(
+  identity: Identity,
+  cfg: ScoringConfig = scoringConfig
+): TrustScore {
+  const bondScore = computeBondScore(identity.bondedAmount, cfg)
+  const durationScore = computeDurationScore(identity.bondStart, Date.now(), cfg)
+  const attestationScore = computeAttestationScore(identity.attestationCount, cfg)
   const score = Math.min(100, bondScore + durationScore + attestationScore)
 
   return {
@@ -68,6 +100,7 @@ export function computeTrustScore(identity: Identity): TrustScore {
     bondedAmount: identity.bondedAmount,
     bondStart: identity.bondStart,
     attestationCount: identity.attestationCount,
+    scoringModelVersion: cfg.scoringModelVersion,
     ...(identity.agreedFields ? { agreedFields: identity.agreedFields } : {}),
   }
 }


### PR DESCRIPTION
close #331 

Configuration (
index.ts
):

Added REPUTATION_MODEL_VERSION (default: "1.0.0")
Added REPUTATION_BOND_SCORE_MAX (default: 50)
Added REPUTATION_DURATION_SCORE_MAX (default: 20)
Added REPUTATION_ATTESTATION_SCORE_MAX (default: 30)
Added REPUTATION_ONE_ETH_WEI (default: 1000000000000000000)
Added REPUTATION_MAX_DURATION_DAYS (default: 365)
Added REPUTATION_MAX_ATTESTATION_COUNT (default: 5)
All values validated with Zod
Code Refactoring:

Updated 
reputationService.ts
 to use config
Made scoring functions accept optional config parameter
Updated 
scoreSnapshot.ts
 to record scoringModelVersion
Updated 
types.ts
 to include scoringModelVersion field
Tests:

Created 
reputation.test.ts
 (comprehensive config validation)
Created 
reputationService.test.ts
 (config-driven scoring tests)
Tests cover defaults, custom values, validation, edge cases, and regression
Documentation:

Updated .env.example with all reputation config variables
Updated 
README.md
 with configuration guide
✅ Git Operations
Created branch: feature/config-driven-reputation
Committed changes with descriptive message
Pushed to remote: origin/feature/config-driven-reputation