### PR TITLE
feat: validate report type against allowlist enum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -597,29 +598,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1858,6 +1836,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2143,6 +2122,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2839,6 +2819,7 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3022,6 +3003,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3502,6 +3484,7 @@
       "integrity": "sha512-lOt/VDh+sihAx3OUxCE5CC0qZfAhIzE3Dxw75NJ3P0C6ruUgT9b/jZKECE1ctpbxSVic9OkLdXz5UEX39ks4Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3527,6 +3510,7 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -3706,6 +3690,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4439,6 +4424,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5529,6 +5515,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6910,6 +6897,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8791,6 +8779,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10753,6 +10742,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10861,6 +10851,7 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11051,6 +11042,7 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11129,6 +11121,7 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -11567,6 +11560,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/routes/report.ts
+++ b/src/routes/report.ts
@@ -1,21 +1,19 @@
-import { Router, Request, Response } from 'express'
-import { requireApiKey, ApiScope } from '../middleware/auth.js'
-import { ReportService } from '../services/reportService.js'
-import { ReportRepository } from '../db/repositories/reportRepository.js'
-import { ReportStorageService } from '../services/reportStorage.js'
-import { pool } from '../db/pool.js'
+import { Router, Request, Response } from "express";
+import { requireApiKey, ApiScope } from "../middleware/auth.js";
+import { ReportService } from "../services/reportService.js";
+import { ReportRepository } from "../db/repositories/reportRepository.js";
+import { ReportStorageService } from "../services/reportStorage.js";
+import { pool } from "../db/pool.js";
+import { validate } from "../middleware/validate.js";
+import {
+  createReportBodySchema,
+  type CreateReportBody,
+} from "../schemas/report.js";
 
-const router = Router()
-const reportRepository = new ReportRepository(pool)
-const reportStorage = new ReportStorageService()
-const reportService = new ReportService(reportRepository, reportStorage)
-
-/**
- * Request body schema for report generation
- */
-interface ReportRequest {
-  type: string
-}
+const router = Router();
+const reportRepository = new ReportRepository(pool);
+const reportStorage = new ReportStorageService();
+const reportService = new ReportService(reportRepository, reportStorage);
 
 /**
  * POST /api/reports
@@ -29,38 +27,31 @@ interface ReportRequest {
  * @returns {object} Job information with status 'queued'
  */
 router.post(
-  '/',
+  "/",
   requireApiKey(ApiScope.ENTERPRISE),
+  validate({ body: createReportBodySchema }),
   async (req: Request, res: Response): Promise<void> => {
     try {
-      const { type } = req.body as ReportRequest
+      const { type } = req.validated!.body! as CreateReportBody;
 
-      if (!type || typeof type !== 'string') {
-        res.status(400).json({
-          error: 'InvalidRequest',
-          message: 'Report type is required and must be a string',
-        })
-        return
-      }
-
-      const tenantId = (req as any).apiKey?.tenantId ?? 'default'
-      const job = await reportService.startReportGeneration(type, tenantId)
+      const tenantId = (req as any).apiKey?.tenantId ?? "default";
+      const job = await reportService.startReportGeneration(type, tenantId);
 
       res.status(202).json({
         jobId: job.id,
         status: job.status,
         type: job.type,
         createdAt: job.createdAt,
-      })
+      });
     } catch (error) {
-      console.error('Report generation error:', error)
+      console.error("Report generation error:", error);
       res.status(500).json({
-        error: 'InternalServerError',
-        message: 'An unexpected error occurred while starting the report job',
-      })
+        error: "InternalServerError",
+        message: "An unexpected error occurred while starting the report job",
+      });
     }
-  }
-)
+  },
+);
 
 /**
  * GET /api/reports/:jobId
@@ -74,31 +65,31 @@ router.post(
  * @returns {object} Job status and artifact availability
  */
 router.get(
-  '/:jobId',
+  "/:jobId",
   requireApiKey(ApiScope.ENTERPRISE),
   async (req: Request, res: Response): Promise<void> => {
     try {
-      const { jobId } = req.params
+      const { jobId } = req.params;
 
       if (!jobId) {
         res.status(400).json({
-          error: 'InvalidRequest',
-          message: 'Job ID is required',
-        })
-        return
+          error: "InvalidRequest",
+          message: "Job ID is required",
+        });
+        return;
       }
 
-      const job = await reportService.getReportStatus(jobId)
+      const job = await reportService.getReportStatus(jobId);
 
       if (!job) {
         res.status(404).json({
-          error: 'NotFound',
+          error: "NotFound",
           message: `Report job ${jobId} not found`,
-        })
-        return
+        });
+        return;
       }
 
-      const signedUrl = reportService.getSignedDownloadUrl(job)
+      const signedUrl = reportService.getSignedDownloadUrl(job);
 
       res.status(200).json({
         jobId: job.id,
@@ -108,16 +99,16 @@ router.get(
         failureReason: job.failureReason,
         createdAt: job.createdAt,
         updatedAt: job.updatedAt,
-      })
+      });
     } catch (error) {
-      console.error('Report status query error:', error)
+      console.error("Report status query error:", error);
       res.status(500).json({
-        error: 'InternalServerError',
-        message: 'An unexpected error occurred while fetching report status',
-      })
+        error: "InternalServerError",
+        message: "An unexpected error occurred while fetching report status",
+      });
     }
-  }
-)
+  },
+);
 
 /**
  * GET /api/reports/download/:key
@@ -130,42 +121,45 @@ router.get(
  * @query {string} signature - HMAC-SHA256 signature
  */
 router.get(
-  '/download/:key',
+  "/download/:key",
   async (req: Request, res: Response): Promise<void> => {
     try {
-      const key = decodeURIComponent(req.params.key)
-      const expires = parseInt(req.query.expires as string, 10)
-      const signature = req.query.signature as string
+      const key = decodeURIComponent(req.params.key);
+      const expires = parseInt(req.query.expires as string, 10);
+      const signature = req.query.signature as string;
 
       if (!expires || !signature) {
         res.status(400).json({
-          error: 'InvalidRequest',
-          message: 'Signed URL requires expires and signature query parameters',
-        })
-        return
+          error: "InvalidRequest",
+          message: "Signed URL requires expires and signature query parameters",
+        });
+        return;
       }
 
-      const data = reportStorage.verifyAndRetrieve(key, expires, signature)
+      const data = reportStorage.verifyAndRetrieve(key, expires, signature);
 
       if (!data) {
         res.status(401).json({
-          error: 'Unauthorized',
-          message: 'Invalid or expired signed URL',
-        })
-        return
+          error: "Unauthorized",
+          message: "Invalid or expired signed URL",
+        });
+        return;
       }
 
-      res.setHeader('Content-Type', 'application/pdf')
-      res.setHeader('Content-Disposition', `attachment; filename="${key.split('/').pop() || 'report.pdf'}"`)
-      res.status(200).send(data)
+      res.setHeader("Content-Type", "application/pdf");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${key.split("/").pop() || "report.pdf"}"`,
+      );
+      res.status(200).send(data);
     } catch (error) {
-      console.error('Report download error:', error)
+      console.error("Report download error:", error);
       res.status(500).json({
-        error: 'InternalServerError',
-        message: 'An unexpected error occurred while downloading the report',
-      })
+        error: "InternalServerError",
+        message: "An unexpected error occurred while downloading the report",
+      });
     }
-  }
-)
+  },
+);
 
-export default router
+export default router;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -31,3 +31,10 @@ export {
   type WithdrawalEventPayload,
   type BondCreationEventPayload,
 } from './queue.js'
+export {
+  REPORT_TYPES,
+  reportTypeSchema,
+  createReportBodySchema,
+  type ReportType,
+  type CreateReportBody,
+} from './report.js'

--- a/src/schemas/report.test.ts
+++ b/src/schemas/report.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  createReportBodySchema,
+  reportTypeSchema,
+  REPORT_TYPES,
+} from "./report.js";
+
+describe("reportTypeSchema", () => {
+  it.each(REPORT_TYPES)("accepts allowed type: %s", (type) => {
+    expect(reportTypeSchema.parse(type)).toBe(type);
+  });
+
+  it("rejects an unknown type string", () => {
+    expect(reportTypeSchema.safeParse("foobar").success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(reportTypeSchema.safeParse("").success).toBe(false);
+  });
+
+  it("rejects a numeric value", () => {
+    expect(reportTypeSchema.safeParse(42).success).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(reportTypeSchema.safeParse(null).success).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(reportTypeSchema.safeParse(undefined).success).toBe(false);
+  });
+
+  it("is case-sensitive (rejects uppercase variant)", () => {
+    expect(reportTypeSchema.safeParse("Trust_Score_Summary").success).toBe(
+      false,
+    );
+  });
+
+  it("is case-sensitive (rejects all-uppercase variant)", () => {
+    expect(reportTypeSchema.safeParse("BOND_AUDIT").success).toBe(false);
+  });
+
+  it("rejects an overly long string", () => {
+    const longString = "a".repeat(500);
+    expect(reportTypeSchema.safeParse(longString).success).toBe(false);
+  });
+});
+
+describe("createReportBodySchema", () => {
+  it("accepts a valid body with an allowed type", () => {
+    expect(
+      createReportBodySchema.parse({ type: "trust_score_summary" }),
+    ).toEqual({
+      type: "trust_score_summary",
+    });
+  });
+
+  it("accepts each allowed report type", () => {
+    for (const type of REPORT_TYPES) {
+      expect(createReportBodySchema.parse({ type })).toEqual({ type });
+    }
+  });
+
+  it("rejects a body with an unknown type", () => {
+    const result = createReportBodySchema.safeParse({ type: "invalid_report" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a body with missing type field", () => {
+    const result = createReportBodySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a body with empty string type", () => {
+    const result = createReportBodySchema.safeParse({ type: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a body with numeric type", () => {
+    const result = createReportBodySchema.safeParse({ type: 123 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a body with null type", () => {
+    const result = createReportBodySchema.safeParse({ type: null });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects extra unknown fields (.strict())", () => {
+    const result = createReportBodySchema.safeParse({
+      type: "bond_audit",
+      extraField: "unexpected",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an overly long type string", () => {
+    const result = createReportBodySchema.safeParse({ type: "x".repeat(500) });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/schemas/report.ts
+++ b/src/schemas/report.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+/**
+ * Allowed report types — single source of truth for the route and worker.
+ * Add new report types here as they are implemented.
+ */
+export const REPORT_TYPES = [
+  'trust_score_summary',
+  'bond_audit',
+  'attestation_export',
+] as const
+
+/**
+ * Schema for a valid report type string.
+ */
+export const reportTypeSchema = z.enum(REPORT_TYPES)
+
+/**
+ * Body schema for POST /api/reports
+ */
+export const createReportBodySchema = z
+  .object({
+    type: reportTypeSchema,
+  })
+  .strict()
+
+export type ReportType = z.infer<typeof reportTypeSchema>
+export type CreateReportBody = z.infer<typeof createReportBodySchema>

--- a/tests/routes/report.test.ts
+++ b/tests/routes/report.test.ts
@@ -1,0 +1,137 @@
+/**
+ * @file Integration tests for POST /api/reports report-type validation.
+ *
+ * Builds a minimal Express app with the validate middleware and
+ * errorHandler to test that invalid report types are rejected at
+ * the route level, without requiring a live database or Redis.
+ */
+
+import { describe, it, expect } from "vitest";
+import express, {
+  type Request,
+  type Response,
+  type NextFunction,
+} from "express";
+import request from "supertest";
+import { validate } from "../../src/middleware/validate.js";
+import { errorHandler } from "../../src/middleware/errorHandler.js";
+import {
+  createReportBodySchema,
+  type CreateReportBody,
+  REPORT_TYPES,
+} from "../../src/schemas/report.js";
+
+/**
+ * Build a self-contained Express app that mirrors the report route's
+ * validation layer without the module-level DB/Redis dependencies.
+ */
+function createApp() {
+  const app = express();
+  app.use(express.json());
+
+  app.post(
+    "/api/reports",
+    validate({ body: createReportBodySchema }),
+    (req: Request, res: Response) => {
+      const { type } = req.validated!.body! as CreateReportBody;
+      res.status(202).json({ type, status: "queued" });
+    },
+  );
+
+  app.use(errorHandler);
+  return app;
+}
+
+describe("POST /api/reports — type validation", () => {
+  const app = createApp();
+
+  // Happy-path
+
+  it.each(REPORT_TYPES)("returns 202 for allowed type: %s", async (type) => {
+    const res = await request(app).post("/api/reports").send({ type });
+
+    expect(res.status).toBe(202);
+    expect(res.body.type).toBe(type);
+    expect(res.body.status).toBe("queued");
+  });
+
+  // Invalid type
+
+  it("returns 400 for an unknown report type", async () => {
+    const res = await request(app)
+      .post("/api/reports")
+      .send({ type: "nonexistent_report" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Validation failed");
+    expect(res.body.details).toBeDefined();
+  });
+
+  it("returns 400 for an empty string type", async () => {
+    const res = await request(app).post("/api/reports").send({ type: "" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when type is missing", async () => {
+    const res = await request(app).post("/api/reports").send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is empty", async () => {
+    const res = await request(app).post("/api/reports").send();
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a numeric type", async () => {
+    const res = await request(app).post("/api/reports").send({ type: 42 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for null type", async () => {
+    const res = await request(app).post("/api/reports").send({ type: null });
+
+    expect(res.status).toBe(400);
+  });
+
+  // Case sensitivity
+
+  it("returns 400 for a case-mismatched type (mixed case)", async () => {
+    const res = await request(app)
+      .post("/api/reports")
+      .send({ type: "Trust_Score_Summary" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a case-mismatched type (uppercase)", async () => {
+    const res = await request(app)
+      .post("/api/reports")
+      .send({ type: "BOND_AUDIT" });
+
+    expect(res.status).toBe(400);
+  });
+
+  // Security: overly long strings
+
+  it("returns 400 for an overly long type string", async () => {
+    const res = await request(app)
+      .post("/api/reports")
+      .send({ type: "a".repeat(500) });
+
+    expect(res.status).toBe(400);
+  });
+
+  // Strict mode: extra fields
+
+  it("returns 400 when extra unknown fields are present", async () => {
+    const res = await request(app)
+      .post("/api/reports")
+      .send({ type: "bond_audit", extraField: "unexpected" });
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
This PR resolves issue #333  by introducing robust, compile-time and runtime validation for the POST /api/reports endpoint. Previously, any non-empty string payload was accepted, leading to silent failures downstream in the background worker or unsafe string persistence in the database.

We now leverage a centralized Zod schema enum allowlist applied via the shared validate middleware to reject invalid report type configurations at the HTTP routing boundary.

Closes #333 