### PR TITLE
feat: tune pg pool with statement timeouts and saturation metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,18 @@ LOG_LEVEL=info
 # ── Database ─────────────────────────────────────────────────────────────────
 DB_URL=postgresql://user:password@localhost:5432/credence
 
+# ── Database Pool Tuning ─────────────────────────────────────────────────────
+# Maximum connections in the API pool (default: 20)
+DB_POOL_MAX=20
+# Milliseconds a client can sit idle before being closed (default: 30000)
+DB_POOL_IDLE_TIMEOUT_MS=30000
+# Milliseconds to wait for a connection before erroring (default: 5000)
+DB_POOL_CONNECTION_TIMEOUT_MS=5000
+# Default per-statement timeout in milliseconds; kills runaway queries (default: 30000)
+DB_STATEMENT_TIMEOUT_MS=30000
+# Maximum connections in the worker pool for background jobs (default: 5)
+DB_WORKER_POOL_MAX=5
+
 # ── Redis ────────────────────────────────────────────────────────────────────
 REDIS_URL=redis://localhost:6379
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -795,6 +795,14 @@ open http://localhost:3001
 | `health_check_status` | Gauge | dependency | Health status (1=up, 0=down) |
 | `health_check_duration_seconds` | Gauge | dependency | Health check duration |
 
+### Pool Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pg_pool_total_count` | Gauge | pool | Total clients (active + idle) |
+| `pg_pool_idle_count` | Gauge | pool | Idle clients |
+| `pg_pool_waiting_count` | Gauge | pool | Queued requests waiting |
+
 ### Business Metrics
 
 | Metric | Type | Labels | Description |

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -85,3 +85,32 @@ groups:
         annotations:
           summary: "High bulk verification failure rate"
           description: "Bulk verification failure rate is {{ $value | humanizePercentage }}"
+
+      # Pool saturation — connections exhausted
+      - alert: PgPoolSaturation
+        expr: |
+          pg_pool_waiting_count{job="credence-backend", pool="api"} > 0
+        for: 2m
+        labels:
+          severity: warning
+          service: credence-backend
+        annotations:
+          summary: "PostgreSQL connection pool saturated"
+          description: >-
+            API pool has {{ $value }} requests queued waiting for a
+            connection for >2 minutes. Consider increasing DB_POOL_MAX
+            or investigating slow queries.
+
+      # Worker pool saturation
+      - alert: PgWorkerPoolSaturation
+        expr: |
+          pg_pool_waiting_count{job="credence-backend", pool="worker"} > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: credence-backend
+        annotations:
+          summary: "Worker connection pool saturated"
+          description: >-
+            Worker pool has {{ $value }} jobs queued waiting for a
+            connection for >5 minutes.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,6 +25,33 @@ export const envSchema = z.object({
   // Database
   DB_URL: z.string().url({ message: 'DB_URL must be a valid URL' }),
 
+  // Database pool tuning
+  DB_POOL_MAX: z
+    .string()
+    .default('20')
+    .transform(Number)
+    .pipe(z.number().int().min(1).max(200)),
+  DB_POOL_IDLE_TIMEOUT_MS: z
+    .string()
+    .default('30000')
+    .transform(Number)
+    .pipe(z.number().int().min(0)),
+  DB_POOL_CONNECTION_TIMEOUT_MS: z
+    .string()
+    .default('5000')
+    .transform(Number)
+    .pipe(z.number().int().min(1000).max(30000)),
+  DB_STATEMENT_TIMEOUT_MS: z
+    .string()
+    .default('30000')
+    .transform(Number)
+    .pipe(z.number().int().min(0)),
+  DB_WORKER_POOL_MAX: z
+    .string()
+    .default('5')
+    .transform(Number)
+    .pipe(z.number().int().min(1).max(50)),
+
   // Redis
   REDIS_URL: z.string().url({ message: 'REDIS_URL must be a valid URL' }),
 
@@ -213,6 +240,15 @@ export interface Config {
       defaultMs: number
       criticalMs: number
     }
+    pool: {
+      max: number
+      idleTimeoutMillis: number
+      connectionTimeoutMillis: number
+      statementTimeoutMs: number
+    }
+    workerPool: {
+      max: number
+    }
   }
   redis: {
     url: string
@@ -342,6 +378,15 @@ function mapEnvToConfig(env: Env): Config {
         readonlyMs: env.DB_LOCK_TIMEOUT_READONLY_MS,
         defaultMs: env.DB_LOCK_TIMEOUT_DEFAULT_MS,
         criticalMs: env.DB_LOCK_TIMEOUT_CRITICAL_MS,
+      },
+      pool: {
+        max: env.DB_POOL_MAX,
+        idleTimeoutMillis: env.DB_POOL_IDLE_TIMEOUT_MS,
+        connectionTimeoutMillis: env.DB_POOL_CONNECTION_TIMEOUT_MS,
+        statementTimeoutMs: env.DB_STATEMENT_TIMEOUT_MS,
+      },
+      workerPool: {
+        max: env.DB_WORKER_POOL_MAX,
       },
     },
     redis: {

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Pool } from 'pg'
+
+describe('DB Pool configuration', () => {
+  let envSnapshot: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    envSnapshot = { ...process.env }
+  })
+
+  afterEach(() => {
+    process.env = envSnapshot
+    vi.resetModules()
+  })
+
+  it('pool is a Pool instance with expected options.max', async () => {
+    const { pool } = await import('./pool.js')
+    expect(pool).toBeInstanceOf(Pool)
+    // The default in the code without env vars might be the fallback (20)
+    // Actually we can check options if exposed or just check it's a Pool
+    expect(pool.options.max).toBeDefined()
+  })
+
+  it('workerPool is a separate Pool instance', async () => {
+    const { pool, workerPool } = await import('./pool.js')
+    expect(workerPool).toBeInstanceOf(Pool)
+    expect(workerPool).not.toBe(pool)
+  })
+
+  it('envInt returns fallback for missing env var', async () => {
+    const { envInt } = await import('./pool.js')
+    expect(envInt('MISSING_VAR_TEST', 42)).toBe(42)
+  })
+
+  it('envInt returns fallback for non-numeric string', async () => {
+    const { envInt } = await import('./pool.js')
+    process.env.NON_NUMERIC_TEST = 'not_a_number'
+    expect(envInt('NON_NUMERIC_TEST', 42)).toBe(42)
+  })
+  
+  it('envInt returns parsed number for valid string', async () => {
+    const { envInt } = await import('./pool.js')
+    process.env.VALID_NUM_TEST = '99'
+    expect(envInt('VALID_NUM_TEST', 42)).toBe(99)
+  })
+
+  it('statement_timeout is set in options string', async () => {
+    const { pool, workerPool } = await import('./pool.js')
+    expect(pool.options.options).toContain('-c statement_timeout=')
+    expect(workerPool.options.options).toContain('-c statement_timeout=')
+  })
+})

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,15 +1,61 @@
-import { Pool } from 'pg'
-import dotenv from 'dotenv'
+import { Pool } from "pg";
+import dotenv from "dotenv";
 
-dotenv.config()
+dotenv.config();
 
+/**
+ * Parse a numeric environment variable with a fallback default.
+ * Returns the fallback if the variable is missing or non-numeric.
+ * @internal Exported for testing only.
+ */
+export function envInt(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (raw === undefined || raw === "") return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const DB_URL = process.env.DB_URL;
+const POOL_MAX = envInt("DB_POOL_MAX", 20);
+const IDLE_TIMEOUT = envInt("DB_POOL_IDLE_TIMEOUT_MS", 30_000);
+const CONN_TIMEOUT = envInt("DB_POOL_CONNECTION_TIMEOUT_MS", 5_000);
+const STMT_TIMEOUT = envInt("DB_STATEMENT_TIMEOUT_MS", 30_000);
+const WORKER_MAX = envInt("DB_WORKER_POOL_MAX", 5);
+
+/**
+ * Primary API pool — serves route handlers and services.
+ *
+ * Configured with a default statement_timeout so that runaway queries
+ * are killed automatically and cannot hold connections indefinitely.
+ */
 export const pool = new Pool({
-     connectionString: process.env.DB_URL,
-     max: 10,
-     idleTimeoutMillis: 30_000,
-     connectionTimeoutMillis: 5_000,
-})
+  connectionString: DB_URL,
+  max: POOL_MAX,
+  idleTimeoutMillis: IDLE_TIMEOUT,
+  connectionTimeoutMillis: CONN_TIMEOUT,
+  options: `-c statement_timeout=${STMT_TIMEOUT}`,
+});
 
-pool.on('error', (err) => {
-     console.error('[pool] unexpected client error', err)
-})
+pool.on("error", (err) => {
+  console.error("[pool] unexpected client error", err);
+});
+
+/**
+ * Worker pool — bounded budget for background jobs (outbox, exports, reports).
+ *
+ * Runs with a smaller connection limit so that long-running background
+ * work cannot starve the API pool of connections. The statement_timeout
+ * is 4× longer than the API pool since report/export jobs are inherently
+ * slower.
+ */
+export const workerPool = new Pool({
+  connectionString: DB_URL,
+  max: WORKER_MAX,
+  idleTimeoutMillis: IDLE_TIMEOUT,
+  connectionTimeoutMillis: CONN_TIMEOUT,
+  options: `-c statement_timeout=${STMT_TIMEOUT * 4}`,
+});
+
+workerPool.on("error", (err) => {
+  console.error("[workerPool] unexpected client error", err);
+});

--- a/src/jobs/reportWorker.ts
+++ b/src/jobs/reportWorker.ts
@@ -2,7 +2,7 @@ import { ReportJobStatus } from './types.js'
 import { ReportRepository } from '../db/repositories/reportRepository.js'
 import { ReportStorageService } from '../services/reportStorage.js'
 import { invalidateCache } from '../cache/invalidation.js'
-import { pool } from '../db/pool.js'
+import { workerPool } from '../db/pool.js'
 
 /**
  * Report worker that generates report artifacts as a streaming AsyncIterable
@@ -84,7 +84,7 @@ export class ReportWorker {
  * Factory: creates a ReportWorker wired to the default pool and storage.
  */
 export function createReportWorker(storage?: ReportStorageService): ReportWorker {
-  const repo = new ReportRepository(pool)
+  const repo = new ReportRepository(workerPool)
   const svc = storage ?? new ReportStorageService()
   return new ReportWorker(repo, svc)
 }

--- a/src/middleware/metrics.ts
+++ b/src/middleware/metrics.ts
@@ -12,12 +12,17 @@
 import { Request, Response, NextFunction } from 'express'
 import client from 'prom-client'
 import { registerLatencyMetrics } from '../observability/latencyMetrics.js'
+import { registerPoolMetrics } from '../observability/index.js'
+import { pool, workerPool } from '../db/pool.js'
 
 // Create a Registry to register metrics
 export const register = new client.Registry()
 
 // Register latency percentile metrics
 registerLatencyMetrics(register)
+
+// Register database connection pool metrics
+registerPoolMetrics(register, pool, workerPool)
 
 // Add default Node.js metrics (CPU, memory, event loop, etc.)
 client.collectDefaultMetrics({ 

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -21,3 +21,5 @@ export {
   createSlowOperationEvent,
   createSuccessEvent,
 } from './timeoutMetrics.js'
+
+export { registerPoolMetrics } from './poolMetrics.js'

--- a/src/observability/poolMetrics.test.ts
+++ b/src/observability/poolMetrics.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import client from 'prom-client'
+import { registerPoolMetrics } from './poolMetrics.js'
+import type { Pool } from 'pg'
+
+describe('Pool Metrics Exporter', () => {
+  it('registers pool saturation gauges and reports correct values', async () => {
+    const registry = new client.Registry()
+
+    // Mock pools with specific states
+    const apiPool = {
+      totalCount: 15,
+      idleCount: 5,
+      waitingCount: 2,
+    } as Pool
+
+    const workerPool = {
+      totalCount: 4,
+      idleCount: 1,
+      waitingCount: 0,
+    } as Pool
+
+    registerPoolMetrics(registry, apiPool, workerPool)
+
+    const metricsStr = await registry.metrics()
+
+    // API pool metrics
+    expect(metricsStr).toContain('pg_pool_total_count{pool="api"} 15')
+    expect(metricsStr).toContain('pg_pool_idle_count{pool="api"} 5')
+    expect(metricsStr).toContain('pg_pool_waiting_count{pool="api"} 2')
+
+    // Worker pool metrics
+    expect(metricsStr).toContain('pg_pool_total_count{pool="worker"} 4')
+    expect(metricsStr).toContain('pg_pool_idle_count{pool="worker"} 1')
+    expect(metricsStr).toContain('pg_pool_waiting_count{pool="worker"} 0')
+
+    // Dynamic updates via collect()
+    apiPool.totalCount = 20
+    apiPool.waitingCount = 5
+
+    const updatedMetricsStr = await registry.metrics()
+    expect(updatedMetricsStr).toContain('pg_pool_total_count{pool="api"} 20')
+    expect(updatedMetricsStr).toContain('pg_pool_waiting_count{pool="api"} 5')
+  })
+})

--- a/src/observability/poolMetrics.ts
+++ b/src/observability/poolMetrics.ts
@@ -1,0 +1,56 @@
+/**
+ * PostgreSQL connection pool saturation metrics.
+ *
+ * Registers Prometheus gauges for total, idle, and waiting connection counts
+ * on both the API and worker pools. Uses collect() callbacks so values are
+ * sampled at scrape time rather than polled on a timer.
+ */
+
+import type { Pool } from "pg";
+import client from "prom-client";
+
+/**
+ * Register pool saturation gauges for both the API and worker pools.
+ *
+ * @param registry - Prometheus registry to register metrics with.
+ * @param apiPool  - Primary API connection pool.
+ * @param workerPool - Background worker connection pool.
+ */
+export function registerPoolMetrics(
+  registry: client.Registry,
+  apiPool: Pool,
+  workerPool: Pool,
+): void {
+  new client.Gauge({
+    name: "pg_pool_total_count",
+    help: "Total number of clients in the pool (active + idle)",
+    labelNames: ["pool"] as const,
+    registers: [registry],
+    collect() {
+      this.set({ pool: "api" }, apiPool.totalCount);
+      this.set({ pool: "worker" }, workerPool.totalCount);
+    },
+  });
+
+  new client.Gauge({
+    name: "pg_pool_idle_count",
+    help: "Number of idle clients in the pool",
+    labelNames: ["pool"] as const,
+    registers: [registry],
+    collect() {
+      this.set({ pool: "api" }, apiPool.idleCount);
+      this.set({ pool: "worker" }, workerPool.idleCount);
+    },
+  });
+
+  new client.Gauge({
+    name: "pg_pool_waiting_count",
+    help: "Number of queued requests waiting for a pool connection",
+    labelNames: ["pool"] as const,
+    registers: [registry],
+    collect() {
+      this.set({ pool: "api" }, apiPool.waitingCount);
+      this.set({ pool: "worker" }, workerPool.waitingCount);
+    },
+  });
+}


### PR DESCRIPTION
This PR resolves issue #344 by introducing database connection pool tuning, query timeboxing, and explicit resource isolation between user-facing API routes and intensive background jobs.

Previously, a single slow query could hold a connection indefinitely, and heavy parallel processing (reports, exports, outbox polling) could cause pool exhaustion, causing the API to queue requests indefinitely. We have introduced defensive runtime variables and a dedicated secondary connection pool to eliminate this risk.

Closes #344 