### PR TITLE
feat: enforce granular per-endpoint API scopes

### DIFF
--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -18,31 +18,70 @@ cr_a3f2b1c0d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1
 
 ## Sending a Key
 
-Include the key in one of these headers (Authorization takes precedence):
-
-```http
-Authorization: Bearer cr_your_key_here
-```
+Include the key in one of these headers (`X-API-Key` takes precedence):
 
 ```http
 X-API-Key: cr_your_key_here
 ```
 
-## Scopes
+```http
+Authorization: Bearer cr_your_key_here
+```
 
-| Scope  | Description                             |
-|--------|-----------------------------------------|
-| `read` | Read-only access to trust and bond data |
-| `full` | Full access, including write operations |
+## Granular Scopes
 
-Requests to endpoints that require `full` scope with a `read` key receive **403 Forbidden**.
+Each API key is issued with one or more **scopes** that control exactly which endpoints it may call. This enforces least-privilege: a key can only do what it was explicitly granted.
+
+| Scope                | Description                                                        |
+|----------------------|--------------------------------------------------------------------|
+| `trust:read`         | Read-only access to trust scores and bond data                     |
+| `attestations:read`  | List and count attestations                                        |
+| `attestations:write` | Create or revoke attestations                                      |
+| `payouts:write`      | Initiate payout / settlement operations                            |
+| `reports:generate`   | Trigger and poll report generation jobs                            |
+| `exports:read`       | Download report artifacts and audit-log exports                    |
+| `webhooks:admin`     | Manage webhook signing secrets (rotate / revoke)                   |
+| `admin:read`         | Read admin resources (users, audit logs, failed events)            |
+| `admin:write`        | Mutate admin resources (assign roles, revoke keys, replay events, impersonate) |
+
+### Legacy tier aliases (backward-compatible)
+
+Keys issued before the granular scope model was introduced carry one of two legacy values. They continue to work and are automatically expanded:
+
+| Legacy scope  | Expands to                                                                                                                                      |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `public`      | `trust:read`, `attestations:read`                                                                                                               |
+| `enterprise`  | All granular scopes (full access)                                                                                                               |
+
+### Scope enforcement per endpoint
+
+| Endpoint                                    | Required scope          |
+|---------------------------------------------|-------------------------|
+| `GET /api/trust/*`                          | `trust:read`            |
+| `GET /api/attestations/:identity`           | `attestations:read`     |
+| `GET /api/attestations/:identity/count`     | `attestations:read`     |
+| `POST /api/attestations`                    | `attestations:write`    |
+| `DELETE /api/attestations/:id`              | `attestations:write`    |
+| `POST /api/payouts`                         | `payouts:write`         |
+| `POST /api/reports`                         | `reports:generate`      |
+| `GET /api/reports/:jobId`                   | `reports:generate`      |
+| `GET /api/reports/download/:key`            | *(signed URL — no key)* |
+| `POST /api/admin/webhooks/:id/rotate`       | `webhooks:admin` *(or admin role)* |
+| `POST /api/admin/webhooks/:id/revoke-previous` | `webhooks:admin` *(or admin role)* |
+| `GET /api/admin/users`                      | admin role              |
+| `GET /api/admin/audit-logs`                 | admin role              |
+| `GET /api/admin/audit-logs/export`          | admin role              |
+| `POST /api/admin/roles/assign`              | admin role              |
+| `POST /api/admin/keys/revoke`               | admin role              |
+| `POST /api/admin/impersonate`               | admin role              |
+| `POST /api/admin/events/replay/:id`         | admin role              |
 
 ## Subscription Tiers
 
-| Tier         | Rate limit   |
-|--------------|--------------|
-| `free`       | 100 req/min  |
-| `pro`        | 1 000 req/min |
+| Tier         | Rate limit     |
+|--------------|----------------|
+| `free`       | 100 req/min    |
+| `pro`        | 1 000 req/min  |
 | `enterprise` | 10 000 req/min |
 
 ## Key Lifecycle
@@ -55,7 +94,7 @@ Content-Type: application/json
 
 {
   "ownerId": "user_abc",
-  "scope": "read",
+  "scopes": ["trust:read", "attestations:read"],
   "tier": "free"
 }
 ```
@@ -67,11 +106,14 @@ Response (201 — the raw key is **only returned here**):
   "id": "3f8a1c2b",
   "key": "cr_a3f2b1c0...",
   "prefix": "a3f2b1c0",
-  "scope": "read",
+  "scopes": ["trust:read", "attestations:read"],
+  "scope": "trust:read",
   "tier": "free",
   "createdAt": "2026-02-24T12:00:00.000Z"
 }
 ```
+
+> `scope` (singular) is kept for backward compatibility and reflects the first granted scope.
 
 ### List keys for an owner
 
@@ -86,7 +128,8 @@ Response omits the raw key and the stored hash:
   {
     "id": "3f8a1c2b",
     "prefix": "a3f2b1c0",
-    "scope": "read",
+    "scopes": ["trust:read", "attestations:read"],
+    "scope": "trust:read",
     "tier": "free",
     "ownerId": "user_abc",
     "createdAt": "2026-02-24T12:00:00.000Z",
@@ -98,7 +141,7 @@ Response omits the raw key and the stored hash:
 
 ### Rotate a key
 
-Revokes the current key and issues a new one with the same scope and tier:
+Revokes the current key and issues a new one with the same scopes and tier:
 
 ```http
 POST /api/keys/:id/rotate
@@ -117,16 +160,17 @@ Response: **204 No Content**. Subsequent requests using the revoked key receive 
 ## Security Notes
 
 - Keys are stored as **SHA-256 hashes** — the raw key is never persisted and is shown exactly once.
-- Use the `read` scope unless write operations are required.
+- Issue keys with the **minimum scopes required** for the integration. Do not use `enterprise` unless all operations are needed.
 - Rotate keys periodically; compromised keys can be revoked at any time.
 - Rate limits are enforced per tier (integration at the infrastructure layer, e.g. via a reverse proxy or Redis-based limiter).
+- The middleware is **deny-by-default**: if a key does not carry the required scope, the request is rejected with `403 Forbidden` before reaching the handler.
 
 ## Error Responses
 
-| Status | Body                                            | Cause                            |
-|--------|-------------------------------------------------|----------------------------------|
-| 400    | `{ "error": "ownerId is required" }`            | Missing required field           |
-| 401    | `{ "error": "API key required" }`               | No key in request headers        |
-| 401    | `{ "error": "Invalid or revoked API key" }`     | Key not found, bad format, or revoked |
-| 403    | `{ "error": "Insufficient scope: full access required" }` | `read` key on a `full`-only endpoint |
-| 404    | `{ "error": "Key not found" }`                  | Unknown key ID                   |
+| Status | Body                                                                 | Cause                                          |
+|--------|----------------------------------------------------------------------|------------------------------------------------|
+| 400    | `{ "error": "ownerId is required" }`                                 | Missing required field                         |
+| 401    | `{ "error": "Unauthorized", "message": "API key is required" }`      | No key in request headers                      |
+| 401    | `{ "error": "Unauthorized", "message": "Invalid API key" }`          | Key not found, bad format, or revoked          |
+| 403    | `{ "error": "Forbidden", "message": "Insufficient scope: '...' is required", "requiredScope": "...", "grantedScopes": [...] }` | Key lacks the required scope |
+| 404    | `{ "error": "Key not found" }`                                       | Unknown key ID                                 |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,55 @@
 # Security Architecture
 
+## API Key Scope Model
+
+### Granular Scopes (Least Privilege)
+
+Every API key is issued with an explicit set of **scopes** that determine which endpoints it may call. The middleware enforces a **deny-by-default** policy: if the key's granted scopes do not cover the required scope, the request is rejected with `403 Forbidden` before reaching any handler.
+
+| Scope                | Grants access to                                                   |
+|----------------------|--------------------------------------------------------------------|
+| `trust:read`         | Trust scores and bond read endpoints                               |
+| `attestations:read`  | Attestation list and count endpoints                               |
+| `attestations:write` | Create and revoke attestations                                     |
+| `payouts:write`      | Payout / settlement creation                                       |
+| `reports:generate`   | Report job creation and status polling                             |
+| `exports:read`       | Report artifact downloads and audit-log exports                    |
+| `webhooks:admin`     | Webhook secret rotation and revocation                             |
+| `admin:read`         | Admin read operations (users, audit logs, failed events)           |
+| `admin:write`        | Admin write operations (role assignment, key revocation, impersonation, event replay) |
+
+Legacy `public` and `enterprise` values are still accepted and automatically expanded to their respective scope sets (see `docs/api-keys.md`).
+
+### Scope Enforcement Implementation
+
+`src/middleware/auth.ts` exports:
+
+- **`ApiScope`** — enum of all valid scope strings.
+- **`SCOPE_SETS`** — maps legacy tier names to their expanded `Set<ApiScope>`.
+- **`scopeSatisfies(grantedScopes, requiredScope)`** — pure function; returns `true` when the granted set covers the required scope (including legacy expansion).
+- **`requireApiKey(requiredScope)`** — Express middleware factory. Reads the key from `X-API-Key` or `Authorization: Bearer`, validates it, checks scope, and attaches `{ key, scopes, scope }` to `req.apiKey`.
+
+### Scope Assignment at Key Creation
+
+When issuing a key via `generateApiKey` / `InMemoryApiKeyRepository.create`, pass an explicit `scopes` array:
+
+```typescript
+repo.create('owner-id', 'trust:read', 'free', ['trust:read', 'attestations:read'])
+```
+
+The `scopes` array is stored on `StoredApiKey` and preserved through key rotation.
+
+### Security Properties
+
+- **Deny-by-default**: missing or insufficient scope → `403` before handler execution.
+- **No scope escalation**: a key can only be rotated to the same or narrower scope set.
+- **Audit trail**: every `403` response includes `requiredScope` and `grantedScopes` for debugging without leaking key material.
+- **Backward compatibility**: existing `enterprise` keys continue to work and satisfy all granular scopes.
+
+---
+
 ## Encrypted Evidence Storage
+
 Dispute and slash evidence submitted to the platform often contain sensitive user data. To ensure privacy, security, and integrity, all evidence is encrypted at rest before being saved to the database or object storage.
 
 ### Encryption Standard

--- a/src/__tests__/auth.scopes.test.ts
+++ b/src/__tests__/auth.scopes.test.ts
@@ -1,0 +1,600 @@
+/**
+ * @file src/__tests__/auth.scopes.test.ts
+ *
+ * Comprehensive tests for the granular API scope model.
+ *
+ * Coverage targets
+ * ────────────────
+ * • ApiScope enum values
+ * • SCOPE_SETS expansion (PUBLIC / ENTERPRISE legacy tiers)
+ * • scopeSatisfies() helper — all edge cases
+ * • requireApiKey() middleware — per-scope enforcement
+ *   - missing key → 401
+ *   - invalid key → 401
+ *   - key with insufficient scope → 403 (deny-by-default)
+ *   - key with exact scope → 200 / next()
+ *   - key with superset scopes → 200 / next()
+ *   - ENTERPRISE key satisfies every granular scope
+ *   - PUBLIC key satisfies only read scopes
+ *   - req.apiKey metadata shape (scopes array + legacy scope field)
+ *   - Authorization: Bearer header accepted alongside X-API-Key
+ *   - unknown scope string → deny
+ *   - backward compat: existing test-enterprise-key-12345 still works
+ */
+
+import { Request, Response, NextFunction } from 'express'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  requireApiKey,
+  ApiScope,
+  SCOPE_SETS,
+  scopeSatisfies,
+  AuthenticatedRequest,
+} from '../middleware/auth.js'
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeReq(headers: Record<string, string> = {}): Partial<Request> {
+  return { headers }
+}
+
+function makeRes(): { res: Partial<Response>; status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+  const json = vi.fn().mockReturnThis()
+  const status = vi.fn().mockReturnValue({ json })
+  const res = { status, json } as unknown as Partial<Response>
+  return { res, status, json }
+}
+
+function makeNext(): NextFunction {
+  return vi.fn() as unknown as NextFunction
+}
+
+// ─── ApiScope enum ───────────────────────────────────────────────────────────
+
+describe('ApiScope enum', () => {
+  it('has all granular scope values', () => {
+    expect(ApiScope.TRUST_READ).toBe('trust:read')
+    expect(ApiScope.ATTESTATIONS_READ).toBe('attestations:read')
+    expect(ApiScope.ATTESTATIONS_WRITE).toBe('attestations:write')
+    expect(ApiScope.PAYOUTS_WRITE).toBe('payouts:write')
+    expect(ApiScope.REPORTS_GENERATE).toBe('reports:generate')
+    expect(ApiScope.EXPORTS_READ).toBe('exports:read')
+    expect(ApiScope.WEBHOOKS_ADMIN).toBe('webhooks:admin')
+    expect(ApiScope.ADMIN_READ).toBe('admin:read')
+    expect(ApiScope.ADMIN_WRITE).toBe('admin:write')
+  })
+
+  it('retains legacy backward-compat values', () => {
+    expect(ApiScope.PUBLIC).toBe('public')
+    expect(ApiScope.ENTERPRISE).toBe('enterprise')
+  })
+})
+
+// ─── SCOPE_SETS ──────────────────────────────────────────────────────────────
+
+describe('SCOPE_SETS', () => {
+  it('PUBLIC set contains only read scopes', () => {
+    const pub = SCOPE_SETS[ApiScope.PUBLIC]
+    expect(pub.has(ApiScope.TRUST_READ)).toBe(true)
+    expect(pub.has(ApiScope.ATTESTATIONS_READ)).toBe(true)
+    // must NOT contain write scopes
+    expect(pub.has(ApiScope.ATTESTATIONS_WRITE)).toBe(false)
+    expect(pub.has(ApiScope.PAYOUTS_WRITE)).toBe(false)
+    expect(pub.has(ApiScope.REPORTS_GENERATE)).toBe(false)
+    expect(pub.has(ApiScope.WEBHOOKS_ADMIN)).toBe(false)
+    expect(pub.has(ApiScope.ADMIN_READ)).toBe(false)
+    expect(pub.has(ApiScope.ADMIN_WRITE)).toBe(false)
+  })
+
+  it('ENTERPRISE set contains every granular scope', () => {
+    const ent = SCOPE_SETS[ApiScope.ENTERPRISE]
+    const granular: ApiScope[] = [
+      ApiScope.TRUST_READ,
+      ApiScope.ATTESTATIONS_READ,
+      ApiScope.ATTESTATIONS_WRITE,
+      ApiScope.PAYOUTS_WRITE,
+      ApiScope.REPORTS_GENERATE,
+      ApiScope.EXPORTS_READ,
+      ApiScope.WEBHOOKS_ADMIN,
+      ApiScope.ADMIN_READ,
+      ApiScope.ADMIN_WRITE,
+    ]
+    for (const scope of granular) {
+      expect(ent.has(scope)).toBe(true)
+    }
+  })
+})
+
+// ─── scopeSatisfies() ────────────────────────────────────────────────────────
+
+describe('scopeSatisfies()', () => {
+  describe('direct match', () => {
+    it('returns true when granted set contains the required scope', () => {
+      expect(scopeSatisfies([ApiScope.TRUST_READ], ApiScope.TRUST_READ)).toBe(true)
+      expect(scopeSatisfies([ApiScope.PAYOUTS_WRITE], ApiScope.PAYOUTS_WRITE)).toBe(true)
+    })
+
+    it('returns false when granted set does not contain the required scope', () => {
+      expect(scopeSatisfies([ApiScope.TRUST_READ], ApiScope.PAYOUTS_WRITE)).toBe(false)
+      expect(scopeSatisfies([ApiScope.ATTESTATIONS_READ], ApiScope.ATTESTATIONS_WRITE)).toBe(false)
+    })
+  })
+
+  describe('ENTERPRISE superset', () => {
+    it('ENTERPRISE scope satisfies every granular scope', () => {
+      const granular: ApiScope[] = [
+        ApiScope.TRUST_READ,
+        ApiScope.ATTESTATIONS_READ,
+        ApiScope.ATTESTATIONS_WRITE,
+        ApiScope.PAYOUTS_WRITE,
+        ApiScope.REPORTS_GENERATE,
+        ApiScope.EXPORTS_READ,
+        ApiScope.WEBHOOKS_ADMIN,
+        ApiScope.ADMIN_READ,
+        ApiScope.ADMIN_WRITE,
+      ]
+      for (const scope of granular) {
+        expect(scopeSatisfies([ApiScope.ENTERPRISE], scope)).toBe(true)
+      }
+    })
+
+    it('ENTERPRISE scope satisfies itself', () => {
+      expect(scopeSatisfies([ApiScope.ENTERPRISE], ApiScope.ENTERPRISE)).toBe(true)
+    })
+  })
+
+  describe('PUBLIC legacy expansion', () => {
+    it('PUBLIC scope satisfies trust:read', () => {
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.TRUST_READ)).toBe(true)
+    })
+
+    it('PUBLIC scope satisfies attestations:read', () => {
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.ATTESTATIONS_READ)).toBe(true)
+    })
+
+    it('PUBLIC scope does NOT satisfy write scopes', () => {
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.ATTESTATIONS_WRITE)).toBe(false)
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.PAYOUTS_WRITE)).toBe(false)
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.REPORTS_GENERATE)).toBe(false)
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.WEBHOOKS_ADMIN)).toBe(false)
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.ADMIN_READ)).toBe(false)
+      expect(scopeSatisfies([ApiScope.PUBLIC], ApiScope.ADMIN_WRITE)).toBe(false)
+    })
+  })
+
+  describe('scope subsets', () => {
+    it('a key with subset scopes is denied for out-of-scope endpoints', () => {
+      const granted = [ApiScope.TRUST_READ, ApiScope.ATTESTATIONS_READ]
+      expect(scopeSatisfies(granted, ApiScope.PAYOUTS_WRITE)).toBe(false)
+      expect(scopeSatisfies(granted, ApiScope.REPORTS_GENERATE)).toBe(false)
+    })
+
+    it('a key with multiple scopes satisfies any of them', () => {
+      const granted = [ApiScope.REPORTS_GENERATE, ApiScope.EXPORTS_READ]
+      expect(scopeSatisfies(granted, ApiScope.REPORTS_GENERATE)).toBe(true)
+      expect(scopeSatisfies(granted, ApiScope.EXPORTS_READ)).toBe(true)
+      expect(scopeSatisfies(granted, ApiScope.PAYOUTS_WRITE)).toBe(false)
+    })
+  })
+
+  describe('empty / unknown scopes', () => {
+    it('empty granted set denies everything', () => {
+      expect(scopeSatisfies([], ApiScope.TRUST_READ)).toBe(false)
+      expect(scopeSatisfies([], ApiScope.ENTERPRISE)).toBe(false)
+    })
+
+    it('unknown scope string in granted set does not satisfy a known scope', () => {
+      expect(scopeSatisfies(['unknown:scope' as ApiScope], ApiScope.TRUST_READ)).toBe(false)
+    })
+
+    it('accepts Set<ApiScope> as well as array', () => {
+      const set = new Set([ApiScope.PAYOUTS_WRITE])
+      expect(scopeSatisfies(set, ApiScope.PAYOUTS_WRITE)).toBe(true)
+      expect(scopeSatisfies(set, ApiScope.TRUST_READ)).toBe(false)
+    })
+  })
+})
+
+// ─── requireApiKey() middleware ──────────────────────────────────────────────
+
+describe('requireApiKey() middleware', () => {
+  let next: NextFunction
+
+  beforeEach(() => {
+    next = makeNext()
+  })
+
+  // ── missing key ────────────────────────────────────────────────────────────
+
+  describe('missing API key', () => {
+    it('returns 401 when no key header is present', () => {
+      const req = makeReq()
+      const { res, status, json } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(401)
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Unauthorized' }))
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when X-API-Key is empty string', () => {
+      const req = makeReq({ 'x-api-key': '' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── invalid key ────────────────────────────────────────────────────────────
+
+  describe('invalid API key', () => {
+    it('returns 401 for an unrecognised key', () => {
+      const req = makeReq({ 'x-api-key': 'not-a-real-key' })
+      const { res, status, json } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(401)
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Unauthorized', message: 'Invalid API key' }))
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 for a random string', () => {
+      const req = makeReq({ 'x-api-key': 'random-garbage-xyz' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── insufficient scope (deny-by-default) ──────────────────────────────────
+
+  describe('insufficient scope — deny-by-default', () => {
+    it('returns 403 when trust:read key is used on attestations:write endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+      const { res, status, json } = makeRes()
+      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({
+        error: 'Forbidden',
+        requiredScope: ApiScope.ATTESTATIONS_WRITE,
+      }))
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when attestations:write key is used on payouts:write endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when reports key is used on webhooks:admin endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-reports-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.WEBHOOKS_ADMIN)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when admin:read key is used on admin:write endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-admin-read-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ADMIN_WRITE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when PUBLIC key is used on payouts:write endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 when PUBLIC key is used on reports:generate endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.REPORTS_GENERATE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('response body includes grantedScopes for debugging', () => {
+      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+      const { res, json } = makeRes()
+      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+
+      expect(json).toHaveBeenCalledWith(expect.objectContaining({
+        grantedScopes: expect.arrayContaining([ApiScope.TRUST_READ]),
+      }))
+    })
+  })
+
+  // ── exact scope match ──────────────────────────────────────────────────────
+
+  describe('exact scope match — allow', () => {
+    it('trust:read key passes trust:read endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('attestations:write key passes attestations:write endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('attestations:write key also passes attestations:read endpoint (superset)', () => {
+      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ATTESTATIONS_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('payouts:write key passes payouts:write endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-payouts-write-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('reports key passes reports:generate endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-reports-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.REPORTS_GENERATE)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('reports key passes exports:read endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-reports-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.EXPORTS_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('webhooks:admin key passes webhooks:admin endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-webhooks-admin-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.WEBHOOKS_ADMIN)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('admin:write key passes admin:read endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-admin-write-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ADMIN_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('admin:write key passes admin:write endpoint', () => {
+      const req = makeReq({ 'x-api-key': 'test-admin-write-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ADMIN_WRITE)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── ENTERPRISE superset ────────────────────────────────────────────────────
+
+  describe('ENTERPRISE key — superset of all scopes', () => {
+    const enterpriseKey = 'test-enterprise-key-12345'
+
+    const allGranularScopes: ApiScope[] = [
+      ApiScope.TRUST_READ,
+      ApiScope.ATTESTATIONS_READ,
+      ApiScope.ATTESTATIONS_WRITE,
+      ApiScope.PAYOUTS_WRITE,
+      ApiScope.REPORTS_GENERATE,
+      ApiScope.EXPORTS_READ,
+      ApiScope.WEBHOOKS_ADMIN,
+      ApiScope.ADMIN_READ,
+      ApiScope.ADMIN_WRITE,
+    ]
+
+    for (const scope of allGranularScopes) {
+      it(`ENTERPRISE key satisfies ${scope}`, () => {
+        const req = makeReq({ 'x-api-key': enterpriseKey })
+        const { res, status } = makeRes()
+        requireApiKey(scope)(req as Request, res as Response, next)
+
+        expect(next).toHaveBeenCalled()
+        expect(status).not.toHaveBeenCalled()
+      })
+    }
+
+    it('ENTERPRISE key satisfies legacy ENTERPRISE scope (backward compat)', () => {
+      const req = makeReq({ 'x-api-key': enterpriseKey })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── PUBLIC key ─────────────────────────────────────────────────────────────
+
+  describe('PUBLIC key — read-only subset', () => {
+    const publicKey = 'test-public-key-67890'
+
+    it('PUBLIC key satisfies trust:read', () => {
+      const req = makeReq({ 'x-api-key': publicKey })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('PUBLIC key satisfies attestations:read', () => {
+      const req = makeReq({ 'x-api-key': publicKey })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ATTESTATIONS_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('PUBLIC key satisfies legacy PUBLIC scope', () => {
+      const req = makeReq({ 'x-api-key': publicKey })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.PUBLIC)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    const writeScopes: ApiScope[] = [
+      ApiScope.ATTESTATIONS_WRITE,
+      ApiScope.PAYOUTS_WRITE,
+      ApiScope.REPORTS_GENERATE,
+      ApiScope.EXPORTS_READ,
+      ApiScope.WEBHOOKS_ADMIN,
+      ApiScope.ADMIN_READ,
+      ApiScope.ADMIN_WRITE,
+    ]
+
+    for (const scope of writeScopes) {
+      it(`PUBLIC key is denied for ${scope}`, () => {
+        const req = makeReq({ 'x-api-key': publicKey })
+        const { res, status } = makeRes()
+        requireApiKey(scope)(req as Request, res as Response, next)
+
+        expect(status).toHaveBeenCalledWith(403)
+        expect(next).not.toHaveBeenCalled()
+      })
+    }
+  })
+
+  // ── req.apiKey metadata ────────────────────────────────────────────────────
+
+  describe('req.apiKey metadata', () => {
+    it('attaches scopes array to req.apiKey', () => {
+      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+      const { res } = makeRes()
+      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+
+      const authReq = req as AuthenticatedRequest & { apiKey: any }
+      expect(authReq.apiKey).toBeDefined()
+      expect(authReq.apiKey.scopes).toContain(ApiScope.ATTESTATIONS_READ)
+      expect(authReq.apiKey.scopes).toContain(ApiScope.ATTESTATIONS_WRITE)
+    })
+
+    it('attaches legacy scope field for backward compatibility', () => {
+      const req = makeReq({ 'x-api-key': 'test-enterprise-key-12345' })
+      const { res } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      const authReq = req as any
+      expect(authReq.apiKey.scope).toBe(ApiScope.ENTERPRISE)
+    })
+
+    it('attaches key value to req.apiKey.key', () => {
+      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+      const { res } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      const authReq = req as any
+      expect(authReq.apiKey.key).toBe('test-trust-read-key')
+    })
+  })
+
+  // ── Authorization: Bearer header ──────────────────────────────────────────
+
+  describe('Authorization: Bearer header', () => {
+    it('accepts key from Authorization: Bearer header', () => {
+      const req = makeReq({ authorization: 'Bearer test-trust-read-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('X-API-Key takes precedence over Authorization header', () => {
+      // X-API-Key has a valid key; Authorization has an invalid one
+      const req = makeReq({
+        'x-api-key': 'test-trust-read-key',
+        authorization: 'Bearer invalid-key',
+      })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 when Bearer token is invalid', () => {
+      const req = makeReq({ authorization: 'Bearer not-a-real-key' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── backward compatibility ─────────────────────────────────────────────────
+
+  describe('backward compatibility', () => {
+    it('existing test-enterprise-key-12345 still works for ENTERPRISE scope', () => {
+      const req = makeReq({ 'x-api-key': 'test-enterprise-key-12345' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('existing test-public-key-67890 still works for PUBLIC scope', () => {
+      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.PUBLIC)(req as Request, res as Response, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(status).not.toHaveBeenCalled()
+    })
+
+    it('existing enterprise key is denied for ENTERPRISE scope when using public key', () => {
+      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+      const { res, status } = makeRes()
+      requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(403)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,11 +2,96 @@ import { Request, Response, NextFunction } from 'express'
 import type { StoredApiKey } from '../services/apiKeys.js'
 
 /**
- * API key scopes for authorization
+ * Granular API key scopes for per-endpoint authorization.
+ *
+ * Scope semantics
+ * ───────────────
+ * trust:read        – Read-only access to trust scores and bond data
+ * attestations:read – Read attestations (list, count)
+ * attestations:write – Create or revoke attestations
+ * payouts:write     – Initiate payout / settlement operations
+ * reports:generate  – Trigger and poll report generation jobs
+ * exports:read      – Download report artifacts and audit-log exports
+ * webhooks:admin    – Manage webhook signing secrets (rotate / revoke)
+ * admin:read        – Read admin resources (users, audit logs, failed events)
+ * admin:write       – Mutate admin resources (assign roles, revoke keys, replay events, impersonate)
+ *
+ * Backward-compat aliases
+ * ───────────────────────
+ * PUBLIC     – alias kept for existing callers; grants trust:read + attestations:read
+ * ENTERPRISE – alias kept for existing callers; grants all scopes
  */
 export enum ApiScope {
+  // Granular scopes
+  TRUST_READ = 'trust:read',
+  ATTESTATIONS_READ = 'attestations:read',
+  ATTESTATIONS_WRITE = 'attestations:write',
+  PAYOUTS_WRITE = 'payouts:write',
+  REPORTS_GENERATE = 'reports:generate',
+  EXPORTS_READ = 'exports:read',
+  WEBHOOKS_ADMIN = 'webhooks:admin',
+  ADMIN_READ = 'admin:read',
+  ADMIN_WRITE = 'admin:write',
+
+  // Legacy aliases (backward-compatible)
   PUBLIC = 'public',
   ENTERPRISE = 'enterprise',
+}
+
+/**
+ * Scope sets granted by each legacy tier.
+ * An ENTERPRISE key implicitly holds every granular scope.
+ * A PUBLIC key holds the read-only subset.
+ */
+export const SCOPE_SETS: Record<string, ReadonlySet<ApiScope>> = {
+  [ApiScope.PUBLIC]: new Set([
+    ApiScope.TRUST_READ,
+    ApiScope.ATTESTATIONS_READ,
+  ]),
+  [ApiScope.ENTERPRISE]: new Set([
+    ApiScope.TRUST_READ,
+    ApiScope.ATTESTATIONS_READ,
+    ApiScope.ATTESTATIONS_WRITE,
+    ApiScope.PAYOUTS_WRITE,
+    ApiScope.REPORTS_GENERATE,
+    ApiScope.EXPORTS_READ,
+    ApiScope.WEBHOOKS_ADMIN,
+    ApiScope.ADMIN_READ,
+    ApiScope.ADMIN_WRITE,
+  ]),
+}
+
+/**
+ * Return true when the granted scope set satisfies the required scope.
+ *
+ * Rules (in order):
+ * 1. If grantedScopes contains the requiredScope directly → allow.
+ * 2. If grantedScopes contains ENTERPRISE → allow (superset).
+ * 3. If requiredScope is PUBLIC or TRUST_READ and grantedScopes contains PUBLIC → allow.
+ * 4. Otherwise → deny.
+ */
+export function scopeSatisfies(
+  grantedScopes: ReadonlySet<ApiScope> | ApiScope[],
+  requiredScope: ApiScope,
+): boolean {
+  const scopes: ReadonlySet<ApiScope> =
+    Array.isArray(grantedScopes) ? new Set(grantedScopes) : grantedScopes
+
+  // Direct match
+  if (scopes.has(requiredScope)) return true
+
+  // ENTERPRISE is a superset of everything
+  if (scopes.has(ApiScope.ENTERPRISE)) return true
+
+  // Expand legacy scope sets and re-check
+  for (const legacyScope of [ApiScope.PUBLIC, ApiScope.ENTERPRISE]) {
+    if (scopes.has(legacyScope)) {
+      const expanded = SCOPE_SETS[legacyScope]
+      if (expanded?.has(requiredScope)) return true
+    }
+  }
+
+  return false
 }
 
 /**
@@ -33,12 +118,25 @@ export interface AuthenticatedRequest extends Request {
 }
 
 /**
- * Mock API key store - in production, use database or secret manager
- * Format: { key: scope }
+ * Mock API key store — maps raw key → set of granted scopes.
+ *
+ * In production this is replaced by a database lookup via ApiKeyRepository.
+ * The legacy single-scope values (PUBLIC / ENTERPRISE) are preserved here so
+ * that existing test fixtures continue to work without modification.
  */
-const API_KEYS: Record<string, ApiScope> = {
-  'test-enterprise-key-12345': ApiScope.ENTERPRISE,
-  'test-public-key-67890': ApiScope.PUBLIC,
+const API_KEYS: Record<string, ApiScope[]> = {
+  // Legacy keys — kept for backward compatibility
+  'test-enterprise-key-12345': [ApiScope.ENTERPRISE],
+  'test-public-key-67890': [ApiScope.PUBLIC],
+
+  // Granular-scope test keys (used in auth.scopes.test.ts)
+  'test-trust-read-key': [ApiScope.TRUST_READ],
+  'test-attestations-write-key': [ApiScope.ATTESTATIONS_READ, ApiScope.ATTESTATIONS_WRITE],
+  'test-payouts-write-key': [ApiScope.PAYOUTS_WRITE],
+  'test-reports-key': [ApiScope.REPORTS_GENERATE, ApiScope.EXPORTS_READ],
+  'test-webhooks-admin-key': [ApiScope.WEBHOOKS_ADMIN],
+  'test-admin-read-key': [ApiScope.ADMIN_READ],
+  'test-admin-write-key': [ApiScope.ADMIN_READ, ApiScope.ADMIN_WRITE],
 }
 
 /**
@@ -71,19 +169,33 @@ export const API_KEY_TO_USER: Record<string, string> = {
 }
 
 /**
- * Middleware to validate API key and check required scope
- * 
- * @param requiredScope - Minimum scope required for the endpoint
- * @returns Express middleware function
- * 
+ * Middleware to validate API key and enforce a required scope.
+ *
+ * The middleware:
+ * 1. Reads the key from `X-API-Key` or `Authorization: Bearer` headers.
+ * 2. Looks up the granted scope set (deny-by-default when key is unknown).
+ * 3. Calls `scopeSatisfies` to check whether the granted scopes cover the
+ *    required scope — including legacy ENTERPRISE superset expansion.
+ * 4. Attaches `{ key, scopes }` to `req.apiKey` for downstream handlers.
+ *
+ * @param requiredScope - The single scope that must be satisfied.
+ *
  * @example
  * ```typescript
- * app.post('/api/bulk/verify', requireApiKey(ApiScope.ENTERPRISE), handler)
+ * router.post('/api/attestations', requireApiKey(ApiScope.ATTESTATIONS_WRITE), handler)
+ * router.get('/api/trust/:id',     requireApiKey(ApiScope.TRUST_READ),          handler)
  * ```
  */
 export function requireApiKey(requiredScope: ApiScope) {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const apiKey = req.headers['x-api-key'] as string
+    // Accept key from X-API-Key header or Authorization: Bearer <key>
+    let apiKey = req.headers['x-api-key'] as string | undefined
+    if (!apiKey) {
+      const authHeader = req.headers['authorization']
+      if (authHeader?.startsWith('Bearer ')) {
+        apiKey = authHeader.slice(7)
+      }
+    }
 
     if (!apiKey) {
       res.status(401).json({
@@ -93,9 +205,9 @@ export function requireApiKey(requiredScope: ApiScope) {
       return
     }
 
-    const scope = API_KEYS[apiKey]
+    const grantedScopes = API_KEYS[apiKey]
 
-    if (!scope) {
+    if (!grantedScopes) {
       res.status(401).json({
         error: 'Unauthorized',
         message: 'Invalid API key',
@@ -103,17 +215,29 @@ export function requireApiKey(requiredScope: ApiScope) {
       return
     }
 
-    // Check if the key has sufficient scope
-    if (requiredScope === ApiScope.ENTERPRISE && scope !== ApiScope.ENTERPRISE) {
+    // Deny-by-default: key must satisfy the required scope
+    if (!scopeSatisfies(grantedScopes, requiredScope)) {
       res.status(403).json({
         error: 'Forbidden',
-        message: 'Enterprise API key required',
+        message: `Insufficient scope: '${requiredScope}' is required`,
+        requiredScope,
+        grantedScopes,
       })
       return
     }
 
-    // Preserve legacy metadata shape expected by route tests.
-    ;(req as any).apiKey = { key: apiKey, scope }
+    // Attach metadata to request for downstream handlers.
+    // `scope` (singular) is kept for backward compatibility with existing
+    // route handlers that read `req.apiKey.scope`.
+    ;(req as any).apiKey = {
+      key: apiKey,
+      scopes: grantedScopes,
+      // Legacy single-scope field: use ENTERPRISE when the key holds it,
+      // otherwise fall back to the first granted scope.
+      scope: grantedScopes.includes(ApiScope.ENTERPRISE)
+        ? ApiScope.ENTERPRISE
+        : grantedScopes[0],
+    }
     next()
   }
 }

--- a/src/repositories/apiKeyRepository.ts
+++ b/src/repositories/apiKeyRepository.ts
@@ -20,8 +20,15 @@ import type {
  * future PostgreSQL-backed implementation satisfy this interface.
  */
 export interface ApiKeyRepository {
-  /** Create and persist a new key; returns metadata including the raw key (shown once). */
-  create(ownerId: string, scope?: KeyScope, tier?: SubscriptionTier): CreateApiKeyResult
+  /**
+   * Create and persist a new key; returns metadata including the raw key (shown once).
+   *
+   * @param ownerId  Owner identifier
+   * @param scope    Primary scope (legacy; prefer `scopes`)
+   * @param tier     Subscription tier
+   * @param scopes   Explicit list of granted scopes. When provided, overrides `scope`.
+   */
+  create(ownerId: string, scope?: KeyScope, tier?: SubscriptionTier, scopes?: string[]): CreateApiKeyResult
 
   /** Look up a key record by its opaque ID, excluding the hash. Returns null when not found. */
   findById(id: string): Omit<StoredApiKey, 'hashedKey'> | null
@@ -31,7 +38,7 @@ export interface ApiKeyRepository {
 
   /**
    * Atomically revoke the key identified by `id` and issue a replacement with
-   * identical owner, scope, and tier.
+   * identical owner, scope(s), and tier.
    *
    * @returns New key metadata (raw key included — shown once), or null if the
    *          key was not found or is already revoked.
@@ -55,8 +62,8 @@ export interface ApiKeyRepository {
  * database-backed adapter is wired in.
  */
 export class InMemoryApiKeyRepository implements ApiKeyRepository {
-  create(ownerId: string, scope: KeyScope = 'read', tier: SubscriptionTier = 'free'): CreateApiKeyResult {
-    return generateApiKey(ownerId, scope, tier)
+  create(ownerId: string, scope: KeyScope = 'read', tier: SubscriptionTier = 'free', scopes?: string[]): CreateApiKeyResult {
+    return generateApiKey(ownerId, scope, tier, scopes)
   }
 
   findById(id: string): Omit<StoredApiKey, 'hashedKey'> | null {

--- a/src/routes/admin/webhooks.ts
+++ b/src/routes/admin/webhooks.ts
@@ -2,12 +2,16 @@ import { Router, Request, Response } from 'express'
 import { WebhookService } from '../../services/webhooks/service.js'
 import { PostgresWebhookRepository } from '../../db/repositories/webhookRepository.js'
 import { pool } from '../../db/pool.js'
-import { AuthenticatedRequest, requireUserAuth, requireAdminRole } from '../../middleware/auth.js'
+import { AuthenticatedRequest, requireUserAuth, requireAdminRole, requireApiKey, ApiScope } from '../../middleware/auth.js'
 import { auditLogService } from '../../services/audit/index.js'
 
 /**
  * Create the webhook admin router.
  * Provides endpoints for rotating and revoking signing secrets with auditing.
+ *
+ * All routes require EITHER:
+ *   - A user session with admin role (requireUserAuth + requireAdminRole), OR
+ *   - An API key with the webhooks:admin scope (requireApiKey(ApiScope.WEBHOOKS_ADMIN))
  */
 export function createWebhookAdminRouter(): Router {
   const router = Router()
@@ -19,6 +23,8 @@ export function createWebhookAdminRouter(): Router {
    * 
    * Rotates the signing secret for a webhook.
    * Moves current secret to previousSecret and generates a new one.
+   *
+   * @requires webhooks:admin scope OR admin role
    */
   router.post('/:id/rotate', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
     try {
@@ -46,6 +52,8 @@ export function createWebhookAdminRouter(): Router {
    * 
    * Revokes the previous signing secret for a webhook.
    * Stops sending dual signatures.
+   *
+   * @requires webhooks:admin scope OR admin role
    */
   router.post('/:id/revoke-previous', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
     try {

--- a/src/routes/attestations.ts
+++ b/src/routes/attestations.ts
@@ -13,6 +13,7 @@ import type {
   AttestationListResponse,
 } from '../types/attestation.js';
 import { NotFoundError } from '../lib/errors.js';
+import { requireApiKey, ApiScope } from '../middleware/auth.js';
 
 /**
  * Create and return an Express {@link Router} wired to the given
@@ -25,7 +26,7 @@ export function createAttestationRouter(repo: AttestationRepository): Router {
   const router = Router();
 
   // ── GET /api/attestations/:identity/count ────────────────────────────
-  router.get('/:identity/count', (req: Request, res: Response): void => {
+  router.get('/:identity/count', requireApiKey(ApiScope.ATTESTATIONS_READ), (req: Request, res: Response): void => {
     const { identity } = req.params;
     const includeRevoked = req.query.includeRevoked === 'true';
 
@@ -41,7 +42,7 @@ export function createAttestationRouter(repo: AttestationRepository): Router {
   });
 
   // ── GET /api/attestations/:identity ──────────────────────────────────
-  router.get('/:identity', (req: Request, res: Response, next): void => {
+  router.get('/:identity', requireApiKey(ApiScope.ATTESTATIONS_READ), (req: Request, res: Response, next): void => {
     const { identity } = req.params;
     const includeRevoked = req.query.includeRevoked === 'true';
 
@@ -68,7 +69,7 @@ export function createAttestationRouter(repo: AttestationRepository): Router {
   });
 
   // ── POST /api/attestations ───────────────────────────────────────────
-  router.post('/', (req: Request, res: Response, next): void => {
+  router.post('/', requireApiKey(ApiScope.ATTESTATIONS_WRITE), (req: Request, res: Response, next): void => {
     try {
       const { subject, verifier, weight, claim } = req.body as {
         subject: string;
@@ -85,7 +86,7 @@ export function createAttestationRouter(repo: AttestationRepository): Router {
   });
 
   // ── DELETE /api/attestations/:id ─────────────────────────────────────
-  router.delete('/:id', (req: Request, res: Response, next): void => {
+  router.delete('/:id', requireApiKey(ApiScope.ATTESTATIONS_WRITE), (req: Request, res: Response, next): void => {
     try {
       const result = repo.revoke(req.params.id);
       if (!result) {

--- a/src/routes/payouts.ts
+++ b/src/routes/payouts.ts
@@ -6,6 +6,7 @@ import { validate } from '../middleware/validate.js'
 import { createPayoutSchema } from '../schemas/index.js'
 import { pool } from '../db/pool.js'
 import { SettlementsRepository } from '../db/repositories/settlementsRepository.js'
+import { requireApiKey, ApiScope } from '../middleware/auth.js'
 
 /**
  * Creates the payouts router with idempotency protection.
@@ -22,9 +23,12 @@ export function createPayoutsRouter(): Router {
    * 
    * Creates a new payout record.
    * Protected by idempotency keys to prevent duplicate payouts on retries.
+   *
+   * @requires payouts:write scope
    */
   router.post(
     '/',
+    requireApiKey(ApiScope.PAYOUTS_WRITE),
     idempotencyMiddleware(idempotencyRepo),
     validate({ body: createPayoutSchema }),
     async (req: Request, res: Response, next) => {

--- a/src/routes/report.ts
+++ b/src/routes/report.ts
@@ -22,7 +22,7 @@ interface ReportRequest {
  *
  * Starts an asynchronous report generation job
  *
- * @requires Enterprise API key via X-API-Key header
+ * @requires reports:generate scope
  *
  * @body {string} type - Type of report to generate (e.g., 'trust_score_summary')
  *
@@ -30,7 +30,7 @@ interface ReportRequest {
  */
 router.post(
   '/',
-  requireApiKey(ApiScope.ENTERPRISE),
+  requireApiKey(ApiScope.REPORTS_GENERATE),
   async (req: Request, res: Response): Promise<void> => {
     try {
       const { type } = req.body as ReportRequest
@@ -67,7 +67,7 @@ router.post(
  *
  * Gets the status of a report generation job
  *
- * @requires Enterprise API key via X-API-Key header
+ * @requires reports:generate scope
  *
  * @param {string} jobId - Unique report job ID
  *
@@ -75,7 +75,7 @@ router.post(
  */
 router.get(
   '/:jobId',
-  requireApiKey(ApiScope.ENTERPRISE),
+  requireApiKey(ApiScope.REPORTS_GENERATE),
   async (req: Request, res: Response): Promise<void> => {
     try {
       const { jobId } = req.params

--- a/src/services/apiKeys.ts
+++ b/src/services/apiKeys.ts
@@ -1,6 +1,6 @@
 import { randomBytes, createHash } from 'crypto'
 
-export type KeyScope = 'read' | 'full'
+export type KeyScope = 'read' | 'full' | string   // extended to accept granular scope strings
 export type SubscriptionTier = 'free' | 'pro' | 'enterprise'
 
 export interface StoredApiKey {
@@ -9,6 +9,17 @@ export interface StoredApiKey {
   hashedKey: string
   /** First 8 chars after the "cr_" prefix — used for fast lookup */
   prefix: string
+  /**
+   * Granted scopes for this key.
+   *
+   * Legacy keys carry a single-element array with 'read' or 'full'.
+   * Granular keys carry one or more scope strings from ApiScope.
+   *
+   * The `scope` field (singular) is kept for backward compatibility and
+   * reflects the primary / most-privileged scope in the array.
+   */
+  scopes: string[]
+  /** @deprecated Use `scopes` instead. Kept for backward compatibility. */
   scope: KeyScope
   tier: SubscriptionTier
   ownerId: string
@@ -22,7 +33,9 @@ export interface CreateApiKeyResult {
   /** Raw key — only returned once at creation/rotation. Store securely. */
   key: string
   prefix: string
+  /** @deprecated Use `scopes` instead. */
   scope: KeyScope
+  scopes: string[]
   tier: SubscriptionTier
   createdAt: Date
 }
@@ -43,25 +56,31 @@ function extractPrefix(rawKey: string): string {
  * Generate and store a new API key.
  *
  * @param ownerId  Identifier of the key owner (user/org ID)
- * @param scope    Access scope: 'read' (default) or 'full'
+ * @param scope    Primary access scope: 'read' (default) or 'full', or a granular scope string
  * @param tier     Subscription tier controlling rate limits (default: 'free')
+ * @param scopes   Optional explicit list of granted scopes. When provided, overrides `scope`.
  * @returns        Key metadata including the raw key (shown once only)
  */
 export function generateApiKey(
   ownerId: string,
   scope: KeyScope = 'read',
   tier: SubscriptionTier = 'free',
+  scopes?: string[],
 ): CreateApiKeyResult {
   const random = randomBytes(32).toString('hex') // 64 hex chars
   const rawKey = `cr_${random}` // 67 chars total
   const prefix = extractPrefix(rawKey)
   const id = randomBytes(8).toString('hex')
 
+  const grantedScopes = scopes ?? [scope]
+  const primaryScope = grantedScopes[0] as KeyScope
+
   const stored: StoredApiKey = {
     id,
     hashedKey: hashKey(rawKey),
     prefix,
-    scope,
+    scope: primaryScope,
+    scopes: grantedScopes,
     tier,
     ownerId,
     createdAt: new Date(),
@@ -70,7 +89,15 @@ export function generateApiKey(
   }
 
   store.set(id, stored)
-  return { id, key: rawKey, prefix, scope, tier, createdAt: stored.createdAt }
+  return {
+    id,
+    key: rawKey,
+    prefix,
+    scope: primaryScope,
+    scopes: grantedScopes,
+    tier,
+    createdAt: stored.createdAt,
+  }
 }
 
 /**
@@ -116,7 +143,7 @@ export function rotateApiKey(id: string): CreateApiKeyResult | null {
   if (!existing || !existing.active) return null
 
   existing.active = false
-  return generateApiKey(existing.ownerId, existing.scope, existing.tier)
+  return generateApiKey(existing.ownerId, existing.scope, existing.tier, existing.scopes)
 }
 
 /**


### PR DESCRIPTION
Closes #330

---

- Expand ApiScope enum with 9 granular scopes: trust:read, attestations:read, attestations:write, payouts:write, reports:generate, exports:read, webhooks:admin, admin:read, admin:write. Legacy PUBLIC/ENTERPRISE aliases retained for backward compatibility via SCOPE_SETS expansion.

- Add scopeSatisfies() pure helper with deny-by-default logic: direct match, ENTERPRISE superset, and legacy tier expansion.

- Rewrite requireApiKey() middleware to accept X-API-Key or Authorization: Bearer, validate against a per-key string[] scope set, and attach { key, scopes, scope } to req.apiKey.

- Apply granular scopes to routes: reports:generate  -> POST/GET /api/reports attestations:read -> GET /api/attestations/:identity[/count] attestations:write -> POST/DELETE /api/attestations
    payouts:write     -> POST /api/payouts

- Extend StoredApiKey and CreateApiKeyResult with scopes[] field; generateApiKey/rotateApiKey preserve the full scope set.

- Update ApiKeyRepository.create signature to accept scopes[].

- Add src/__tests__/auth.scopes.test.ts covering: enum values, SCOPE_SETS contents, scopeSatisfies edge cases (subsets, superset, empty/unknown scopes, Set vs array input), and requireApiKey middleware (missing key, invalid key, insufficient scope deny-by-default, exact match, ENTERPRISE superset, PUBLIC read-only enforcement, req.apiKey metadata, Bearer header, backward compat for existing enterprise keys).

- Update docs/api-keys.md with granular scope table, per-endpoint scope matrix, and updated lifecycle examples.

- Update docs/security.md with API Key Scope Model section documenting enforcement implementation and security properties.