### PR TITLE
feat(outbox): quarantine poison-pill events and expose admin reinjection

### DIFF
--- a/docs/outbox-quarantine.md
+++ b/docs/outbox-quarantine.md
@@ -1,0 +1,47 @@
+# Outbox Quarantine
+
+The outbox publisher quarantines poison-pill events before they enter retry backoff. This keeps malformed rows from consuming retry budget, polluting failure metrics, or blocking throughput for valid events.
+
+## Quarantine Reasons
+
+- `malformed_json`: the stored payload cannot be parsed as a JSON object.
+- `schema_invalid`: a queue payload with an existing runtime schema in `src/schemas/queue.ts` fails validation.
+- `oversized_payload`: the serialized payload exceeds the publisher size limit, 256 KiB by default.
+- `unknown_event_type`: the event type is not registered as a known outbox or queue event.
+
+Quarantined events are moved from `event_outbox` to `outbox_quarantine` immediately. The original retry count is preserved and is not incremented.
+
+## Operator API
+
+List active quarantine rows:
+
+```http
+GET /v1/admin/outbox/quarantine?limit=50&reason=schema_invalid
+Authorization: Bearer <admin-token>
+```
+
+Reinject after fixing the payload:
+
+```http
+POST /v1/admin/outbox/quarantine/:id/reinject
+X-API-Key: <key with outbox:reinject>
+Content-Type: application/json
+
+{
+  "payload": {
+    "id": "fixed-event-id"
+  }
+}
+```
+
+Reinjection creates a fresh `pending` outbox row with `retry_count = 0`, marks the quarantine row with `reinjected_at` and `reinjected_by`, and writes an audit log entry with action `OUTBOX_REINJECT`.
+
+## Metrics
+
+The publisher increments:
+
+```text
+outbox_quarantine_total{reason="<reason>"}
+```
+
+Alert on sustained growth by reason. `malformed_json` and `unknown_event_type` usually indicate producer or migration defects; `schema_invalid` means the payload shape needs correction before reinjection.

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import bulkRouter from './routes/bulk.js'
 import importsRouter from './routes/imports.js'
 import { createAdminRouter } from './routes/admin/index.js'
 import { createWebhookAdminRouter } from './routes/admin/webhooks.js'
+import { createOutboxAdminRouter } from './routes/admin/outbox.js'
 import { createPolicyRouter } from './routes/policy.js'
 import { createAnalyticsRouter } from './routes/analytics.js'
 import { createPayoutsRouter } from './routes/payouts.js'
@@ -76,6 +77,7 @@ app.use('/api/imports', importsRouter)
 
 app.use('/api/admin', createAdminRouter())
 app.use('/api/admin/webhooks', createWebhookAdminRouter())
+app.use('/v1/admin/outbox', createOutboxAdminRouter())
 
 app.use('/api/orgs/:orgId/policies', createPolicyRouter())
 

--- a/src/db/outbox/publisher.test.ts
+++ b/src/db/outbox/publisher.test.ts
@@ -1,0 +1,188 @@
+import { newDb } from 'pg-mem'
+import { Pool } from 'pg'
+import { OutboxPublisher } from './publisher'
+import { OutboxRepository } from './repository'
+import type { OutboxEvent } from './types'
+
+async function buildTestPool(): Promise<Pool> {
+  const db = newDb()
+  const adapter = db.adapters.createPg()
+  const pool = new adapter.Pool() as unknown as Pool
+
+  await pool.query(`
+    CREATE TABLE event_outbox (
+      id BIGSERIAL PRIMARY KEY,
+      aggregate_type TEXT NOT NULL,
+      aggregate_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      status TEXT NOT NULL,
+      retry_count INTEGER NOT NULL DEFAULT 0,
+      max_retries INTEGER NOT NULL DEFAULT 5,
+      consumer_id TEXT,
+      lease_expires_at TIMESTAMPTZ,
+      next_attempt_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      processed_at TIMESTAMPTZ,
+      error_message TEXT
+    )
+  `)
+
+  await pool.query(`
+    CREATE TABLE outbox_quarantine (
+      id BIGSERIAL PRIMARY KEY,
+      original_event_id BIGINT NOT NULL UNIQUE,
+      aggregate_type TEXT NOT NULL,
+      aggregate_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload TEXT,
+      reason TEXT NOT NULL,
+      error_message TEXT NOT NULL,
+      retry_count INTEGER NOT NULL DEFAULT 0,
+      max_retries INTEGER NOT NULL DEFAULT 5,
+      quarantined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      reinjected_at TIMESTAMPTZ,
+      reinjected_by TEXT
+    )
+  `)
+
+  return pool
+}
+
+function baseEvent(overrides: Partial<OutboxEvent> = {}): OutboxEvent {
+  return {
+    id: 1n,
+    aggregateType: 'bond',
+    aggregateId: 'bond-1',
+    eventType: 'bond.created',
+    payload: { id: 'bond-1' },
+    rawPayload: JSON.stringify({ id: 'bond-1' }),
+    status: 'processing',
+    retryCount: 0,
+    maxRetries: 5,
+    consumerId: 'consumer',
+    leaseExpiresAt: new Date(),
+    createdAt: new Date(),
+    processedAt: null,
+    errorMessage: null,
+    ...overrides,
+  }
+}
+
+function detect(event: OutboxEvent, maxPayloadBytes = 1024) {
+  const publisher = new OutboxPublisher(
+    { publish: async () => undefined },
+    { maxPayloadBytes }
+  )
+  return (publisher as any).detectPoisonPill(event)
+}
+
+describe('OutboxPublisher poison-pill detection', () => {
+  it('detects malformed JSON before publish attempts', () => {
+    const result = detect(baseEvent({ payloadParseError: 'Unexpected token' }))
+    expect(result).toEqual({ reason: 'malformed_json', message: 'Unexpected token' })
+  })
+
+  it('detects oversized payloads before retrying', () => {
+    const result = detect(
+      baseEvent({
+        rawPayload: JSON.stringify({ body: 'x'.repeat(64) }),
+      }),
+      16
+    )
+
+    expect(result?.reason).toBe('oversized_payload')
+  })
+
+  it('detects unknown event types as poison pills', () => {
+    const result = detect(baseEvent({ eventType: 'not.registered' }))
+    expect(result?.reason).toBe('unknown_event_type')
+  })
+
+  it('detects schema-invalid queue payloads', () => {
+    const result = detect(
+      baseEvent({
+        eventType: 'bond.creation',
+        payload: { type: 'create_bond', amount: -1 },
+        rawPayload: JSON.stringify({ type: 'create_bond', amount: -1 }),
+      })
+    )
+
+    expect(result?.reason).toBe('schema_invalid')
+    expect(result?.message).toContain('id')
+  })
+
+  it('allows structurally valid known webhook events', () => {
+    expect(detect(baseEvent())).toBeNull()
+  })
+})
+
+describe('OutboxRepository quarantine handling', () => {
+  let pool: Pool
+  let repo: OutboxRepository
+
+  beforeEach(async () => {
+    pool = await buildTestPool()
+    repo = new OutboxRepository()
+  })
+
+  afterEach(async () => {
+    await pool.end()
+  })
+
+  it('moves malformed rows to quarantine without incrementing retry_count', async () => {
+    const insert = await pool.query(
+      `INSERT INTO event_outbox (aggregate_type, aggregate_id, event_type, payload, status, retry_count, max_retries)
+       VALUES ($1, $2, $3, $4, 'pending', 0, 5)
+       RETURNING id`,
+      ['bond', 'bond-1', 'bond.created', '{bad-json']
+    )
+
+    const [event] = await repo.claimEvents(pool, 'consumer-1', 10, 60)
+    expect(event.id).toBe(BigInt(insert.rows[0].id))
+    expect(event.payloadParseError).toBeTruthy()
+
+    await repo.quarantine(pool, event, 'malformed_json', event.payloadParseError!)
+
+    const outbox = await pool.query('SELECT COUNT(*)::int AS count FROM event_outbox')
+    const quarantine = await pool.query('SELECT reason, retry_count, payload FROM outbox_quarantine')
+
+    expect(outbox.rows[0].count).toBe(0)
+    expect(quarantine.rows[0].reason).toBe('malformed_json')
+    expect(Number(quarantine.rows[0].retry_count)).toBe(0)
+    expect(quarantine.rows[0].payload).toBe('{bad-json')
+  })
+
+  it('reinserts a fixed quarantined event and marks the quarantine row', async () => {
+    const quarantine = await pool.query(
+      `INSERT INTO outbox_quarantine (
+        original_event_id, aggregate_type, aggregate_id, event_type, payload,
+        reason, error_message, retry_count, max_retries
+      )
+      VALUES (10, 'bond', 'bond-1', 'bond.created', '{bad-json', 'malformed_json', 'bad', 0, 5)
+      RETURNING id`
+    )
+
+    const newId = await repo.reinjectQuarantined(
+      pool,
+      BigInt(quarantine.rows[0].id),
+      { id: 'bond-1' },
+      'operator'
+    )
+
+    expect(newId).not.toBeNull()
+
+    const outbox = await pool.query('SELECT payload, status, retry_count FROM event_outbox WHERE id = $1', [
+      newId!.toString(),
+    ])
+    const marked = await pool.query('SELECT reinjected_by, reinjected_at FROM outbox_quarantine WHERE id = $1', [
+      quarantine.rows[0].id,
+    ])
+
+    expect(JSON.parse(outbox.rows[0].payload)).toEqual({ id: 'bond-1' })
+    expect(outbox.rows[0].status).toBe('pending')
+    expect(Number(outbox.rows[0].retry_count)).toBe(0)
+    expect(marked.rows[0].reinjected_by).toBe('operator')
+    expect(marked.rows[0].reinjected_at).not.toBeNull()
+  })
+})

--- a/src/db/outbox/publisher.ts
+++ b/src/db/outbox/publisher.ts
@@ -1,11 +1,17 @@
 import { pool } from '../pool.js'
 import { OutboxRepository } from './repository.js'
-import type { OutboxEvent, OutboxCleanupConfig } from './types.js'
+import type { OutboxEvent, OutboxCleanupConfig, OutboxQuarantineReason } from './types.js'
 import { randomUUID } from 'crypto'
+import type { ZodType } from 'zod'
 import {
   recordOutboxPublisherHeartbeat,
   setOutboxPublisherRunning,
 } from '../../services/health/runtimeState.js'
+import {
+  attestationEventSchema,
+  bondCreationEventSchema,
+  withdrawalEventSchema,
+} from '../../schemas/queue.js'
 import { logger } from '../../utils/logger.js'
 import {
   incrementOutboxDeadLetter,
@@ -13,6 +19,7 @@ import {
   incrementOutboxFailed,
   setOutboxPendingGauge,
   incrementOutboxLeaseRenew,
+  incrementOutboxQuarantine,
 } from '../../observability/index.js'
 
 /**
@@ -40,6 +47,8 @@ export interface OutboxPublisherConfig {
   heartbeatIntervalMs?: number
   /** Metrics scrape interval in milliseconds. Default: 15000 */
   metricsIntervalMs?: number
+  /** Maximum serialized payload size accepted by the publisher. Default: 262144 (256 KiB) */
+  maxPayloadBytes?: number
 }
 
 const DEFAULT_CONFIG: OutboxPublisherConfig = {
@@ -51,6 +60,31 @@ const DEFAULT_CONFIG: OutboxPublisherConfig = {
   },
   cleanupIntervalMs: 3600000,
   metricsIntervalMs: 15000,
+  maxPayloadBytes: 262144,
+}
+
+const QUEUE_EVENT_SCHEMAS: Record<string, ZodType> = {
+  'attestation.event': attestationEventSchema,
+  'attestation.add': attestationEventSchema,
+  'attestation.revoke': attestationEventSchema,
+  'bond.creation': bondCreationEventSchema,
+  'bond.create': bondCreationEventSchema,
+  'withdrawal.event': withdrawalEventSchema,
+  'bond.withdrawal': withdrawalEventSchema,
+}
+
+const KNOWN_OUTBOX_EVENT_TYPES = new Set([
+  'bond.created',
+  'bond.slashed',
+  'bond.withdrawn',
+  'attestation.created',
+  'attestation.revoked',
+  ...Object.keys(QUEUE_EVENT_SCHEMAS),
+])
+
+interface PoisonPillDetection {
+  reason: OutboxQuarantineReason
+  message: string
 }
 
 /**
@@ -246,6 +280,12 @@ export class OutboxPublisher {
    * Process a single event with error handling and retry logic.
    */
   private async processEvent(event: OutboxEvent): Promise<void> {
+    const poison = this.detectPoisonPill(event)
+    if (poison) {
+      await this.quarantineEvent(event, poison.reason, poison.message)
+      return
+    }
+
     try {
       await this.publisher.publish(event)
       await this.repository.markPublished(pool, event.id)
@@ -272,6 +312,67 @@ export class OutboxPublisher {
       } catch (err) {
         logger.error('[OutboxPublisher] Error marking event failed', err)
       }
+    }
+  }
+
+  private detectPoisonPill(event: OutboxEvent): PoisonPillDetection | null {
+    if (event.payloadParseError) {
+      return {
+        reason: 'malformed_json',
+        message: event.payloadParseError,
+      }
+    }
+
+    const serializedPayload = event.rawPayload ?? JSON.stringify(event.payload)
+    if (Buffer.byteLength(serializedPayload, 'utf8') > (this.config.maxPayloadBytes ?? DEFAULT_CONFIG.maxPayloadBytes!)) {
+      return {
+        reason: 'oversized_payload',
+        message: `Payload exceeds ${this.config.maxPayloadBytes ?? DEFAULT_CONFIG.maxPayloadBytes} bytes`,
+      }
+    }
+
+    if (!KNOWN_OUTBOX_EVENT_TYPES.has(event.eventType)) {
+      return {
+        reason: 'unknown_event_type',
+        message: `Unknown outbox event type: ${event.eventType}`,
+      }
+    }
+
+    const schema = QUEUE_EVENT_SCHEMAS[event.eventType]
+    if (!schema) {
+      return null
+    }
+
+    const result = schema.safeParse(event.payload)
+    if (!result.success) {
+      return {
+        reason: 'schema_invalid',
+        message: result.error.issues
+          .map(issue => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+          .join('; ')
+          .slice(0, 2000),
+      }
+    }
+
+    return null
+  }
+
+  private async quarantineEvent(
+    event: OutboxEvent,
+    reason: OutboxQuarantineReason,
+    message: string
+  ): Promise<void> {
+    try {
+      await this.repository.quarantine(pool, event, reason, message)
+      incrementOutboxQuarantine(reason)
+      logger.warn({
+        message: `[OutboxPublisher] Event ${event.id} quarantined`,
+        eventType: event.eventType,
+        reason,
+        error: message,
+      })
+    } catch (error) {
+      logger.error('[OutboxPublisher] Error quarantining event', error)
     }
   }
 

--- a/src/db/outbox/repository.ts
+++ b/src/db/outbox/repository.ts
@@ -1,5 +1,105 @@
 import type { Queryable } from '../repositories/queryable.js'
-import type { OutboxEvent, CreateOutboxEvent, OutboxEventStatus, OutboxCleanupConfig } from './types.js'
+import type {
+  OutboxEvent,
+  CreateOutboxEvent,
+  OutboxEventStatus,
+  OutboxCleanupConfig,
+  OutboxQuarantineEntry,
+  OutboxQuarantineReason,
+} from './types.js'
+
+type OutboxEventRow = {
+  id: string
+  aggregate_type: string
+  aggregate_id: string
+  event_type: string
+  payload: string | Record<string, unknown>
+  status: OutboxEventStatus
+  retry_count: number
+  max_retries: number
+  created_at: string
+  processed_at: string | null
+  error_message: string | null
+  consumer_id?: string | null
+  lease_expires_at?: string | null
+}
+
+type OutboxQuarantineRow = {
+  id: string
+  original_event_id: string
+  aggregate_type: string
+  aggregate_id: string
+  event_type: string
+  payload: string | Record<string, unknown> | null
+  reason: OutboxQuarantineReason
+  error_message: string
+  retry_count: number
+  max_retries: number
+  quarantined_at: string
+  reinjected_at: string | null
+  reinjected_by: string | null
+}
+
+function mapOutboxEvent(row: OutboxEventRow): OutboxEvent {
+  let payload: Record<string, unknown> = {}
+  let rawPayload: string | undefined
+  let payloadParseError: string | undefined
+
+  if (typeof row.payload === 'string') {
+    rawPayload = row.payload
+    try {
+      const parsed = JSON.parse(row.payload) as unknown
+      payload =
+        parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : {}
+      if (payload !== parsed) {
+        payloadParseError = 'Payload JSON must be an object'
+      }
+    } catch (error) {
+      payloadParseError = error instanceof Error ? error.message : String(error)
+    }
+  } else {
+    payload = row.payload
+    rawPayload = JSON.stringify(row.payload)
+  }
+
+  return {
+    id: BigInt(row.id),
+    aggregateType: row.aggregate_type,
+    aggregateId: row.aggregate_id,
+    eventType: row.event_type,
+    payload,
+    rawPayload,
+    payloadParseError,
+    status: row.status,
+    retryCount: row.retry_count,
+    maxRetries: row.max_retries,
+    consumerId: row.consumer_id,
+    leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : null,
+    createdAt: new Date(row.created_at),
+    processedAt: row.processed_at ? new Date(row.processed_at) : null,
+    errorMessage: row.error_message,
+  }
+}
+
+function mapQuarantineEntry(row: OutboxQuarantineRow): OutboxQuarantineEntry {
+  return {
+    id: BigInt(row.id),
+    originalEventId: BigInt(row.original_event_id),
+    aggregateType: row.aggregate_type,
+    aggregateId: row.aggregate_id,
+    eventType: row.event_type,
+    payload: row.payload,
+    reason: row.reason,
+    errorMessage: row.error_message,
+    retryCount: row.retry_count,
+    maxRetries: row.max_retries,
+    quarantinedAt: new Date(row.quarantined_at),
+    reinjectedAt: row.reinjected_at ? new Date(row.reinjected_at) : null,
+    reinjectedBy: row.reinjected_by,
+  }
+}
 
 /**
  * Repository for transactional outbox events.
@@ -78,21 +178,7 @@ export class OutboxRepository {
         [limit, consumerId, leaseSeconds.toString()]
       )
 
-      return result.rows.map(row => ({
-        id: BigInt(row.id),
-        aggregateType: row.aggregate_type,
-        aggregateId: row.aggregate_id,
-        eventType: row.event_type,
-        payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
-        status: row.status,
-        retryCount: row.retry_count,
-        maxRetries: row.max_retries,
-        consumerId: row.consumer_id,
-        leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : null,
-        createdAt: new Date(row.created_at),
-        processedAt: row.processed_at ? new Date(row.processed_at) : null,
-        errorMessage: row.error_message,
-      }))
+      return result.rows.map(mapOutboxEvent)
     } catch (error) {
       // Fallback for pg-mem (doesn't support SKIP LOCKED)
       const result = await db.query<{
@@ -127,21 +213,7 @@ export class OutboxRepository {
         [limit, consumerId, leaseSeconds.toString()]
       )
 
-      return result.rows.map(row => ({
-        id: BigInt(row.id),
-        aggregateType: row.aggregate_type,
-        aggregateId: row.aggregate_id,
-        eventType: row.event_type,
-        payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
-        status: row.status,
-        retryCount: row.retry_count,
-        maxRetries: row.max_retries,
-        consumerId: row.consumer_id,
-        leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : null,
-        createdAt: new Date(row.created_at),
-        processedAt: row.processed_at ? new Date(row.processed_at) : null,
-        errorMessage: row.error_message,
-      }))
+      return result.rows.map(mapOutboxEvent)
     }
   }
 
@@ -217,21 +289,7 @@ export class OutboxRepository {
       [consumerId, limit]
     )
 
-    return result.rows.map(row => ({
-      id: BigInt(row.id),
-      aggregateType: row.aggregate_type,
-      aggregateId: row.aggregate_id,
-      eventType: row.event_type,
-      payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
-      status: row.status,
-      retryCount: row.retry_count,
-      maxRetries: row.max_retries,
-      consumerId: row.consumer_id,
-      leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : null,
-      createdAt: new Date(row.created_at),
-      processedAt: row.processed_at ? new Date(row.processed_at) : null,
-      errorMessage: row.error_message,
-    }))
+    return result.rows.map(mapOutboxEvent)
   }
 
   /**
@@ -268,19 +326,7 @@ export class OutboxRepository {
         [limit]
       )
 
-      return result.rows.map(row => ({
-        id: BigInt(row.id),
-        aggregateType: row.aggregate_type,
-        aggregateId: row.aggregate_id,
-        eventType: row.event_type,
-        payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
-        status: row.status,
-        retryCount: row.retry_count,
-        maxRetries: row.max_retries,
-        createdAt: new Date(row.created_at),
-        processedAt: row.processed_at ? new Date(row.processed_at) : null,
-        errorMessage: row.error_message,
-      }))
+      return result.rows.map(mapOutboxEvent)
     } catch (error) {
       // Fallback for pg-mem
       const result = await db.query<{
@@ -309,19 +355,7 @@ export class OutboxRepository {
         [limit]
       )
 
-      return result.rows.map(row => ({
-        id: BigInt(row.id),
-        aggregateType: row.aggregate_type,
-        aggregateId: row.aggregate_id,
-        eventType: row.event_type,
-        payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
-        status: row.status,
-        retryCount: row.retry_count,
-        maxRetries: row.max_retries,
-        createdAt: new Date(row.created_at),
-        processedAt: row.processed_at ? new Date(row.processed_at) : null,
-        errorMessage: row.error_message,
-      }))
+      return result.rows.map(mapOutboxEvent)
     }
   }
 
@@ -412,21 +446,113 @@ export class OutboxRepository {
       [aggregateType, aggregateId, limit]
     )
 
-    return result.rows.map(row => ({
-      id: BigInt(row.id),
-      aggregateType: row.aggregate_type,
-      aggregateId: row.aggregate_id,
-      eventType: row.event_type,
-      payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
-      status: row.status,
-      retryCount: row.retry_count,
-      maxRetries: row.max_retries,
-      consumerId: row.consumer_id,
-      leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : null,
-      createdAt: new Date(row.created_at),
-      processedAt: row.processed_at ? new Date(row.processed_at) : null,
-      errorMessage: row.error_message,
-    }))
+    return result.rows.map(mapOutboxEvent)
+  }
+
+  async quarantine(
+    db: Queryable,
+    event: OutboxEvent,
+    reason: OutboxQuarantineReason,
+    errorMessage: string
+  ): Promise<void> {
+    await db.query(
+      `WITH deleted AS (
+         DELETE FROM event_outbox
+         WHERE id = $1
+         RETURNING id, aggregate_type, aggregate_id, event_type, payload, retry_count, max_retries
+       )
+       INSERT INTO outbox_quarantine (
+         original_event_id,
+         aggregate_type,
+         aggregate_id,
+         event_type,
+         payload,
+         reason,
+         error_message,
+         retry_count,
+         max_retries
+       )
+       SELECT id, aggregate_type, aggregate_id, event_type, payload::text, $2, $3, retry_count, max_retries
+       FROM deleted
+       ON CONFLICT (original_event_id) DO NOTHING`,
+      [event.id.toString(), reason, errorMessage]
+    )
+  }
+
+  async listQuarantine(
+    db: Queryable,
+    limit: number,
+    offset: number,
+    reason?: OutboxQuarantineReason
+  ): Promise<{ entries: OutboxQuarantineEntry[]; total: number }> {
+    const params: unknown[] = []
+    const where: string[] = ['reinjected_at IS NULL']
+    if (reason) {
+      params.push(reason)
+      where.push(`reason = $${params.length}`)
+    }
+
+    params.push(limit)
+    const limitIdx = params.length
+    params.push(offset)
+    const offsetIdx = params.length
+    const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''
+
+    const result = await db.query<OutboxQuarantineRow & { total_count: string }>(
+      `SELECT id, original_event_id, aggregate_type, aggregate_id, event_type, payload,
+              reason, error_message, retry_count, max_retries, quarantined_at,
+              reinjected_at, reinjected_by, COUNT(*) OVER() AS total_count
+       FROM outbox_quarantine
+       ${whereSql}
+       ORDER BY quarantined_at DESC, id DESC
+       LIMIT $${limitIdx} OFFSET $${offsetIdx}`,
+      params
+    )
+
+    return {
+      entries: result.rows.map(mapQuarantineEntry),
+      total: Number(result.rows[0]?.total_count ?? 0),
+    }
+  }
+
+  async reinjectQuarantined(
+    db: Queryable,
+    quarantineId: bigint,
+    fixedPayload: Record<string, unknown>,
+    reinjectedBy: string
+  ): Promise<bigint | null> {
+    const result = await db.query<{ id: string }>(
+      `WITH source AS (
+         SELECT *
+         FROM outbox_quarantine
+         WHERE id = $1 AND reinjected_at IS NULL
+         FOR UPDATE
+       ),
+       inserted AS (
+         INSERT INTO event_outbox (
+           aggregate_type,
+           aggregate_id,
+           event_type,
+           payload,
+           status,
+           retry_count,
+           max_retries
+         )
+         SELECT aggregate_type, aggregate_id, event_type, $2, 'pending', 0, max_retries
+         FROM source
+         RETURNING id
+       ),
+       marked AS (
+         UPDATE outbox_quarantine
+         SET reinjected_at = NOW(), reinjected_by = $3
+         WHERE id = $1 AND EXISTS (SELECT 1 FROM inserted)
+       )
+       SELECT id FROM inserted`,
+      [quarantineId.toString(), JSON.stringify(fixedPayload), reinjectedBy]
+    )
+
+    const id = result.rows[0]?.id
+    return id ? BigInt(id) : null
   }
 
   /**

--- a/src/db/outbox/types.ts
+++ b/src/db/outbox/types.ts
@@ -7,6 +7,8 @@ export interface OutboxEvent {
   aggregateId: string
   eventType: string
   payload: Record<string, unknown>
+  rawPayload?: string
+  payloadParseError?: string
   status: OutboxEventStatus
   retryCount: number
   maxRetries: number
@@ -18,6 +20,28 @@ export interface OutboxEvent {
 }
 
 export type OutboxEventStatus = 'pending' | 'processing' | 'published' | 'failed' | 'dead_letter'
+
+export type OutboxQuarantineReason =
+  | 'malformed_json'
+  | 'schema_invalid'
+  | 'oversized_payload'
+  | 'unknown_event_type'
+
+export interface OutboxQuarantineEntry {
+  id: bigint
+  originalEventId: bigint
+  aggregateType: string
+  aggregateId: string
+  eventType: string
+  payload: Record<string, unknown> | string | null
+  reason: OutboxQuarantineReason
+  errorMessage: string
+  retryCount: number
+  maxRetries: number
+  quarantinedAt: Date
+  reinjectedAt: Date | null
+  reinjectedBy: string | null
+}
 
 /**
  * Input for creating a new outbox event.

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -16,6 +16,7 @@ import { requireApiKey as requireApiKeyFromApiKeyMiddleware } from './apiKey.js'
  * reports:generate  – Trigger and poll report generation jobs
  * exports:read      – Download report artifacts and audit-log exports
  * webhooks:admin    – Manage webhook signing secrets (rotate / revoke)
+ * outbox:reinject   – Reinsert fixed quarantined outbox events
  * admin:read        – Read admin resources (users, audit logs, failed events)
  * admin:write       – Mutate admin resources (assign roles, revoke keys, replay events, impersonate)
  *
@@ -33,6 +34,7 @@ export enum ApiScope {
   REPORTS_GENERATE = 'reports:generate',
   EXPORTS_READ = 'exports:read',
   WEBHOOKS_ADMIN = 'webhooks:admin',
+  OUTBOX_REINJECT = 'outbox:reinject',
   ADMIN_READ = 'admin:read',
   ADMIN_WRITE = 'admin:write',
 
@@ -59,6 +61,7 @@ export const SCOPE_SETS: Record<string, ReadonlySet<ApiScope>> = {
     ApiScope.REPORTS_GENERATE,
     ApiScope.EXPORTS_READ,
     ApiScope.WEBHOOKS_ADMIN,
+    ApiScope.OUTBOX_REINJECT,
     ApiScope.ADMIN_READ,
     ApiScope.ADMIN_WRITE,
   ]),
@@ -138,6 +141,7 @@ const API_KEYS: Record<string, ApiScope[]> = {
   'test-payouts-write-key': [ApiScope.PAYOUTS_WRITE],
   'test-reports-key': [ApiScope.REPORTS_GENERATE, ApiScope.EXPORTS_READ],
   'test-webhooks-admin-key': [ApiScope.WEBHOOKS_ADMIN],
+  'test-outbox-reinject-key': [ApiScope.OUTBOX_REINJECT],
   'test-admin-read-key': [ApiScope.ADMIN_READ],
   'test-admin-write-key': [ApiScope.ADMIN_READ, ApiScope.ADMIN_WRITE],
 }

--- a/src/migrations/008_create_outbox_quarantine.ts
+++ b/src/migrations/008_create_outbox_quarantine.ts
@@ -1,0 +1,31 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('outbox_quarantine', {
+    id: { type: 'bigserial', primaryKey: true },
+    original_event_id: { type: 'bigint', notNull: true, unique: true },
+    aggregate_type: { type: 'text', notNull: true },
+    aggregate_id: { type: 'text', notNull: true },
+    event_type: { type: 'text', notNull: true },
+    payload: { type: 'text' },
+    reason: { type: 'text', notNull: true },
+    error_message: { type: 'text', notNull: true },
+    retry_count: { type: 'integer', notNull: true, default: 0 },
+    max_retries: { type: 'integer', notNull: true, default: 5 },
+    quarantined_at: { type: 'timestamptz', notNull: true, default: pgm.func('now()') },
+    reinjected_at: { type: 'timestamptz' },
+    reinjected_by: { type: 'text' },
+  })
+
+  pgm.addConstraint(
+    'outbox_quarantine',
+    'outbox_quarantine_reason_check',
+    "CHECK (reason IN ('malformed_json', 'schema_invalid', 'oversized_payload', 'unknown_event_type'))"
+  )
+  pgm.createIndex('outbox_quarantine', ['reason', 'quarantined_at'])
+  pgm.createIndex('outbox_quarantine', ['reinjected_at', 'quarantined_at'])
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('outbox_quarantine')
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -23,3 +23,11 @@ export {
 } from './timeoutMetrics.js'
 
 export { registerPoolMetrics } from './poolMetrics.js'
+export {
+  incrementOutboxDeadLetter,
+  incrementOutboxPublished,
+  incrementOutboxFailed,
+  setOutboxPendingGauge,
+  incrementOutboxLeaseRenew,
+  incrementOutboxQuarantine,
+} from './outboxMetrics.js'

--- a/src/observability/outboxMetrics.test.ts
+++ b/src/observability/outboxMetrics.test.ts
@@ -5,6 +5,7 @@ import {
   incrementOutboxFailed,
   setOutboxPendingGauge,
   incrementOutboxLeaseRenew,
+  incrementOutboxQuarantine,
   _resetOutboxMetricsCacheForTests,
 } from './outboxMetrics.js'
 import promClient from 'prom-client'
@@ -66,5 +67,13 @@ describe('Outbox Metrics (#329)', () => {
     const metrics = await promClient.register.getMetricsAsJSON()
     const metric = metrics.find(m => m.name === 'outbox_lease_renew_total')
     expect(metric?.values[0].value).toBe(5)
+  })
+
+  it('updates outbox_quarantine_total correctly', async () => {
+    incrementOutboxQuarantine('schema_invalid')
+    const metrics = await promClient.register.getMetricsAsJSON()
+    const metric = metrics.find(m => m.name === 'outbox_quarantine_total')
+    expect(metric?.values[0].value).toBe(1)
+    expect(metric?.values[0].labels).toEqual({ reason: 'schema_invalid' })
   })
 })

--- a/src/observability/outboxMetrics.ts
+++ b/src/observability/outboxMetrics.ts
@@ -18,6 +18,7 @@ let _publishedCounter: any | undefined = undefined
 let _failedCounter: any | undefined = undefined
 let _pendingGauge: any | undefined = undefined
 let _leaseRenewCounter: any | undefined = undefined
+let _quarantineCounter: any | undefined = undefined
 
 function getMetric(name: string, type: 'Counter' | 'Gauge', help: string, labelNames: string[] = []) {
     const prom = tryLoadPromClient()
@@ -81,6 +82,15 @@ export function incrementOutboxLeaseRenew(count: number = 1) {
     }
 }
 
+export function incrementOutboxQuarantine(reason: string = 'unknown') {
+    if (!_quarantineCounter) {
+        _quarantineCounter = getMetric('outbox_quarantine_total', 'Counter', 'Total number of outbox events moved to quarantine', ['reason'])
+    }
+    if (_quarantineCounter) {
+        try { _quarantineCounter.inc({ reason }, 1) } catch {}
+    }
+}
+
 export function _resetOutboxMetricsCacheForTests(): void {
     const prom = tryLoadPromClient()
     if (prom) {
@@ -92,4 +102,5 @@ export function _resetOutboxMetricsCacheForTests(): void {
     _failedCounter = undefined
     _pendingGauge = undefined
     _leaseRenewCounter = undefined
+    _quarantineCounter = undefined
 }

--- a/src/routes/admin/outbox.ts
+++ b/src/routes/admin/outbox.ts
@@ -1,0 +1,132 @@
+import { Router, Request, Response, NextFunction } from 'express'
+import { pool } from '../../db/pool.js'
+import { OutboxRepository } from '../../db/outbox/repository.js'
+import type { OutboxQuarantineEntry, OutboxQuarantineReason } from '../../db/outbox/types.js'
+import { buildPaginationMeta, parsePaginationParams } from '../../lib/pagination.js'
+import {
+  ApiScope,
+  AuthenticatedRequest,
+  requireAdminRole,
+  requireApiKey,
+  requireUserAuth,
+} from '../../middleware/auth.js'
+import { auditLogService } from '../../services/audit/index.js'
+
+const quarantineReasons = new Set<OutboxQuarantineReason>([
+  'malformed_json',
+  'schema_invalid',
+  'oversized_payload',
+  'unknown_event_type',
+])
+
+function serializeBigInt(value: bigint): string {
+  return value.toString()
+}
+
+function serializeEntry(entry: OutboxQuarantineEntry) {
+  return {
+    id: serializeBigInt(entry.id),
+    originalEventId: serializeBigInt(entry.originalEventId),
+    aggregateType: entry.aggregateType,
+    aggregateId: entry.aggregateId,
+    eventType: entry.eventType,
+    payload: entry.payload,
+    reason: entry.reason,
+    errorMessage: entry.errorMessage,
+    retryCount: entry.retryCount,
+    maxRetries: entry.maxRetries,
+    quarantinedAt: entry.quarantinedAt.toISOString(),
+    reinjectedAt: entry.reinjectedAt?.toISOString() ?? null,
+    reinjectedBy: entry.reinjectedBy,
+  }
+}
+
+export function createOutboxAdminRouter(repository = new OutboxRepository()): Router {
+  const router = Router()
+
+  router.get(
+    '/quarantine',
+    requireUserAuth,
+    requireAdminRole,
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { page, limit, offset } = parsePaginationParams(req.query as Record<string, unknown>, {
+          defaultLimit: 50,
+        })
+        const reason = typeof req.query.reason === 'string' ? req.query.reason : undefined
+        if (reason && !quarantineReasons.has(reason as OutboxQuarantineReason)) {
+          res.status(400).json({ error: 'InvalidReason', message: `Unsupported quarantine reason: ${reason}` })
+          return
+        }
+
+        const { entries, total } = await repository.listQuarantine(
+          pool,
+          limit,
+          offset,
+          reason as OutboxQuarantineReason | undefined
+        )
+
+        res.status(200).json({
+          success: true,
+          data: entries.map(serializeEntry),
+          ...buildPaginationMeta(total, page, limit),
+        })
+      } catch (error) {
+        next(error)
+      }
+    }
+  )
+
+  router.post(
+    '/quarantine/:id/reinject',
+    requireApiKey(ApiScope.OUTBOX_REINJECT),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const id = BigInt(req.params.id)
+        const payload = req.body?.payload
+        if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+          res.status(400).json({ error: 'InvalidPayload', message: 'payload must be a JSON object' })
+          return
+        }
+
+        const apiKey = (req as AuthenticatedRequest).apiKey as { key?: string } | undefined
+        const actorId = apiKey?.key ?? 'api-key'
+        const actorEmail = 'api-key@credence.local'
+        const tenantId = 'system'
+
+        const newEventId = await repository.reinjectQuarantined(pool, id, payload as Record<string, unknown>, actorId)
+        if (!newEventId) {
+          res.status(404).json({ error: 'NotFound', message: 'Quarantined event not found or already reinjected' })
+          return
+        }
+
+        await auditLogService.logAction({
+          tenantId,
+          actorId,
+          actorEmail,
+          action: 'OUTBOX_REINJECT',
+          resourceType: 'outbox_quarantine',
+          resourceId: id.toString(),
+          details: {
+            quarantineId: id.toString(),
+            newOutboxEventId: newEventId.toString(),
+          },
+          status: 'success',
+          ipAddress: req.ip,
+        })
+
+        res.status(201).json({
+          success: true,
+          data: {
+            id: newEventId.toString(),
+            quarantineId: id.toString(),
+          },
+        })
+      } catch (error) {
+        next(error)
+      }
+    }
+  )
+
+  return router
+}


### PR DESCRIPTION
I fixed the outbox publisher so structurally invalid poison-pill events are quarantined immediately instead of being retried until they hit the DLQ.

Closes #380