### PR TITLE
Added chaos test suite under the chaos directory

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,3 +17,26 @@ services:
     tmpfs:
       - /var/lib/postgresql/data:rw,noexec,nosuid,size=100m
       - /tmp:rw,noexec,nosuid,size=50m
+
+  test-redis:
+    image: redis:7-alpine
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  test-horizon:
+    image: node:20-alpine
+    command: ["node", "/app/horizon-stub.js"]
+    volumes:
+      - ./tests/chaos/horizon-stub.js:/app/horizon-stub.js:ro
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"const http = require('http'); const req = http.get('http://127.0.0.1:8000/health', res => process.exit(res.statusCode === 200 ? 0 : 1)); req.on('error', () => process.exit(1));\""]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/docs/chaos-testing.md
+++ b/docs/chaos-testing.md
@@ -1,0 +1,45 @@
+# Chaos Testing Guide
+
+This repository includes a dedicated chaos test harness for validating resilience against:
+
+- Postgres restarts and connection recovery
+- Redis stalls and fail-open behavior
+- Horizon endpoint outages and listener recovery
+
+## Files and services
+
+- `docker-compose.test.yml`
+  - `test-db` — Postgres 16
+  - `test-redis` — Redis 7
+  - `test-horizon` — Horizon stub service used by the listener recovery test
+
+- `tests/chaos/chaosHelpers.ts` — Docker Compose helpers and wait helpers for the chaos tests
+- `tests/chaos/postgresFailover.test.ts` — DB restart/failover validation for trust scoring
+- `tests/chaos/redisAndOutboxChaos.test.ts` — Redis stall validation plus `/api/trust`, `/api/bond`, and outbox reinjection flows
+- `tests/chaos/horizonRecovery.test.ts` — Horizon listener restart/recovery validation
+- `tests/chaos/horizon-stub.js` — Local Horizon-compatible stub for controlled failure and event replay
+
+## Running the chaos suite
+
+Run the chaos tests with:
+
+```bash
+npm run test:chaos
+```
+
+The suite brings up the test stack from `docker-compose.test.yml` and tears it down automatically.
+
+## When to use
+
+Use this harness when you need to verify that the backend:
+
+- recovers from a Postgres restart without losing service availability
+- continues serving rate-limited endpoints when Redis is unavailable
+- preserves outbox reinjection capability during cache outages
+- resumes Horizon polling after a Horizon endpoint stall
+
+## Notes
+
+- The tests are intentionally run sequentially to avoid service interference.
+- The Horizon test uses a lightweight stub service rather than a full Stellar network.
+- The Redis and Postgres services are mounted on ports `6380` and `5433` respectively.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:chaos": "vitest run tests/chaos --sequence",
     "test:coverage": "vitest run --coverage",
     "coverage": "vitest run --coverage",
     "coverage:audit": "vitest run --config vitest.audit.config.ts --coverage",

--- a/tests/chaos/chaosHelpers.ts
+++ b/tests/chaos/chaosHelpers.ts
@@ -1,0 +1,123 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import path from 'node:path'
+import { fetch } from 'node:undici'
+import { createClient } from 'redis'
+import { Pool } from 'pg'
+
+const execFileAsync = promisify(execFile)
+const workspaceRoot = path.resolve(__dirname, '../../')
+const composeFile = path.join(workspaceRoot, 'docker-compose.test.yml')
+
+export async function dockerCompose(args: string[]) {
+  const { stdout, stderr } = await execFileAsync('docker', ['compose', '-f', composeFile, ...args], {
+    cwd: workspaceRoot,
+    windowsHide: true,
+  })
+
+  if (stdout) process.stdout.write(stdout)
+  if (stderr) process.stderr.write(stderr)
+}
+
+export async function dockerComposeUp() {
+  await dockerCompose(['up', '-d', '--remove-orphans'])
+}
+
+export async function dockerComposeDown() {
+  await dockerCompose(['down', '--volumes', '--remove-orphans'])
+}
+
+export async function dockerComposeRestart(service: string) {
+  await dockerCompose(['restart', service])
+}
+
+export async function dockerComposeStop(service: string) {
+  await dockerCompose(['stop', service])
+}
+
+export async function dockerComposePause(service: string) {
+  await dockerCompose(['pause', service])
+}
+
+export async function dockerComposeUnpause(service: string) {
+  await dockerCompose(['unpause', service])
+}
+
+async function waitFor(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs))
+}
+
+export async function waitForUrl(url: string, timeoutMs = 30000, intervalMs = 500) {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+      lastError = new Error(`Status ${response.status}`)
+    } catch (err) {
+      lastError = err
+    }
+    await waitFor(intervalMs)
+  }
+
+  throw new Error(`Timeout waiting for URL ${url}: ${String(lastError)}`)
+}
+
+export async function waitForDbConnection(connectionString: string, timeoutMs = 30000, intervalMs = 500) {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+
+  while (Date.now() < deadline) {
+    const pool = new Pool({ connectionString })
+    try {
+      await pool.query('SELECT 1')
+      await pool.end()
+      return
+    } catch (err) {
+      lastError = err
+      await pool.end().catch(() => {})
+    }
+    await waitFor(intervalMs)
+  }
+
+  throw new Error(`Timeout waiting for Postgres at ${connectionString}: ${String(lastError)}`)
+}
+
+export async function waitForRedis(connectionString: string, timeoutMs = 30000, intervalMs = 500) {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+
+  while (Date.now() < deadline) {
+    const client = createClient({ url: connectionString })
+    try {
+      await client.connect()
+      await client.ping()
+      await client.quit()
+      return
+    } catch (err) {
+      lastError = err
+      await client.disconnect().catch(() => {})
+    }
+    await waitFor(intervalMs)
+  }
+
+  throw new Error(`Timeout waiting for Redis at ${connectionString}: ${String(lastError)}`)
+}
+
+export async function waitForCondition<T>(fn: () => Promise<T>, timeoutMs = 30000, intervalMs = 500): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+
+  while (Date.now() < deadline) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+    }
+    await waitFor(intervalMs)
+  }
+
+  throw new Error(`Timeout waiting for condition: ${String(lastError)}`)
+}

--- a/tests/chaos/horizon-stub.js
+++ b/tests/chaos/horizon-stub.js
@@ -1,0 +1,59 @@
+import express from 'express'
+
+const app = express()
+app.use(express.json())
+
+const records = []
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' })
+})
+
+app.post('/__test/add-event', (req, res) => {
+  const event = req.body
+  if (!event || typeof event !== 'object') {
+    return res.status(400).json({ error: 'InvalidEvent', message: 'Expected an event object' })
+  }
+
+  if (!event.id || !event.paging_token || event.type !== 'payment') {
+    return res.status(400).json({ error: 'InvalidEvent', message: 'Missing required payment event fields' })
+  }
+
+  records.push({
+    ...event,
+    paging_token: String(event.paging_token),
+    created_at: event.created_at || new Date().toISOString(),
+  })
+
+  res.status(201).json(event)
+})
+
+app.post('/__test/reset', (_req, res) => {
+  records.length = 0
+  res.json({ ok: true })
+})
+
+app.get('/operations', (req, res) => {
+  const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : undefined
+  let filtered = records
+
+  if (cursor && cursor !== 'now') {
+    try {
+      const cursorValue = BigInt(cursor)
+      filtered = records.filter((record) => BigInt(record.paging_token) > cursorValue)
+    } catch {
+      filtered = records
+    }
+  }
+
+  const limit = Number(req.query.limit) || 100
+  const ordered = filtered.slice().sort((a, b) => BigInt(a.paging_token) - BigInt(b.paging_token))
+  const payload = ordered.slice(0, limit)
+
+  res.json({ records: payload, _links: {} })
+})
+
+const port = Number(process.env.PORT || 8000)
+app.listen(port, () => {
+  console.log(`Horizon stub listening on port ${port}`)
+})

--- a/tests/chaos/horizonRecovery.test.ts
+++ b/tests/chaos/horizonRecovery.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
+import { fetch } from 'node:undici'
+import { Pool } from 'pg'
+import { createHorizonWithdrawalListener } from '../../src/listeners/horizonWithdrawalEvents.js'
+import {
+  dockerComposeUp,
+  dockerComposeDown,
+  dockerComposePause,
+  dockerComposeUnpause,
+  waitForCondition,
+  waitForDbConnection,
+  waitForUrl,
+} from './chaosHelpers.js'
+
+vi.setTimeout(120000)
+
+describe('Horizon listener recovery chaos', () => {
+  const dbUrl = process.env.TEST_DATABASE_URL ?? 'postgresql://credence:credence@localhost:5433/credence_test'
+  const horizonUrl = process.env.TEST_HORIZON_URL ?? 'http://localhost:8000'
+  let pool: Pool
+  let listener: ReturnType<typeof createHorizonWithdrawalListener>
+
+  beforeAll(async () => {
+    process.env.DB_URL = dbUrl
+    process.env.HORIZON_URL = horizonUrl
+    process.env.NODE_ENV = 'test'
+
+    await dockerComposeUp()
+    await waitForDbConnection(dbUrl)
+    await waitForUrl(`${horizonUrl}/health`)
+
+    pool = new Pool({ connectionString: dbUrl })
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS horizon_cursors (
+        stream_name TEXT PRIMARY KEY,
+        paging_token TEXT NOT NULL,
+        last_checkpoint TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `)
+
+    listener = createHorizonWithdrawalListener({ horizonUrl, pollingInterval: 1000 }, pool, {
+      captureFailure: async () => ({})
+    })
+
+    await listener.start()
+    await waitForCondition(async () => {
+      if (!listener.isActive()) {
+        throw new Error('Listener has not started')
+      }
+      return true
+    }, 10000)
+  })
+
+  afterAll(async () => {
+    await listener.stop().catch(() => {})
+    await pool.end().catch(() => {})
+    await dockerComposeDown()
+  })
+
+  it('recovers from a Horizon stall and resumes polling after restart', async () => {
+    const firstEvent = {
+      id: '1',
+      paging_token: '1000',
+      type: 'payment',
+      created_at: '2024-01-01T00:00:00Z',
+      transaction_hash: 'txhash-1',
+      source_account: 'GABCDEF1234567890ABCDEF1234567890ABCDEF',
+      amount: '10',
+      asset_type: 'native',
+    }
+
+    await fetch(`${horizonUrl}/__test/add-event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(firstEvent),
+    })
+
+    await waitForCondition(async () => {
+      if (listener.getCursor() !== '1000') {
+        throw new Error(`Expected cursor 1000, got ${listener.getCursor()}`)
+      }
+      return true
+    }, 20000)
+
+    await dockerComposePause('test-horizon')
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+    await dockerComposeUnpause('test-horizon')
+
+    const secondEvent = {
+      id: '2',
+      paging_token: '2000',
+      type: 'payment',
+      created_at: '2024-01-01T00:00:01Z',
+      transaction_hash: 'txhash-2',
+      source_account: 'GABCDEF1234567890ABCDEF1234567890ABCDEF',
+      amount: '15',
+      asset_type: 'native',
+    }
+
+    await fetch(`${horizonUrl}/__test/add-event`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(secondEvent),
+    })
+
+    await waitForCondition(async () => {
+      if (listener.getCursor() !== '2000') {
+        throw new Error(`Expected cursor 2000, got ${listener.getCursor()}`)
+      }
+      return true
+    }, 20000)
+
+    expect(listener.isActive()).toBe(true)
+  })
+})

--- a/tests/chaos/postgresFailover.test.ts
+++ b/tests/chaos/postgresFailover.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import { Pool } from 'pg'
+import trustRouter from '../../src/routes/trust.js'
+import { createRateLimitMiddleware } from '../../src/middleware/rateLimit.js'
+import { requestIdMiddleware } from '../../src/middleware/requestId.js'
+import { securityHeadersWithOverride } from '../../src/middleware/securityHeaders.js'
+import { errorHandler } from '../../src/middleware/errorHandler.js'
+import {
+  dockerComposeUp,
+  dockerComposeDown,
+  dockerComposeRestart,
+  waitForDbConnection,
+  waitForUrl,
+  waitForRedis,
+} from './chaosHelpers.js'
+
+vi.setTimeout(120000)
+
+describe('Postgres failover chaos', () => {
+  const dbUrl = process.env.TEST_DATABASE_URL ?? 'postgresql://credence:credence@localhost:5433/credence_test'
+  const redisUrl = process.env.TEST_REDIS_URL ?? 'redis://localhost:6380'
+  const horizonUrl = process.env.TEST_HORIZON_URL ?? 'http://localhost:8000'
+  let pool: Pool
+  let app: express.Express
+
+  beforeAll(async () => {
+    process.env.DB_URL = dbUrl
+    process.env.REDIS_URL = redisUrl
+    process.env.HORIZON_URL = horizonUrl
+    process.env.NODE_ENV = 'test'
+
+    await dockerComposeUp()
+    await waitForDbConnection(dbUrl)
+    await waitForRedis(redisUrl)
+    await waitForUrl(`${horizonUrl}/health`)
+
+    pool = new Pool({ connectionString: dbUrl })
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS identities (
+        address TEXT PRIMARY KEY,
+        bonded_amount TEXT NOT NULL,
+        bond_start TIMESTAMPTZ
+      )
+    `)
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS attestations (
+        id SERIAL PRIMARY KEY,
+        subject_address TEXT NOT NULL
+      )
+    `)
+    await pool.query(
+      `INSERT INTO identities (address, bonded_amount, bond_start)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (address) DO UPDATE SET bonded_amount = excluded.bonded_amount, bond_start = excluded.bond_start`,
+      ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', '1000000000000000000', '2024-01-01T00:00:00.000Z'],
+    )
+
+    app = express()
+    app.use(express.json())
+    app.use(requestIdMiddleware)
+    app.use(securityHeadersWithOverride)
+    app.use(
+      '/api',
+      createRateLimitMiddleware({
+        enabled: true,
+        windowSec: 60,
+        maxFree: 100,
+        maxPro: 100,
+        maxEnterprise: 100,
+        failOpen: true,
+      }),
+    )
+
+    app.get('/chaos/slow-db/:seconds', async (req, res, next) => {
+      const seconds = Number(req.params.seconds)
+      const client = await pool.connect()
+      try {
+        await client.query('SELECT pg_sleep($1)', [seconds])
+        res.status(200).json({ success: true })
+      } catch (error) {
+        next(error)
+      } finally {
+        client.release()
+      }
+    })
+
+    app.use('/api/trust', trustRouter)
+    app.use(errorHandler)
+  })
+
+  afterAll(async () => {
+    await pool.end().catch(() => {})
+    await dockerComposeDown()
+  })
+
+  it('keeps trust scoring available after a Postgres restart', async () => {
+    const address = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+
+    const baselineResponse = await request(app).get(`/api/trust/${address}`)
+    expect(baselineResponse.status).toBe(200)
+    expect(baselineResponse.body.address).toBe(address.toLowerCase())
+
+    const slowRequest = request(app).get('/chaos/slow-db/10')
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await dockerComposeRestart('test-db')
+    await waitForDbConnection(dbUrl)
+
+    const slowResponse = await slowRequest
+    expect([200, 500, 502, 503, 504]).toContain(slowResponse.status)
+
+    const recoveredResponse = await request(app).get(`/api/trust/${address}`)
+    expect(recoveredResponse.status).toBe(200)
+    expect(recoveredResponse.body.address).toBe(address.toLowerCase())
+  })
+})

--- a/tests/chaos/redisAndOutboxChaos.test.ts
+++ b/tests/chaos/redisAndOutboxChaos.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+import { Pool } from 'pg'
+import trustRouter from '../../src/routes/trust.js'
+import { createBondRouter } from '../../src/routes/bond.js'
+import { BondService, BondStore } from '../../src/services/bond/index.js'
+import { createOutboxAdminRouter } from '../../src/routes/admin/outbox.js'
+import { createRateLimitMiddleware } from '../../src/middleware/rateLimit.js'
+import { requestIdMiddleware } from '../../src/middleware/requestId.js'
+import { securityHeadersWithOverride } from '../../src/middleware/securityHeaders.js'
+import { errorHandler } from '../../src/middleware/errorHandler.js'
+import { createOutboxSchema } from '../../src/db/outbox/schema.js'
+import {
+  dockerComposeUp,
+  dockerComposeDown,
+  dockerComposeStop,
+  waitForDbConnection,
+  waitForRedis,
+  waitForUrl,
+} from './chaosHelpers.js'
+
+vi.setTimeout(120000)
+
+describe('Redis stall and outbox chaos', () => {
+  const dbUrl = process.env.TEST_DATABASE_URL ?? 'postgresql://credence:credence@localhost:5433/credence_test'
+  const redisUrl = process.env.TEST_REDIS_URL ?? 'redis://localhost:6380'
+  const horizonUrl = process.env.TEST_HORIZON_URL ?? 'http://localhost:8000'
+  let pool: Pool
+  let app: express.Express
+
+  beforeAll(async () => {
+    process.env.DB_URL = dbUrl
+    process.env.REDIS_URL = redisUrl
+    process.env.HORIZON_URL = horizonUrl
+    process.env.NODE_ENV = 'test'
+
+    await dockerComposeUp()
+    await waitForDbConnection(dbUrl)
+    await waitForRedis(redisUrl)
+    await waitForUrl(`${horizonUrl}/health`)
+
+    pool = new Pool({ connectionString: dbUrl })
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS identities (
+        address TEXT PRIMARY KEY,
+        bonded_amount TEXT NOT NULL,
+        bond_start TIMESTAMPTZ
+      )
+    `)
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS attestations (
+        id SERIAL PRIMARY KEY,
+        subject_address TEXT NOT NULL
+      )
+    `)
+
+    await createOutboxSchema(pool)
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS outbox_quarantine (
+        id BIGSERIAL PRIMARY KEY,
+        original_event_id BIGINT NOT NULL UNIQUE,
+        aggregate_type TEXT NOT NULL,
+        aggregate_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        payload TEXT,
+        reason TEXT NOT NULL,
+        error_message TEXT NOT NULL,
+        retry_count INTEGER NOT NULL DEFAULT 0,
+        max_retries INTEGER NOT NULL DEFAULT 5,
+        quarantined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        reinjected_at TIMESTAMPTZ,
+        reinjected_by TEXT
+      )
+    `)
+
+    await pool.query(`DELETE FROM identities`)
+    await pool.query(`DELETE FROM attestations`)
+    await pool.query(`DELETE FROM event_outbox`)
+    await pool.query(`DELETE FROM outbox_quarantine`)
+
+    await pool.query(
+      `INSERT INTO identities (address, bonded_amount, bond_start)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (address) DO UPDATE SET bonded_amount = excluded.bonded_amount, bond_start = excluded.bond_start`,
+      ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', '1000000000000000000', '2024-01-01T00:00:00.000Z'],
+    )
+
+    await pool.query(
+      `INSERT INTO outbox_quarantine (original_event_id, aggregate_type, aggregate_id, event_type, payload, reason, error_message, retry_count, max_retries)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      ['1', 'bond', '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', 'BondRecalculated', JSON.stringify({ original: true }), 'malformed_json', 'Stubbed for chaos test', 0, 5],
+    )
+
+    const bondStore = new BondStore()
+    bondStore.set({
+      address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      bondedAmount: '1000000000000000000',
+      bondStart: '2024-01-01T00:00:00.000Z',
+      bondDuration: 31536000,
+      active: true,
+      slashedAmount: '0',
+    })
+
+    app = express()
+    app.use(express.json())
+    app.use(requestIdMiddleware)
+    app.use(securityHeadersWithOverride)
+    app.use(
+      '/api',
+      createRateLimitMiddleware({
+        enabled: true,
+        windowSec: 60,
+        maxFree: 100,
+        maxPro: 100,
+        maxEnterprise: 100,
+        failOpen: true,
+      }),
+    )
+
+    app.use('/api/trust', trustRouter)
+    app.use('/api/bond', createBondRouter(new BondService(bondStore)))
+    app.use('/v1/admin/outbox', createOutboxAdminRouter())
+    app.use(errorHandler)
+  })
+
+  afterAll(async () => {
+    await pool.end().catch(() => {})
+    await dockerComposeDown()
+  })
+
+  it('serves trust and bond requests while Redis is stalled and reinjects quarantined outbox events', async () => {
+    const address = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+
+    const trustBefore = await request(app).get(`/api/trust/${address}`)
+    expect(trustBefore.status).toBe(200)
+
+    const bondBefore = await request(app).get(`/api/bond/${address}`)
+    expect(bondBefore.status).toBe(200)
+
+    await dockerComposeStop('test-redis')
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const trustAfter = await request(app).get(`/api/trust/${address}`)
+    expect(trustAfter.status).toBe(200)
+    expect(trustAfter.body.address).toBe(address.toLowerCase())
+
+    const bondAfter = await request(app).get(`/api/bond/${address}`)
+    expect(bondAfter.status).toBe(200)
+    expect(bondAfter.body.address).toBe(address.toLowerCase())
+
+    const reinjectResponse = await request(app)
+      .post('/v1/admin/outbox/quarantine/1/reinject')
+      .set('X-API-Key', 'test-outbox-reinject-key')
+      .send({ payload: { retry: true } })
+
+    expect(reinjectResponse.status).toBe(201)
+    expect(reinjectResponse.body.success).toBe(true)
+    expect(reinjectResponse.body.data.quarantineId).toBe('1')
+
+    const eventRow = await pool.query(`SELECT status, payload FROM event_outbox ORDER BY id DESC LIMIT 1`)
+    expect(eventRow.rows.length).toBe(1)
+    expect(eventRow.rows[0].status).toBe('pending')
+    expect(eventRow.rows[0].payload).toEqual(expect.objectContaining({ retry: true }))
+  })
+})


### PR DESCRIPTION
A chaos test suite was added under the chaos directory, containing:

chaosHelpers.ts
horizon-stub.js
postgresFailover.test.ts
redisAndOutboxChaos.test.ts
horizonRecovery.test.ts

The Docker compose test stack (docker-compose.test.yml) was updated to include two new services: test-redis and test-horizon. A new NPM script was added to package.json:
"test:chaos": "vitest run tests/chaos --sequence"
Documentation was added in chaos-testing.md, describing the harness, the services, and how to run it. it validates

Postgres failover for the /api/trust endpoint
Redis stall behavior across /api/trust, /api/bond, and outbox reinjection Horizon recovery, confirming the listener resumes after a Horizon outage

provides a structured chaos testing harness built on docker-compose.test.yml and Vitest.

Closed #383