### PR TITLE
feat(db): read-replica routing for read-heavy endpoints

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,8 @@ graph TD
     end
 
     subgraph "Data Layer"
-        DB
+        DB[(Primary DB)]
+        Replica[(Read Replica)]
         Redis[(Redis Cache & Rate Limit)]
         Storage[Encrypted Evidence Storage]
     end
@@ -38,9 +39,11 @@ graph TD
         Webhooks -->|Notify| Ext[External Systems]
     end
 
+    DB -.->|Replication| Replica
     Listener <-->|Poll/Stream| Stellar
     API --> Redis
-    API --> DB
+    API -->|Write| DB
+    API -->|Read| Replica
     Rep --> DB
     Gov --> DB
     Gov --> Storage
@@ -115,7 +118,7 @@ Handles the generation of cryptographic proofs for identity data.
 ## 3. Data Architecture
 
 ### 3.1 PostgreSQL Schema
-The relational database serves as the source of truth for off-chain data and system state.
+The relational database serves as the source of truth for off-chain data and system state. The application employs a primary instance for writes and standard operations, and a **Read Replica** for offloading read-heavy endpoints (e.g., trust scores and attestations). Read queries gracefully fall back to the primary instance if the replica lag exceeds `MAX_REPLICA_LAG_MS` or if the replica becomes unreachable.
 
 | Domain | Table | Description | Relationships |
 |--------|-------|-------------|---------------|
@@ -147,6 +150,8 @@ The application requires the following key environment variables, validated at s
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `DATABASE_URL` | PostgreSQL connection string | **Yes** |
+| `DB_REPLICA_URL` | PostgreSQL connection string for the read replica | No (Falls back to primary) |
+| `MAX_REPLICA_LAG_MS` | Max acceptable lag for replica reads | No (Default: 1000) |
 | `REDIS_URL` | Redis connection string | **Yes** |
 | `JWT_SECRET` | Secret for signing/verifying JWTs | **Yes** |
 | `ALLOWED_ORIGINS` | Comma-separated CORS allowlist | **Yes (Prod)** |

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -45,8 +45,65 @@ describe('DB Pool configuration', () => {
   })
 
   it('statement_timeout is set in options string', async () => {
-    const { pool, workerPool } = await import('./pool.js')
+    const { pool, workerPool, replicaPool } = await import('./pool.js')
     expect(pool.options.options).toContain('-c statement_timeout=')
     expect(workerPool.options.options).toContain('-c statement_timeout=')
+    expect(replicaPool.options.options).toContain('-c statement_timeout=')
+  })
+
+  it('replicaPool is a separate Pool instance', async () => {
+    const { pool, replicaPool } = await import('./pool.js')
+    expect(replicaPool).toBeInstanceOf(Pool)
+    expect(replicaPool).not.toBe(pool)
+  })
+
+  it('withReplica uses replicaPool when lag is within bounds', async () => {
+    const { withReplica, replicaPool } = await import('./pool.js')
+    
+    // Mock the lag query
+    vi.spyOn(replicaPool, 'query').mockResolvedValueOnce({ rows: [{ lag_ms: 10 }] } as any)
+    
+    const operation = vi.fn().mockResolvedValue('success')
+    const result = await withReplica(operation, { maxLagMs: 100 })
+    
+    expect(result).toBe('success')
+    expect(operation).toHaveBeenCalledWith(replicaPool)
+  })
+
+  it('withReplica falls back to pool when lag exceeds maxLagMs', async () => {
+    const { pool, withReplica, replicaPool } = await import('./pool.js')
+    
+    // Mock the lag query
+    vi.spyOn(replicaPool, 'query').mockResolvedValueOnce({ rows: [{ lag_ms: 500 }] } as any)
+    
+    const operation = vi.fn().mockResolvedValue('success')
+    const result = await withReplica(operation, { maxLagMs: 100 })
+    
+    expect(result).toBe('success')
+    expect(operation).toHaveBeenCalledWith(pool)
+  })
+
+  it('withReplica falls back to pool when replica query throws', async () => {
+    const { pool, withReplica, replicaPool } = await import('./pool.js')
+    
+    // Mock the lag query
+    vi.spyOn(replicaPool, 'query').mockRejectedValueOnce(new Error('Connection refused'))
+    
+    const operation = vi.fn().mockResolvedValue('success')
+    const result = await withReplica(operation)
+    
+    expect(result).toBe('success')
+    expect(operation).toHaveBeenCalledWith(pool)
+  })
+
+  it('withReplica throws when lag is high and fallback is false', async () => {
+    const { withReplica, replicaPool } = await import('./pool.js')
+    
+    // Mock the lag query
+    vi.spyOn(replicaPool, 'query').mockResolvedValueOnce({ rows: [{ lag_ms: 500 }] } as any)
+    
+    const operation = vi.fn()
+    await expect(withReplica(operation, { maxLagMs: 100, fallback: false })).rejects.toThrow('Replica lag too high: 500ms')
+    expect(operation).not.toHaveBeenCalled()
   })
 })

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,4 +1,4 @@
-import { Pool } from "pg";
+import { Pool, type PoolClient } from "pg";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -21,6 +21,9 @@ const IDLE_TIMEOUT = envInt("DB_POOL_IDLE_TIMEOUT_MS", 30_000);
 const CONN_TIMEOUT = envInt("DB_POOL_CONNECTION_TIMEOUT_MS", 5_000);
 const STMT_TIMEOUT = envInt("DB_STATEMENT_TIMEOUT_MS", 30_000);
 const WORKER_MAX = envInt("DB_WORKER_POOL_MAX", 5);
+
+const DB_REPLICA_URL = process.env.DB_REPLICA_URL || DB_URL;
+const MAX_REPLICA_LAG_MS = envInt("MAX_REPLICA_LAG_MS", 1000);
 
 /**
  * Primary API pool — serves route handlers and services.
@@ -59,3 +62,53 @@ export const workerPool = new Pool({
 workerPool.on("error", (err) => {
   console.error("[workerPool] unexpected client error", err);
 });
+
+/**
+ * Secondary API pool — serves read-heavy endpoints.
+ */
+export const replicaPool = new Pool({
+  connectionString: DB_REPLICA_URL,
+  max: POOL_MAX,
+  idleTimeoutMillis: IDLE_TIMEOUT,
+  connectionTimeoutMillis: CONN_TIMEOUT,
+  options: `-c statement_timeout=${STMT_TIMEOUT}`,
+});
+
+replicaPool.on("error", (err) => {
+  console.error("[replicaPool] unexpected client error", err);
+});
+
+/**
+ * Helper to execute an operation on the replica, falling back to primary
+ * if the replica is lagging or disconnected.
+ */
+export async function withReplica<T>(
+  operation: (client: Pool | PoolClient) => Promise<T>,
+  options: { maxLagMs?: number; fallback?: boolean } = {}
+): Promise<T> {
+  const maxLagMs = options.maxLagMs ?? MAX_REPLICA_LAG_MS;
+  const fallback = options.fallback ?? true;
+
+  try {
+    const { rows } = await replicaPool.query(
+      `SELECT COALESCE(EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) * 1000, 0) as lag_ms`
+    );
+    const lagMs = rows[0]?.lag_ms ?? 0;
+
+    if (lagMs > maxLagMs) {
+      if (!fallback) {
+        throw new Error(`Replica lag too high: ${lagMs}ms`);
+      }
+      return await operation(pool);
+    }
+
+    return await operation(replicaPool);
+  } catch (err) {
+    if (fallback) {
+      // In a real application, you might use a proper logger instead of console.warn
+      console.warn(`[withReplica] Replica error or lag exceeded, falling back to primary`, err);
+      return await operation(pool);
+    }
+    throw err;
+  }
+}

--- a/src/routes/attestations.ts
+++ b/src/routes/attestations.ts
@@ -16,7 +16,7 @@ import {
   type Attestation,
   type CreateAttestationInput,
 } from '../db/repositories/attestationsRepository.js'
-import { pool } from '../db/pool.js'
+import { pool, withReplica } from '../db/pool.js'
 import { TransactionManager } from '../db/transaction.js'
 import { outboxEmitter, type OutboxEventEmitter } from '../db/outbox/index.js'
 import { AttestationCacheService } from '../services/attestationCacheService.js'
@@ -156,9 +156,13 @@ export function createAttestationRouter(
         const { address } = req.validated!.params! as { address: string }
         const normalizedAddress = normalizeAddress(address)
         const { page, limit, offset } = parsePaginationParams(req.query as Record<string, unknown>)
-        const result = await cacheService.getAttestationsBySubjectPage(normalizedAddress, {
-          offset,
-          limit,
+        const result = await withReplica(async (client) => {
+          const reqRepo = deps.repository ?? new AttestationsRepository(client)
+          const reqCache = deps.cacheService ?? new AttestationCacheService(reqRepo)
+          return await reqCache.getAttestationsBySubjectPage(normalizedAddress, {
+            offset,
+            limit,
+          })
         })
 
         res.json({

--- a/src/routes/trust.ts
+++ b/src/routes/trust.ts
@@ -1,14 +1,13 @@
 import { Router, type Request, type Response } from 'express'
 import { getTrustScore } from '../services/reputationService.js'
 import { PgTrustIdentityRepository } from '../db/repositories/trustIdentityRepository.js'
-import { pool } from '../db/pool.js'
+import { pool, withReplica } from '../db/pool.js'
 import { apiKeyMiddleware } from '../middleware/apiKey.js'
 import { validate } from '../middleware/validate.js'
 import { trustPathParamsSchema } from '../schemas/index.js'
 import { NotFoundError } from '../lib/errors.js'
 
 const router = Router()
-const trustRepo = new PgTrustIdentityRepository(pool)
 
 router.get(
   '/:address',
@@ -18,7 +17,10 @@ router.get(
     try {
       const { address } = req.validated!.params! as { address: string }
 
-      const trustScore = await getTrustScore(address, trustRepo)
+      const trustScore = await withReplica(async (client) => {
+        const trustRepo = new PgTrustIdentityRepository(client)
+        return await getTrustScore(address, trustRepo)
+      })
 
       if (!trustScore) {
         throw new NotFoundError('Identity record', address)


### PR DESCRIPTION
## Description

This pull request introduces read-replica routing for read-heavy endpoints (specifically `/v1/trust/:address` and `/v1/attestations/:address`), offloading query load from the primary database and improving overall system capacity.

### Changes
*   **Database Pool**: Configured a new `replicaPool` in `src/db/pool.ts` connected via the `DB_REPLICA_URL` environment variable.
*   **Routing Helper**: Implemented a `withReplica` helper with explicit fallback logic. It validates replica lag against a configurable `MAX_REPLICA_LAG_MS` (defaulting to 1000ms). If the replica exceeds the lag threshold or becomes disconnected, the system gracefully routes the operation to the primary pool.
*   **Routes Updated**:
    *   `src/routes/trust.ts` uses `withReplica` when querying for identity records and reputation scores.
    *   `src/routes/attestations.ts` fetches paginated attestations via the `cacheService` inside the `withReplica` context.
*   **Tests**: Added comprehensive test coverage in `src/db/pool.test.ts` to assert that replica pooling properly manages disconnection, latency fallbacks, and connection parameters.
*   **Architecture Docs**: Updated `docs/architecture.md` to map out the new Read Replica topology in the data layer diagram and detail the new environment variables.

Closes #397
