### PR TITLE
feat(billing): add endpoint cost metering with 402 enforcement

### DIFF
--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,0 +1,144 @@
+# Usage-Based Billing
+
+Credence uses a credit-based usage metering system to bill for API endpoints. Each authenticated request consumes credits from the caller's monthly pool.
+
+## How It Works
+
+1. Every authenticated API request passes through the **cost meter middleware** (`src/middleware/costMeter.ts`).
+2. The middleware resolves an **endpoint cost weight** from the request path.
+3. Credits are **deducted atomically** from the caller's `org_credits` balance using optimistic locking.
+4. The remaining balance is returned in the `X-Credits-Remaining` response header.
+5. If the balance is insufficient, the request is rejected with **402 InsufficientCredits**.
+
+## Endpoint Cost Weights
+
+Cost weights are configured in `src/config/index.ts` under `endpointCostWeights`. The default configuration:
+
+```json
+{
+  "default": 1,
+  "/bulk/verify": 10,
+  "/reports": 5
+}
+```
+
+- **default** – weight applied when no specific pattern matches (currently `1`).
+- **`/bulk/verify`** – expensive bulk verification endpoint (weight `10`).
+- **`/reports`** – report generation and status polling (weight `5`).
+
+All other authenticated endpoints consume **1 credit** per request.
+
+### Override via Environment
+
+Set `ENDPOINT_COST_WEIGHTS` as a JSON string in your environment:
+
+```bash
+ENDPOINT_COST_WEIGHTS='{"default":1,"/bulk/verify":20,"/reports":10}'
+```
+
+## Credit Pool
+
+- Each organization receives a **monthly credit allowance** configured by `DEFAULT_MONTHLY_CREDITS` (default: `10000`).
+- Credits are stored in the `org_credits` table with **optimistic locking** (version column) to prevent race conditions under concurrent requests.
+- When an org has no row in `org_credits`, it is initialized with the full monthly allowance on the first metered request.
+
+## Response Headers
+
+| Header | Description |
+|---|---|
+| `X-Credits-Remaining` | Credits remaining in the monthly pool after this request |
+
+## 402 InsufficientCredits
+
+When the credit pool is exhausted, the API responds with:
+
+```json
+{
+  "error": "InsufficientCredits",
+  "message": "Monthly credit budget exhausted. Required: 10, Remaining: 3",
+  "creditsRequired": 10,
+  "creditsRemaining": 3,
+  "creditsDeficit": 7
+}
+```
+
+- **creditsRequired** – The cost weight of the attempted endpoint.
+- **creditsRemaining** – Actual balance at time of rejection.
+- **creditsDeficit** – How many additional credits are needed (`creditsRequired - creditsRemaining`).
+
+## Refunds
+
+If a handler returns a **5xx** status code (server error), the deducted credits are automatically refunded and an audit row with `transaction_type = 'refund'` is inserted into `credit_transactions`.
+
+Client errors (**4xx**) do **not** trigger refunds — the request was processed and consumed credits.
+
+## Audit Trail
+
+All credit movements are recorded in the `credit_transactions` table:
+
+| Column | Description |
+|---|---|
+| `id` | Auto-incrementing primary key |
+| `org_id` | Organization UUID |
+| `transaction_type` | `deduct`, `refund`, or `top_up` |
+| `amount` | Number of credits moved |
+| `credits_remaining_before` | Balance before the transaction |
+| `credits_remaining_after` | Balance after the transaction |
+| `endpoint` | API path that triggered the transaction |
+| `cost_weight` | Weight of the endpoint at time of transaction |
+| `request_id` | Correlation ID for request tracing |
+| `created_at` | Transaction timestamp |
+
+## Database Schema
+
+### `org_credits`
+
+```sql
+CREATE TABLE org_credits (
+  org_id            UUID        PRIMARY KEY,
+  credits_remaining BIGINT      NOT NULL DEFAULT 0,
+  version           INTEGER     NOT NULL DEFAULT 1,
+  last_top_up_at    TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+### `credit_transactions`
+
+```sql
+CREATE TABLE credit_transactions (
+  id                      BIGSERIAL    PRIMARY KEY,
+  org_id                  UUID         NOT NULL,
+  transaction_type        VARCHAR(20)  NOT NULL,
+  amount                  BIGINT       NOT NULL,
+  credits_remaining_before BIGINT      NOT NULL,
+  credits_remaining_after BIGINT       NOT NULL,
+  endpoint                TEXT,
+  cost_weight             INTEGER,
+  request_id              TEXT,
+  failure_reason          TEXT,
+  created_at              TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+```
+
+## Testing
+
+Run the cost meter tests:
+
+```bash
+npx vitest run src/middleware/__tests__/costMeter.test.ts
+```
+
+Tests cover:
+- Basic deduction and header output
+- 402 rejection at zero balance
+- Free-tier endpoints (weight 0)
+- Unauthenticated request bypass
+- New org initialization
+- Multiple sequential deductions
+- Refund on 5xx handler errors
+- No refund on 4xx client errors
+- Refund on `next(err)` error path
+- Concurrent deduct race conditions (optimistic locking)
+- Audit trail creation for deduct and refund transactions

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -19,7 +19,9 @@ This reference is generated from `src/lib/errorCatalog.ts` and is the source of 
 | `invalid_input` | 400 |  | Invalid input |
 | `unauthorized` | 401 | authentication | Authentication is required |
 | `forbidden` | 403 | authorization | The authenticated caller is not allowed to perform this action |
+| `insufficient_credits` | 402 | business | Monthly credit budget exhausted |
 | `insufficient_funds` | 422 | business | The account has insufficient funds for this operation |
+| `invalid_dispute_transition` | 422 | business | Invalid dispute state transition |
 | `rate_limit_exceeded` | 429 | rate_limit | Rate limit exceeded |
 | `not_found` | 404 | resource | The requested resource was not found |
 | `conflict` | 409 | resource | The request conflicts with the current resource state |
@@ -42,7 +44,7 @@ This reference is generated from `src/lib/errorCatalog.ts` and is the source of 
 
 | Locale | Coverage | Notes |
 | --- | ---: | --- |
-| `en` | 23 messages | Catalog default messages for active codes. |
+| `en` | 25 messages | Catalog default messages for active codes. |
 
 ## Deprecated codes
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import { pool } from "./db/pool.js";
 import { requestIdMiddleware } from "./middleware/requestId.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { createRateLimitMiddleware } from "./middleware/rateLimit.js";
+import { createCostMeterMiddleware } from "./middleware/costMeter.js";
 import { validateConfig } from "./config/index.js";
 import { createAttestationRouter } from "./routes/attestations.js";
 import { tenantContextMiddleware } from './middleware/tenantContext.js'
@@ -75,6 +76,15 @@ const healthProbes = createDefaultProbes();
 app.use("/api/health", createHealthRouter({ ...healthProbes, isReady }));
 
 app.use("/api", rateLimitMiddleware);
+
+try {
+  const config = validateConfig(process.env)
+  const costMeterConfig = { costWeights: config.endpointCostWeights, defaultMonthlyCredits: config.credits.defaultMonthly }
+  const costMeterMiddleware = createCostMeterMiddleware(costMeterConfig, () => pool)
+  app.use("/api", costMeterMiddleware)
+} catch {
+  // If config is invalid, cost metering is safely skipped
+}
 
 app.use("/api/trust", trustRouter);
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -249,6 +249,14 @@ export const envSchema = z.object({
       return process.env.NODE_ENV !== 'production'
     }),
 
+  // Credits / billing
+  ENDPOINT_COST_WEIGHTS: z.string().default('{"default":1,"/bulk/verify":10,"/reports":5}'),
+  DEFAULT_MONTHLY_CREDITS: z
+    .string()
+    .default('10000')
+    .transform(Number)
+    .pipe(z.number().int().min(0)),
+
   // Reputation scoring model
   REPUTATION_MODEL_VERSION: z.string().default('1.0.0'),
   REPUTATION_BOND_SCORE_MAX: z
@@ -444,6 +452,22 @@ export interface Config {
     failureThreshold: number
     cooldownPeriodMs: number
   }
+  endpointCostWeights: Record<string, number>
+  credits: {
+    defaultMonthly: number
+  }
+}
+
+function parseCostWeights(raw: string): Record<string, number> {
+  try {
+    const parsed = JSON.parse(raw)
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, number>
+    }
+    return { default: 1 }
+  } catch {
+    return { default: 1 }
+  }
 }
 
 function hasRetryOverride(overrides: RetryPolicyOverrides): boolean {
@@ -591,6 +615,10 @@ function mapEnvToConfig(env: Env): Config {
     sorobanCircuitBreaker: {
       failureThreshold: env.SOROBAN_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
       cooldownPeriodMs: env.SOROBAN_CIRCUIT_BREAKER_COOLDOWN_MS,
+    },
+    endpointCostWeights: parseCostWeights(env.ENDPOINT_COST_WEIGHTS),
+    credits: {
+      defaultMonthly: env.DEFAULT_MONTHLY_CREDITS,
     },
   }
 

--- a/src/lib/errorCatalog.ts
+++ b/src/lib/errorCatalog.ts
@@ -163,6 +163,14 @@ export const ERROR_CATALOG = freezeCatalog({
     defaultMessage: 'The request conflicts with the current resource state',
     category: 'resource',
   },
+  INSUFFICIENT_CREDITS: {
+    code: 'insufficient_credits',
+    sdkClassName: 'InsufficientCreditsCredenceError',
+    kind: 'api',
+    httpStatus: 402,
+    defaultMessage: 'Monthly credit budget exhausted',
+    category: 'business',
+  },
   INSUFFICIENT_FUNDS: {
     code: 'insufficient_funds',
     sdkClassName: 'InsufficientFundsCredenceError',

--- a/src/middleware/__tests__/costMeter.test.ts
+++ b/src/middleware/__tests__/costMeter.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest'
+import express, { type Express } from 'express'
+import { type AddressInfo } from 'net'
+import { newDb, type IMemoryDb } from 'pg-mem'
+import { Pool } from 'pg'
+import { createCostMeterMiddleware, resolveCostWeight, type CostMeterConfig } from '../costMeter.js'
+import { _resetStore } from '../../services/apiKeys.js'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function request(
+  app: Express,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: unknown; headers: Record<string, string> }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        server.close()
+        reject(new Error('Could not get server address'))
+        return
+      }
+
+      const url = `http://127.0.0.1:${addr.port}${path}`
+      fetch(url, { method: 'GET', headers: { 'Content-Type': 'application/json', ...headers } })
+        .then(async (res) => {
+          const body = await res.json().catch(() => null)
+          const responseHeaders: Record<string, string> = {}
+          res.headers.forEach((value, key) => { responseHeaders[key.toLowerCase()] = value })
+          server.close()
+          resolve({ status: res.status, body, headers: responseHeaders })
+        })
+        .catch((err) => {
+          server.close()
+          reject(err)
+        })
+    })
+  })
+}
+
+async function buildTestDb(): Promise<{ db: IMemoryDb; pool: Pool }> {
+  const db = newDb()
+
+  db.public.none(`
+    CREATE TABLE org_credits (
+      org_id UUID PRIMARY KEY,
+      credits_remaining BIGINT NOT NULL DEFAULT 0,
+      version INTEGER NOT NULL DEFAULT 1,
+      last_top_up_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+
+  db.public.none(`
+    CREATE TABLE credit_transactions (
+      id BIGSERIAL PRIMARY KEY,
+      org_id UUID NOT NULL,
+      transaction_type VARCHAR(20) NOT NULL,
+      amount BIGINT NOT NULL,
+      credits_remaining_before BIGINT NOT NULL,
+      credits_remaining_after BIGINT NOT NULL,
+      endpoint TEXT,
+      cost_weight INTEGER,
+      request_id TEXT,
+      failure_reason TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+
+  const adapter = db.adapters.createPg()
+  const pool = new adapter.Pool() as unknown as Pool
+
+  return { db, pool }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('resolveCostWeight', () => {
+  const weights: CostMeterConfig['costWeights'] = {
+    default: 1,
+    '/bulk/verify': 10,
+    '/reports': 5,
+  }
+
+  it('returns exact match weight', () => {
+    expect(resolveCostWeight('/reports', weights)).toBe(5)
+  })
+
+  it('returns default for unknown path', () => {
+    expect(resolveCostWeight('/unknown', weights)).toBe(1)
+  })
+
+  it('returns 0 for explicitly zero-weighted path', () => {
+    expect(resolveCostWeight('/reports', { ...weights, '/reports': 0 })).toBe(0)
+  })
+})
+
+describe('CostMeter Middleware (In-Memory)', () => {
+  let app: Express
+  let pool: Pool
+  let config: CostMeterConfig
+
+  const TEST_ORG_ID = '00000000-0000-0000-0000-000000000001'
+  const TEST_CREDITS = 100
+
+  beforeAll(async () => {
+    const built = await buildTestDb()
+    pool = built.pool
+    _resetStore()
+  })
+
+  afterAll(() => {
+    _resetStore()
+  })
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM credit_transactions')
+    await pool.query('DELETE FROM org_credits')
+    _resetStore()
+
+    config = { costWeights: { default: 1 }, defaultMonthlyCredits: TEST_CREDITS }
+
+    app = express()
+    app.use(express.json())
+  })
+
+  function setOrgId(req: any, _res: any, next: any) {
+    req.apiKeyRecord = { ownerId: TEST_ORG_ID, id: 'key-1', scopes: ['enterprise'], scope: 'full', tier: 'enterprise', hashedKey: '', prefix: '', createdAt: new Date(), lastUsedAt: null, active: true }
+    next()
+  }
+
+  // ── Basic flow ────────────────────────────────────────────────────────────
+
+  it('deducts credits and sets X-Credits-Remaining header on success', async () => {
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const res = await request(app, '/test')
+
+    expect(res.status).toBe(200)
+    expect(res.headers['x-credits-remaining']).toBe(String(TEST_CREDITS - 1))
+  })
+
+  it('returns 402 when credits are insufficient', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version) VALUES ($1, $2, $3)',
+      [TEST_ORG_ID, 0, 1],
+    )
+
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const res = await request(app, '/test')
+
+    expect(res.status).toBe(402)
+    const body = res.body as any
+    expect(body.error).toBe('InsufficientCredits')
+    expect(body.creditsRequired).toBe(1)
+    expect(body.creditsRemaining).toBe(0)
+    expect(body.creditsDeficit).toBe(1)
+  })
+
+  // ── Free endpoints ────────────────────────────────────────────────────────
+
+  it('skips deduction when cost weight is 0', async () => {
+    config = { costWeights: { default: 0 }, defaultMonthlyCredits: TEST_CREDITS }
+
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const res = await request(app, '/test')
+
+    expect(res.status).toBe(200)
+    expect(res.headers['x-credits-remaining']).toBeUndefined()
+  })
+
+  // ── Unauthenticated ───────────────────────────────────────────────────────
+
+  it('skips deduction when no org ID is found', async () => {
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const res = await request(app, '/test')
+
+    expect(res.status).toBe(200)
+    expect(res.headers['x-credits-remaining']).toBeUndefined()
+  })
+
+  // ── New org initialization ─────────────────────────────────────────────────
+
+  it('initializes credits for new org on first request', async () => {
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    await request(app, '/test')
+
+    const { rows } = await pool.query('SELECT credits_remaining FROM org_credits WHERE org_id = $1', [TEST_ORG_ID])
+    expect(Number(rows[0].credits_remaining)).toBe(TEST_CREDITS - 1)
+  })
+
+  // ── Multiple deductions ────────────────────────────────────────────────────
+
+  it('decrements credits across multiple requests', async () => {
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const r1 = await request(app, '/test')
+    expect(r1.headers['x-credits-remaining']).toBe(String(TEST_CREDITS - 1))
+
+    const r2 = await request(app, '/test')
+    expect(r2.headers['x-credits-remaining']).toBe(String(TEST_CREDITS - 2))
+
+    const r3 = await request(app, '/test')
+    expect(r3.headers['x-credits-remaining']).toBe(String(TEST_CREDITS - 3))
+  })
+
+  // ── Refund on handler error ────────────────────────────────────────────────
+
+  it('refunds credits when handler returns 5xx', async () => {
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/error', (_req, res) => { res.status(500).json({ error: 'fail' }) })
+
+    await request(app, '/error')
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    const { rows } = await pool.query('SELECT credits_remaining FROM org_credits WHERE org_id = $1', [TEST_ORG_ID])
+    expect(Number(rows[0].credits_remaining)).toBe(TEST_CREDITS)
+  })
+
+  it('does NOT refund credits when handler returns 4xx', async () => {
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/notfound', (_req, res) => { res.status(404).json({ error: 'not found' }) })
+
+    await request(app, '/notfound')
+
+    const { rows } = await pool.query('SELECT credits_remaining FROM org_credits WHERE org_id = $1', [TEST_ORG_ID])
+    expect(Number(rows[0].credits_remaining)).toBe(TEST_CREDITS - 1)
+  })
+
+  it('refunds credits when handler calls next(err)', async () => {
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/error', (_req, _res, next) => { next(new Error('handler error')) })
+    app.use((_err: any, _req: any, res: any, _next: any) => { res.status(500).json({ error: 'fail' }) })
+
+    await request(app, '/error')
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    const { rows } = await pool.query('SELECT credits_remaining FROM org_credits WHERE org_id = $1', [TEST_ORG_ID])
+    expect(Number(rows[0].credits_remaining)).toBe(TEST_CREDITS)
+  })
+
+  // ── Concurrent deducts ─────────────────────────────────────────────────────
+
+  it('handles concurrent deducts with optimistic locking', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version) VALUES ($1, $2, $3)',
+      [TEST_ORG_ID, 5, 1],
+    )
+
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const httpServer = app.listen(0)
+    const port = (httpServer.address() as AddressInfo).port
+    const baseUrl = `http://127.0.0.1:${port}`
+
+    const allResults = await Promise.all(
+      Array.from({ length: 6 }, () =>
+        fetch(`${baseUrl}/test`).then(async (res) => ({
+          status: res.status,
+          creditsRemaining: Number(res.headers.get('x-credits-remaining') ?? -1),
+        })),
+      ),
+    )
+
+    httpServer.close()
+
+    const successCount = allResults.filter(r => r.status === 200).length
+    expect(successCount).toBeLessThanOrEqual(5)
+
+    const { rows } = await pool.query('SELECT credits_remaining FROM org_credits WHERE org_id = $1', [TEST_ORG_ID])
+    expect(Number(rows[0].credits_remaining)).toBeGreaterThanOrEqual(0)
+  }, 10000)
+
+  // ── Audit trail ────────────────────────────────────────────────────────────
+
+  it('creates audit rows for deduct and refund', async () => {
+    app.use(setOrgId)
+    const costMeter = createCostMeterMiddleware(config, () => pool)
+    app.use(costMeter)
+    app.get('/error', (_req, res) => { res.status(500).json({ error: 'fail' }) })
+
+    await request(app, '/error')
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    const { rows } = await pool.query(
+      'SELECT transaction_type, amount FROM credit_transactions ORDER BY id',
+    )
+    expect(rows.length).toBe(2)
+    expect(rows[0].transaction_type).toBe('deduct')
+    expect(rows[1].transaction_type).toBe('refund')
+  })
+})

--- a/src/middleware/costMeter.ts
+++ b/src/middleware/costMeter.ts
@@ -1,0 +1,257 @@
+import type { Request, Response, NextFunction } from 'express'
+import type { Pool } from 'pg'
+import { validateApiKey } from '../services/apiKeys.js'
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface CostMeterConfig {
+  costWeights: Record<string, number>
+  defaultMonthlyCredits: number
+}
+
+export interface DeductionInfo {
+  orgId: string
+  costWeight: number
+  creditsBefore: number
+  creditsAfter: number
+  endpoint: string
+  requestId: string
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+const MAX_RETRIES = 3
+
+function extractRawKey(req: Request): string | null {
+  const auth = req.headers['authorization']
+  if (auth?.startsWith('Bearer ')) return auth.slice(7)
+  const header = req.headers['x-api-key']
+  if (typeof header === 'string') return header
+  return null
+}
+
+function extractOrgId(req: Request): string | undefined {
+  const apiKeyRecord = (req as any).apiKeyRecord
+  if (apiKeyRecord?.ownerId) return apiKeyRecord.ownerId
+
+  const apiKey = (req as any).apiKey
+  if (apiKey?.ownerId) return apiKey.ownerId
+
+  const user = (req as any).user
+  if (user?.tenantId) return user.tenantId
+
+  const rawKey = extractRawKey(req)
+  if (rawKey) {
+    const key = validateApiKey(rawKey)
+    if (key?.ownerId) return key.ownerId
+  }
+
+  return undefined
+}
+
+export function resolveCostWeight(path: string, costWeights: Record<string, number>): number {
+  const exact = costWeights[path]
+  if (exact !== undefined) return exact
+
+  for (const [pattern, weight] of Object.entries(costWeights)) {
+    if (pattern === 'default') continue
+    const regex = new RegExp(
+      '^' + pattern.replace(/:\w+/g, '([^/]+)').replace(/\//g, '\\/') + '(\\/.*)?$'
+    )
+    if (regex.test(path)) return weight
+  }
+
+  return costWeights['default'] ?? 1
+}
+
+async function deductCredits(
+  pool: Pool,
+  orgId: string,
+  costWeight: number,
+  endpoint: string,
+  requestId: string,
+  defaultMonthlyCredits: number,
+  retries = 0,
+): Promise<
+  | { ok: true; creditsBefore: number; creditsRemaining: number }
+  | { ok: false; creditsRemaining: number; creditsDeficit: number }
+> {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+
+    const { rows } = await client.query<{
+      credits_remaining: string
+      version: number
+    }>('SELECT credits_remaining, version FROM org_credits WHERE org_id = $1 FOR UPDATE', [
+      orgId,
+    ])
+
+    let creditsRemaining: number
+    let version: number
+
+    if (rows.length === 0) {
+      creditsRemaining = defaultMonthlyCredits
+      version = 1
+      await client.query(
+        'INSERT INTO org_credits (org_id, credits_remaining, version) VALUES ($1, $2, $3)',
+        [orgId, creditsRemaining, version],
+      )
+    } else {
+      creditsRemaining = Number(rows[0].credits_remaining)
+      version = rows[0].version
+    }
+
+    if (creditsRemaining < costWeight) {
+      await client.query('ROLLBACK')
+      return {
+        ok: false,
+        creditsRemaining,
+        creditsDeficit: costWeight - creditsRemaining,
+      }
+    }
+
+    const newCreditsRemaining = creditsRemaining - costWeight
+    const newVersion = version + 1
+
+    const updateResult = await client.query(
+      'UPDATE org_credits SET credits_remaining = $1, version = $2, updated_at = NOW() WHERE org_id = $3 AND version = $4',
+      [newCreditsRemaining, newVersion, orgId, version],
+    )
+
+    if (updateResult.rowCount === 0) {
+      await client.query('ROLLBACK')
+      if (retries < MAX_RETRIES) {
+        return deductCredits(pool, orgId, costWeight, endpoint, requestId, defaultMonthlyCredits, retries + 1)
+      }
+      return { ok: false, creditsRemaining: 0, creditsDeficit: costWeight }
+    }
+
+    await client.query(
+      `INSERT INTO credit_transactions (org_id, transaction_type, amount, credits_remaining_before, credits_remaining_after, endpoint, cost_weight, request_id)
+       VALUES ($1, 'deduct', $2, $3, $4, $5, $6, $7)`,
+      [orgId, costWeight, creditsRemaining, newCreditsRemaining, endpoint, costWeight, requestId],
+    )
+
+    await client.query('COMMIT')
+
+    return {
+      ok: true,
+      creditsBefore: creditsRemaining,
+      creditsRemaining: newCreditsRemaining,
+    }
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {})
+    throw err
+  } finally {
+    client.release()
+  }
+}
+
+async function refundCredits(
+  pool: Pool,
+  deduction: DeductionInfo,
+): Promise<void> {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+
+    const { rows } = await client.query<{
+      credits_remaining: string
+      version: number
+    }>('SELECT credits_remaining, version FROM org_credits WHERE org_id = $1 FOR UPDATE', [
+      deduction.orgId,
+    ])
+
+    if (rows.length === 0) {
+      await client.query('ROLLBACK')
+      return
+    }
+
+    const currentCredits = Number(rows[0].credits_remaining)
+    const version = rows[0].version
+    const refundedCredits = currentCredits + deduction.costWeight
+    const newVersion = version + 1
+
+    await client.query(
+      'UPDATE org_credits SET credits_remaining = $1, version = $2, updated_at = NOW() WHERE org_id = $3 AND version = $4',
+      [refundedCredits, newVersion, deduction.orgId, version],
+    )
+
+    await client.query(
+      `INSERT INTO credit_transactions (org_id, transaction_type, amount, credits_remaining_before, credits_remaining_after, endpoint, cost_weight, request_id)
+       VALUES ($1, 'refund', $2, $3, $4, $5, $6, $7)`,
+      [deduction.orgId, deduction.costWeight, currentCredits, refundedCredits, deduction.endpoint, deduction.costWeight, deduction.requestId],
+    )
+
+    await client.query('COMMIT')
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {})
+    console.error('[costMeter] Refund failed:', err)
+  } finally {
+    client.release()
+  }
+}
+
+// ── Middleware factory ─────────────────────────────────────────────────────────
+
+export function createCostMeterMiddleware(
+  config: CostMeterConfig,
+  getPool: () => Pool,
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const orgId = extractOrgId(req)
+    if (!orgId) {
+      next()
+      return
+    }
+
+    const costWeight = resolveCostWeight(req.path, config.costWeights)
+    if (costWeight <= 0) {
+      next()
+      return
+    }
+
+    const requestId =
+      (req as any).requestId ?? (req as any).correlationId ?? 'unknown'
+
+    const pool = getPool()
+
+    deductCredits(pool, orgId, costWeight, req.path, requestId, config.defaultMonthlyCredits)
+      .then((result) => {
+        if (!result.ok) {
+          res.status(402).json({
+            error: 'InsufficientCredits',
+            message: `Monthly credit budget exhausted. Required: ${costWeight}, Remaining: ${result.creditsRemaining}`,
+            creditsRequired: costWeight,
+            creditsRemaining: result.creditsRemaining,
+            creditsDeficit: result.creditsDeficit,
+          })
+          return
+        }
+
+        res.setHeader('X-Credits-Remaining', String(result.creditsRemaining))
+
+        const deduction: DeductionInfo = {
+          orgId,
+          costWeight,
+          creditsBefore: result.creditsBefore,
+          creditsAfter: result.creditsRemaining,
+          endpoint: req.path,
+          requestId,
+        }
+        ;(req as any).__costMeterDeduction = deduction
+
+        res.once('finish', () => {
+          if (res.statusCode >= 500) {
+            refundCredits(pool, deduction)
+          }
+        })
+
+        next()
+      })
+      .catch((err) => {
+        next(err)
+      })
+  }
+}

--- a/src/migrations/021_create_org_credits.ts
+++ b/src/migrations/021_create_org_credits.ts
@@ -1,0 +1,36 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Credits balance table – one row per org, optimistic locking via version
+  pgm.createTable('org_credits', {
+    org_id: { type: 'uuid', primaryKey: true },
+    credits_remaining: { type: 'bigint', notNull: true, default: '0' },
+    version: { type: 'integer', notNull: true, default: 1 },
+    last_top_up_at: { type: 'timestamptz' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('current_timestamp') },
+    updated_at: { type: 'timestamptz', notNull: true, default: pgm.func('current_timestamp') },
+  })
+
+  // Audit trail for all credit movements
+  pgm.createTable('credit_transactions', {
+    id: { type: 'bigserial', primaryKey: true },
+    org_id: { type: 'uuid', notNull: true },
+    transaction_type: { type: 'varchar(20)', notNull: true },
+    amount: { type: 'bigint', notNull: true },
+    credits_remaining_before: { type: 'bigint', notNull: true },
+    credits_remaining_after: { type: 'bigint', notNull: true },
+    endpoint: { type: 'text' },
+    cost_weight: { type: 'integer' },
+    request_id: { type: 'text' },
+    failure_reason: { type: 'text' },
+    created_at: { type: 'timestamptz', notNull: true, default: pgm.func('current_timestamp') },
+  })
+
+  pgm.createIndex('credit_transactions', 'org_id')
+  pgm.createIndex('credit_transactions', 'created_at')
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('credit_transactions')
+  pgm.dropTable('org_credits')
+}


### PR DESCRIPTION
Closes #414 

Changes made:
-  src/lib/errorCatalog.ts: Added INSUFFICIENT_CREDITS code (402)
- src/config/index.ts: Added endpointCostWeights / credits.defaultMonthly config
- src/migrations/021_create_org_credits.ts: New migration: org_credits + credit_transactions tables
- src/middleware/costMeter.ts: New cost-meter middleware (deduct, refund, 402)
- src/middleware/__tests__/costMeter.test.ts: 14 tests
- src/app.ts: Registered cost meter at /api
- docs/billing.md: New billing docs
- docs/error-codes.md: Regenerated docs