### PR TITLE
test(currency): cover whitelist normalization invariants

### DIFF
--- a/src/services/currency/whitelist.test.ts
+++ b/src/services/currency/whitelist.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import fc from 'fast-check'
+
+import {
+  CurrencyWhitelist,
+  normalize_currency_code,
+  type AdminContext,
+} from './whitelist.js'
+
+const adminCtx: AdminContext = {
+  userId: 'admin-1',
+  role: 'admin',
+}
+
+const snapshotValues = (whitelist: CurrencyWhitelist) =>
+  [...whitelist.snapshot()].sort()
+
+describe('normalize_currency_code', () => {
+  it('normalizes case and surrounding whitespace', () => {
+    expect(normalize_currency_code(' usd ')).toBe('USD')
+    expect(normalize_currency_code('\tEur\n')).toBe('EUR')
+  })
+
+  it('rejects malformed currency codes', () => {
+    for (const value of [
+      '',
+      '  ',
+      'US',
+      'USDD',
+      'U5D',
+      'US-D',
+      '\u20acUR',
+      '\uff35\uff33\uff24',
+    ]) {
+      expect(() => normalize_currency_code(value)).toThrow(TypeError)
+    }
+  })
+
+  it('is idempotent for normalized valid codes', () => {
+    fc.assert(
+      fc.property(
+        fc.tuple(
+          fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+          fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+          fc.constantFrom(...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+        ),
+        (chars) => {
+          const code = chars.join('')
+
+          expect(normalize_currency_code(normalize_currency_code(code))).toBe(
+            normalize_currency_code(code),
+          )
+        },
+      ),
+    )
+  })
+})
+
+describe('CurrencyWhitelist', () => {
+  it('starts empty by default and supports populated lookup behavior', () => {
+    const empty = new CurrencyWhitelist()
+    const populated = new CurrencyWhitelist([' usd ', 'eur'])
+
+    expect(empty.size).toBe(0)
+    expect(empty.is_allowed_currency('USD')).toBe(false)
+    expect(populated.size).toBe(2)
+    expect(populated.is_allowed_currency('USD')).toBe(true)
+    expect(populated.is_allowed_currency(' eur ')).toBe(true)
+    expect(populated.is_allowed_currency('GBP')).toBe(false)
+  })
+
+  it('adds currencies after normalization and returns an isolated snapshot', () => {
+    const whitelist = new CurrencyWhitelist()
+
+    const result = whitelist.add_currency(' usd ', adminCtx)
+    const returnedSnapshot = result.currencies as Set<string>
+    returnedSnapshot.add('EUR')
+
+    expect(result.description).toBe('add_currency(USD): added')
+    expect(whitelist.is_allowed_currency('USD')).toBe(true)
+    expect(whitelist.is_allowed_currency('EUR')).toBe(false)
+  })
+
+  it('keeps adding an existing entry idempotent', () => {
+    const whitelist = new CurrencyWhitelist(['USD'])
+
+    const result = whitelist.add_currency(' usd ', adminCtx)
+
+    expect(result.description).toContain('already present')
+    expect(snapshotValues(whitelist)).toEqual(['USD'])
+  })
+
+  it('removes currencies after normalization and treats missing entries as no-ops', () => {
+    const whitelist = new CurrencyWhitelist(['USD', 'EUR'])
+
+    expect(whitelist.remove_currency(' usd ', adminCtx).description).toBe(
+      'remove_currency(USD): removed',
+    )
+    expect(whitelist.remove_currency('gbp', adminCtx).description).toContain(
+      'not present',
+    )
+    expect(snapshotValues(whitelist)).toEqual(['EUR'])
+  })
+
+  it('clears currencies idempotently', () => {
+    const whitelist = new CurrencyWhitelist(['USD', 'EUR'])
+
+    expect(whitelist.clear_currencies(adminCtx).description).toBe(
+      'clear_currencies(): whitelist cleared',
+    )
+    expect(whitelist.size).toBe(0)
+    expect(whitelist.clear_currencies(adminCtx).currencies.size).toBe(0)
+  })
+
+  it('rejects malformed codes for constructor, reads, and mutations', () => {
+    expect(() => new CurrencyWhitelist(['usd', 'USDD'])).toThrow(TypeError)
+
+    const whitelist = new CurrencyWhitelist(['USD'])
+
+    expect(() => whitelist.is_allowed_currency('USDD')).toThrow(TypeError)
+    expect(() => whitelist.add_currency('12$', adminCtx)).toThrow(TypeError)
+    expect(() => whitelist.remove_currency('\u20acUR', adminCtx)).toThrow(TypeError)
+    expect(() => whitelist.set_currencies(['USD', 'EURO'], adminCtx)).toThrow(
+      TypeError,
+    )
+    expect(snapshotValues(whitelist)).toEqual(['USD'])
+  })
+
+  it('allows super-admin mutations but rejects missing or non-admin contexts', () => {
+    const whitelist = new CurrencyWhitelist()
+
+    expect(() => whitelist.add_currency('USD', undefined as unknown as AdminContext))
+      .toThrow(/Admin context is required/)
+    expect(() =>
+      whitelist.add_currency('USD', { userId: 'user-1', role: 'viewer' }),
+    ).toThrow(/not permitted/)
+
+    whitelist.add_currency('USD', { userId: 'super-1', role: 'super-admin' })
+
+    expect(whitelist.is_allowed_currency('usd')).toBe(true)
+  })
+
+  it('sets currencies in an order-insensitive way after normalization', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.constantFrom('usd', ' EUR ', 'gbp', 'Cad'), {
+          minLength: 1,
+          maxLength: 20,
+        }),
+        (codes) => {
+          const forward = new CurrencyWhitelist()
+          const reverse = new CurrencyWhitelist()
+
+          forward.set_currencies(codes, adminCtx)
+          reverse.set_currencies([...codes].reverse(), adminCtx)
+
+          expect(snapshotValues(forward)).toEqual(snapshotValues(reverse))
+        },
+      ),
+    )
+  })
+})

--- a/src/services/currency/whitelist.ts
+++ b/src/services/currency/whitelist.ts
@@ -48,6 +48,22 @@ export interface WhitelistMutationResult {
 
 /** Roles that are permitted to mutate the whitelist. */
 const ADMIN_ROLES = new Set(['admin', 'super-admin'])
+const ISO_4217_CODE = /^[A-Z]{3}$/
+
+/**
+ * Normalises a caller-supplied ISO 4217 currency code.
+ *
+ * Canonical form is exactly three ASCII uppercase letters. Rejecting anything
+ * else keeps look-alike Unicode, blank strings, and concatenated symbols out
+ * of the allow-list security boundary.
+ */
+export function normalize_currency_code(currency: string): string {
+  const normalised = currency.trim().toUpperCase()
+  if (!ISO_4217_CODE.test(normalised)) {
+    throw new TypeError(`Invalid ISO 4217 currency code: ${currency}`)
+  }
+  return normalised
+}
 
 /**
  * Throws {@link UnauthorizedError} when `ctx` is absent and
@@ -96,7 +112,7 @@ export class CurrencyWhitelist {
    */
   constructor(initial: Iterable<string> = []) {
     this._set = new Set(
-      [...initial].map((c) => c.trim().toUpperCase()),
+      [...initial].map((c) => normalize_currency_code(c)),
     )
   }
 
@@ -112,7 +128,7 @@ export class CurrencyWhitelist {
    * @param currency - ISO 4217 code to test (e.g. `"usd"` or `"USD"`).
    */
   is_allowed_currency(currency: string): boolean {
-    return this._set.has(currency.trim().toUpperCase())
+    return this._set.has(normalize_currency_code(currency))
   }
 
   /**
@@ -146,7 +162,7 @@ export class CurrencyWhitelist {
    */
   add_currency(currency: string, ctx: AdminContext): WhitelistMutationResult {
     assertAdmin(ctx)
-    const normalised = currency.trim().toUpperCase()
+    const normalised = normalize_currency_code(currency)
     const wasPresent = this._set.has(normalised)
     this._set.add(normalised)
     return {
@@ -171,7 +187,7 @@ export class CurrencyWhitelist {
    */
   remove_currency(currency: string, ctx: AdminContext): WhitelistMutationResult {
     assertAdmin(ctx)
-    const normalised = currency.trim().toUpperCase()
+    const normalised = normalize_currency_code(currency)
     const wasPresent = this._set.has(normalised)
     this._set.delete(normalised)
     return {
@@ -197,13 +213,14 @@ export class CurrencyWhitelist {
    */
   set_currencies(currencies: string[], ctx: AdminContext): WhitelistMutationResult {
     assertAdmin(ctx)
+    const normalisedCurrencies = currencies.map((c) => normalize_currency_code(c))
     this._set.clear()
-    for (const c of currencies) {
-      this._set.add(c.trim().toUpperCase())
+    for (const c of normalisedCurrencies) {
+      this._set.add(c)
     }
     return {
       currencies: this.snapshot(),
-      description: `set_currencies([${currencies.map((c) => c.trim().toUpperCase()).join(', ')}]): whitelist replaced`,
+      description: `set_currencies([${[...this._set].join(', ')}]): whitelist replaced`,
     }
   }
 


### PR DESCRIPTION
Closes #458

## Summary
- add `src/services/currency/whitelist.test.ts` with deterministic Vitest coverage for add/remove, idempotent add, empty vs populated lookups, admin guard behavior, and malformed code rejection
- add fast-check property tests for normalization idempotence and order-insensitive set replacement
- centralize currency normalization in `normalize_currency_code`
- validate canonical ISO 4217-style codes as exactly three ASCII uppercase letters after trim/case normalization
- keep `set_currencies` atomic by validating all inputs before replacing the current whitelist

## Verification
- `npm test -- whitelist`
- `npm exec -- vitest run src/services/currency/whitelist.test.ts --coverage --coverage.include=src/services/currency/whitelist.ts` (100% statements/branches/functions/lines for `whitelist.ts`)

Also attempted:
- `npm run lint` currently fails before linting because `eslint.config.js` imports missing `src/observability/eslint-plugin-logger-schema.js`
- `npm run build` currently fails on existing unrelated project-wide TypeScript errors outside the currency whitelist service

## Security
The whitelist now rejects malformed, non-ASCII, overlong, and look-alike currency codes instead of silently adding them to the allow-list security boundary.