### PR TITLE
test(decimal): add property coverage for rounding and multiply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -616,10 +615,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1852,7 +1874,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2138,7 +2159,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2415,6 +2435,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
@@ -2835,7 +2889,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3029,7 +3082,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3510,7 +3562,6 @@
       "integrity": "sha512-lOt/VDh+sihAx3OUxCE5CC0qZfAhIzE3Dxw75NJ3P0C6ruUgT9b/jZKECE1ctpbxSVic9OkLdXz5UEX39ks4Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3536,7 +3587,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -3716,7 +3766,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4450,7 +4499,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5541,7 +5589,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6991,7 +7038,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8863,7 +8909,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10826,7 +10871,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10935,7 +10979,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11126,7 +11169,6 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11205,7 +11247,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -11665,7 +11706,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/decimalMath.test.ts
+++ b/src/lib/decimalMath.test.ts
@@ -1,17 +1,170 @@
 /**
  * Unit tests for decimal-safe arithmetic utilities.
  *
- * Table-driven tests cover boundary values, rounding modes, sign handling,
- * scale edge cases, and multi-precision inputs.
+ * Table-driven and property-based tests cover boundary values, rounding modes,
+ * sign handling, scale edge cases, and multi-precision inputs.
  */
 
 import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
 import {
   roundToScale,
   multiplyDecimals,
   RoundingMode,
   DEFAULT_ROUNDING_MODE,
 } from './decimalMath.js'
+
+const propertyConfig = { numRuns: 250 }
+
+interface DecimalParts {
+  negative: boolean
+  intPart: string
+  fracPart: string
+}
+
+interface UnsignedDecimalCase {
+  value: string
+  intPart: string
+  fracPart: string
+}
+
+interface SignedDecimalCase extends UnsignedDecimalCase {
+  negative: boolean
+}
+
+const digitsToBigInt = (digits: string): bigint =>
+  BigInt(digits.replace(/^0+/, '') || '0')
+
+const tenPow = (scale: number): bigint => 10n ** BigInt(scale)
+
+const formatUnsignedScaled = (value: bigint, scale: number): string => {
+  if (scale === 0) return value.toString()
+
+  const factor = tenPow(scale)
+  const intPart = value / factor
+  const fracPart = value % factor
+
+  return `${intPart}.${fracPart.toString().padStart(scale, '0')}`
+}
+
+const formatReference = (
+  value: bigint,
+  scale: number,
+  negative: boolean,
+): string => {
+  const formatted = formatUnsignedScaled(value, scale)
+
+  return negative && value !== 0n ? `-${formatted}` : formatted
+}
+
+const parseDecimalForTest = (value: string): DecimalParts => {
+  const negative = value.startsWith('-')
+  const abs = negative ? value.slice(1) : value
+  const [intPart, fracPart = ''] = abs.split('.')
+
+  return { negative, intPart, fracPart }
+}
+
+const decimalMagnitudeAtScale = (
+  value: string,
+  targetScale: number,
+): { truncated: bigint; remainder: bigint; shiftFactor: bigint } => {
+  const { intPart, fracPart } = parseDecimalForTest(value)
+  const inputScale = fracPart.length
+  const intValue = digitsToBigInt(`${intPart}${fracPart}`)
+
+  if (inputScale <= targetScale) {
+    return {
+      truncated: intValue * tenPow(targetScale - inputScale),
+      remainder: 0n,
+      shiftFactor: 1n,
+    }
+  }
+
+  const shiftFactor = tenPow(inputScale - targetScale)
+
+  return {
+    truncated: intValue / shiftFactor,
+    remainder: intValue % shiftFactor,
+    shiftFactor,
+  }
+}
+
+const parseOutputMagnitude = (value: string, scale: number): bigint => {
+  const abs = value.startsWith('-') ? value.slice(1) : value
+  const [intPart, fracPart = ''] = abs.split('.')
+
+  expect(fracPart.length).toBe(scale)
+
+  return digitsToBigInt(`${intPart}${fracPart}`)
+}
+
+const referenceRound = (
+  value: string,
+  scale: number,
+  mode: RoundingMode,
+): string => {
+  const { negative } = parseDecimalForTest(value)
+  const { truncated, remainder, shiftFactor } = decimalMagnitudeAtScale(
+    value,
+    scale,
+  )
+  const twice = remainder * 2n
+  let rounded: bigint = truncated
+
+  switch (mode) {
+    case RoundingMode.DOWN:
+      rounded = truncated
+      break
+    case RoundingMode.UP:
+      rounded = remainder > 0n ? truncated + 1n : truncated
+      break
+    case RoundingMode.HALF_UP:
+      rounded = twice >= shiftFactor ? truncated + 1n : truncated
+      break
+    case RoundingMode.HALF_DOWN:
+      rounded = twice > shiftFactor ? truncated + 1n : truncated
+      break
+    case RoundingMode.HALF_EVEN:
+      if (twice > shiftFactor) rounded = truncated + 1n
+      else if (twice < shiftFactor) rounded = truncated
+      else rounded = truncated % 2n === 0n ? truncated : truncated + 1n
+      break
+  }
+
+  return formatReference(rounded, scale, negative)
+}
+
+const digitStringArb = (minLength: number, maxLength: number) =>
+  fc
+    .array(fc.integer({ min: 0, max: 9 }), { minLength, maxLength })
+    .map((digits) => digits.join(''))
+
+const unsignedDecimalArb: fc.Arbitrary<UnsignedDecimalCase> = fc
+  .record({
+    intPart: digitStringArb(1, 18),
+    fracPart: digitStringArb(0, 12),
+  })
+  .map(({ intPart, fracPart }) => ({
+    value: fracPart.length === 0 ? intPart : `${intPart}.${fracPart}`,
+    intPart,
+    fracPart,
+  }))
+
+const signedDecimalArb: fc.Arbitrary<SignedDecimalCase> = fc
+  .record({
+    decimal: unsignedDecimalArb,
+    negative: fc.boolean(),
+  })
+  .map(({ decimal, negative }) => ({
+    ...decimal,
+    value: negative ? `-${decimal.value}` : decimal.value,
+    negative,
+  }))
+
+const scaleArb = fc.integer({ min: 0, max: 8 })
+const roundingModeArb = fc.constantFrom(...Object.values(RoundingMode))
+const negativeZeroPattern = /^-0(?:\.0+)?$/
 
 describe('decimalMath', () => {
   describe('DEFAULT_ROUNDING_MODE', () => {
@@ -172,6 +325,158 @@ describe('decimalMath', () => {
       })
     })
 
+    describe('property-based rounding invariants', () => {
+      it('matches a BigInt reference model for all rounding modes', () => {
+        fc.assert(
+          fc.property(
+            signedDecimalArb,
+            scaleArb,
+            roundingModeArb,
+            ({ value }, scale, mode) => {
+              expect(roundToScale(value, scale, mode)).toBe(
+                referenceRound(value, scale, mode),
+              )
+            },
+          ),
+          propertyConfig,
+        )
+      })
+
+      it('always returns a normalized scale and never returns negative zero', () => {
+        fc.assert(
+          fc.property(
+            signedDecimalArb,
+            scaleArb,
+            roundingModeArb,
+            ({ value }, scale, mode) => {
+              const result = roundToScale(value, scale, mode)
+              const pattern =
+                scale === 0
+                  ? /^-?\d+$/
+                  : new RegExp(`^-?\\d+\\.\\d{${scale}}$`)
+
+              expect(result).toMatch(pattern)
+              expect(result).not.toMatch(negativeZeroPattern)
+            },
+          ),
+          propertyConfig,
+        )
+      })
+
+      it('keeps rounded magnitudes within one unit of the truncated scale', () => {
+        fc.assert(
+          fc.property(
+            signedDecimalArb,
+            scaleArb,
+            roundingModeArb,
+            ({ value }, scale, mode) => {
+              const { truncated, remainder } = decimalMagnitudeAtScale(
+                value,
+                scale,
+              )
+              const rounded = parseOutputMagnitude(
+                roundToScale(value, scale, mode),
+                scale,
+              )
+              const maxRounded =
+                remainder > 0n ? truncated + 1n : truncated
+
+              expect(rounded >= truncated).toBe(true)
+              expect(rounded <= maxRounded).toBe(true)
+            },
+          ),
+          propertyConfig,
+        )
+      })
+
+      it('orders positive DOWN and UP bounds around half rounding modes', () => {
+        fc.assert(
+          fc.property(unsignedDecimalArb, scaleArb, ({ value }, scale) => {
+            const down = parseOutputMagnitude(
+              roundToScale(value, scale, RoundingMode.DOWN),
+              scale,
+            )
+            const up = parseOutputMagnitude(
+              roundToScale(value, scale, RoundingMode.UP),
+              scale,
+            )
+
+            for (const mode of [
+              RoundingMode.HALF_UP,
+              RoundingMode.HALF_DOWN,
+              RoundingMode.HALF_EVEN,
+            ]) {
+              const rounded = parseOutputMagnitude(
+                roundToScale(value, scale, mode),
+                scale,
+              )
+
+              expect(rounded >= down).toBe(true)
+              expect(rounded <= up).toBe(true)
+            }
+          }),
+          propertyConfig,
+        )
+      })
+
+      it('rounds exact HALF_EVEN midpoints to an even final digit', () => {
+        const midpointArb = fc
+          .record({
+            truncated: fc.integer({ min: 0, max: 1_000_000 }),
+            scale: fc.integer({ min: 0, max: 6 }),
+            extraDigits: fc.integer({ min: 1, max: 6 }),
+          })
+          .map(({ truncated, scale, extraDigits }) => {
+            const truncatedMagnitude = BigInt(truncated)
+            const raw =
+              truncatedMagnitude * tenPow(extraDigits) +
+              5n * tenPow(extraDigits - 1)
+
+            return {
+              input: formatUnsignedScaled(raw, scale + extraDigits),
+              scale,
+              truncated: truncatedMagnitude,
+            }
+          })
+
+        fc.assert(
+          fc.property(midpointArb, ({ input, scale, truncated }) => {
+            const result = parseOutputMagnitude(
+              roundToScale(input, scale, RoundingMode.HALF_EVEN),
+              scale,
+            )
+            const expected =
+              truncated % 2n === 0n ? truncated : truncated + 1n
+
+            expect(result).toBe(expected)
+            expect(result % 2n).toBe(0n)
+          }),
+          propertyConfig,
+        )
+      })
+
+      it('keeps HALF_UP and HALF_DOWN symmetric for negative values', () => {
+        fc.assert(
+          fc.property(
+            unsignedDecimalArb,
+            scaleArb,
+            fc.constantFrom(RoundingMode.HALF_UP, RoundingMode.HALF_DOWN),
+            ({ value }, scale, mode) => {
+              const positive = roundToScale(value, scale, mode)
+              const negative = roundToScale(`-${value}`, scale, mode)
+              const expected =
+                parseOutputMagnitude(positive, scale) === 0n
+                  ? positive
+                  : `-${positive}`
+
+              expect(negative).toBe(expected)
+            },
+          ),
+          propertyConfig,
+        )
+      })
+    })
+
     describe('error handling', () => {
       it('throws for negative scale', () => {
         expect(() => roundToScale('1.5', -1)).toThrow()
@@ -214,6 +519,31 @@ describe('decimalMath', () => {
     it('preserves trailing zeros in fractional scale', () => {
       // "1.0" has fracStr length 1, "2.0" has fracStr length 1 → scale 2
       expect(multiplyDecimals('1.0', '2.0')).toBe('2.00')
+    })
+
+    describe('property-based multiplication invariants', () => {
+      it('matches exact BigInt multiplication and preserves product scale', () => {
+        fc.assert(
+          fc.property(signedDecimalArb, signedDecimalArb, (a, b) => {
+            const result = multiplyDecimals(a.value, b.value)
+            const aInt = digitsToBigInt(`${a.intPart}${a.fracPart}`)
+            const bInt = digitsToBigInt(`${b.intPart}${b.fracPart}`)
+            const product = aInt * bInt
+            const scale = a.fracPart.length + b.fracPart.length
+            const expected = formatReference(
+              product,
+              scale,
+              a.negative !== b.negative,
+            )
+            const [, fracPart = ''] = result.replace(/^-/, '').split('.')
+
+            expect(result).toBe(expected)
+            expect(fracPart.length).toBe(scale)
+            expect(result).not.toMatch(negativeZeroPattern)
+          }),
+          propertyConfig,
+        )
+      })
     })
   })
 })

--- a/src/lib/decimalMath.ts
+++ b/src/lib/decimalMath.ts
@@ -132,7 +132,7 @@ export function roundToScale(
     const frac = fracStr.length > 0 ? BigInt(fracStr) : 0n
     const scaled = int * (10n ** BigInt(scale)) + frac * (10n ** BigInt(pad))
     const formatted = formatScaledInt(scaled, scale)
-    return negative && int !== 0n ? `-${formatted}` : formatted
+    return negative && scaled !== 0n ? `-${formatted}` : formatted
   }
 
   // Full-precision integer: digits left of point || digits right of point.


### PR DESCRIPTION
## Summary
- add fast-check property coverage for decimalMath rounding modes, including HALF_EVEN midpoint behavior, ULP bounds, normalized output scale, and negative-value symmetry
- add exact BigInt-reference property coverage for multiplyDecimals scale preservation
- fix roundToScale's no-rounding negative small-value sign handling by checking the scaled magnitude instead of just the integer part
- refresh package-lock entries needed for npm ci to resolve current optional dependency metadata

Closes #514.

## Validation
- npm run test -- decimalMath
- npm run build
- node --import tsx ./node_modules/eslint/bin/eslint.js src/lib/decimalMath.ts src/lib/decimalMath.test.ts
- npm exec --yes --package npm@10 -- npm ci --ignore-scripts --dry-run --cache E:\codex-tools\npm-cache --no-audit --no-fund

Note: full npm run lint is currently blocked on origin/main by an unrelated parse error in src/services/keyManager/kekManager.test.ts line 23, plus existing logger-schema warnings. The touched decimalMath files lint cleanly.