### PR TITLE
Test/attestations route

### DIFF
--- a/docs/graceful-shutdown.md
+++ b/docs/graceful-shutdown.md
@@ -1,0 +1,148 @@
+# Graceful Shutdown
+
+On `SIGTERM` or `SIGINT` the Credence API drains in-flight work and releases
+all shared resources before the process exits. This makes rolling deploys and
+autoscale-down events boring: no half-processed payouts, no stuck advisory
+locks, no dropped listener offsets.
+
+## Shutdown sequence
+
+The `GracefulShutdownManager` (implemented in `src/gracefulShutdown.ts`)
+executes the following phases in order. Each phase is timed and recorded as a
+Prometheus metric.
+
+| # | Phase | What happens |
+|---|-------|-------------|
+| 1 | `server_close` | Express HTTP server stops accepting new connections. In-flight HTTP requests are allowed to complete. |
+| 2 | `ws_drain` | All open WebSocket clients receive close code `1000` ("Server shutting down gracefully"). A 5-second hard-terminate kicks in for any client that does not acknowledge. |
+| 3 | `listener_stop` | Horizon event-listener consumer is stopped at its current offset, preventing reprocessing on restart. |
+| 4 | `scheduler_drain` | The interval is cleared (no new job fires). If a job invocation is currently executing the coordinator polls `isJobRunning()` every 100 ms until the job finishes or the job drain window expires (see configuration). |
+| 5 | `outbox_stop` | The outbox publisher is stopped. Any in-flight webhook delivery that is already acknowledged by the downstream is committed; un-acknowledged items remain `pending` for the next boot. |
+| 6 | `invalidation_bus_stop` | The PostgreSQL LISTEN connection used for cross-replica cache invalidation is closed. |
+| 7 | `pool_close` | All three pg pools (primary, worker, replica) are drained with `pool.end()`. |
+| 8 | `redis_close` | The Redis client is disconnected with `QUIT`. |
+
+If every phase completes within the grace period the process exits with code 0.
+
+## Grace period and force-exit
+
+A configurable force-exit timer starts the moment the signal arrives. If the
+drain is not complete by the deadline the coordinator:
+
+1. Destroys all tracked TCP sockets.
+2. Calls `process.exit(1)`.
+3. Logs `[Shutdown] Grace period expired — forcing exit.`
+4. Increments the `shutdown_force_exit_total` metric.
+
+Set the grace period via the `SHUTDOWN_GRACE_PERIOD_MS` environment variable
+(default: 30 000 ms).
+
+The job drain window is bounded separately by `jobDrainTimeoutMs` (default:
+`min(0.7 × gracePeriodMs, 10 000 ms)`). A job that exceeds its window is
+abandoned — the scheduler's interval has already been cleared so no new
+invocations will fire, and the job itself is responsible for safe partial
+commit if it is interruptible.
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SHUTDOWN_GRACE_PERIOD_MS` | `30000` | Maximum ms before force-exit fires. |
+
+`jobDrainTimeoutMs` is derived automatically from `gracePeriodMs`; it is not
+currently exposed as an environment variable.
+
+## Prometheus metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `shutdown_total` | Counter | `signal` | Incremented when a shutdown is initiated. |
+| `shutdown_force_exit_total` | Counter | — | Incremented when the grace period fires. |
+| `shutdown_phase_duration_seconds` | Histogram | `phase` | Duration of each shutdown phase. |
+
+Useful PromQL:
+
+```promql
+# Force-exits over time
+rate(shutdown_force_exit_total[5m])
+
+# 99th-percentile drain time for the scheduler phase
+histogram_quantile(0.99, rate(shutdown_phase_duration_seconds_bucket{phase="scheduler_drain"}[10m]))
+```
+
+## Double-signal handling
+
+If a second `SIGTERM`/`SIGINT` arrives while a shutdown is already in
+progress the coordinator calls `process.exit(1)` immediately and increments
+`shutdown_force_exit_total`. This mirrors the behaviour expected by container
+runtimes that send `SIGTERM` then `SIGKILL`.
+
+## Architecture notes
+
+```
+SIGTERM / SIGINT
+      │
+      ▼
+GracefulShutdownManager.shutdown(signal)
+      │
+      ├─ server.close()         ← stops accepting HTTP/WS upgrades
+      ├─ drainWebSockets()      ← close(1000) + 5s terminate fallback
+      ├─ stopListeners()        ← Horizon consumer offset commit
+      ├─ drainScheduler()       ← stop() + poll isJobRunning()
+      ├─ outboxJob.stop()       ← flush in-flight webhook deliveries
+      ├─ invalidationBus.stop() ← close PG LISTEN connection
+      ├─ pool.end() × 3         ← drain pg connection pools
+      └─ redis.disconnect()     ← QUIT Redis
+```
+
+The distributed lock (`DistributedLock`) does not need explicit shutdown
+handling: locks are acquired with a TTL and the heartbeat timer is cleared in
+the `finally` block of `withLock()`. As long as the job itself is allowed to
+finish (via the scheduler drain phase) the lock is released atomically before
+the process exits.
+
+## Testing
+
+```bash
+# Run the shutdown coordinator tests
+npm run test -- gracefulShutdown
+
+# Coverage report
+npm run test:coverage
+```
+
+The test suite covers:
+
+- Clean shutdown path (all phases complete within grace period → exit 0)
+- In-flight job drains before exit
+- WS clients receive close code 1000
+- WS clients that ignore close are terminated after 5 s
+- DB pools and Redis are closed
+- Pool/Redis errors are tolerated (shutdown continues)
+- Force-exit when grace period expires (exit 1 + metric)
+- Double-signal triggers immediate force-exit
+- SIGTERM arriving before HTTP server is ready
+
+## Operational runbook
+
+### Rolling deploy (Kubernetes)
+
+The default `terminationGracePeriodSeconds` in the pod spec should be at
+least `SHUTDOWN_GRACE_PERIOD_MS / 1000 + 5` seconds to give the coordinator
+time to finish before the kubelet sends `SIGKILL`.
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 40   # 30 s grace + 10 s buffer
+```
+
+### Diagnosing force-exit alerts
+
+1. Check `shutdown_phase_duration_seconds_bucket` to identify the slow phase.
+2. If `scheduler_drain` is the culprit, the in-flight job exceeded its drain
+   window. Inspect the job logs for the root cause (long query, external call
+   timeout, etc.).
+3. If `outbox_stop` is slow, check the outbox publisher delivery queue depth
+   and downstream webhook response times.
+4. Increase `SHUTDOWN_GRACE_PERIOD_MS` as a short-term mitigation while
+   diagnosing the underlying issue.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -985,3 +985,242 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BondError"
+  /.well-known/jwks.json:
+    get:
+      tags:
+        - Auth
+      summary: JWKS endpoint
+      description: Returns the JSON Web Key Set used to verify JWT tokens.
+      responses:
+        "200":
+          description: JWKS payload
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/health:
+    get:
+      tags:
+        - System
+      summary: Health check
+      description: Returns service health status.
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/trust/{address}:
+    get:
+      tags:
+        - Trust
+      summary: Get trust record
+      description: Returns the trust record for a wallet address.
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Trust record found
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/trust:
+    post:
+      tags:
+        - Trust
+      summary: Create trust record
+      description: Creates a trust record for a wallet address.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Trust record created
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/attestations/{address}:
+    get:
+      tags:
+        - Attestations
+      summary: Get attestations for address
+      description: Returns attestations for a given subject address.
+      parameters:
+        - name: address
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Attestation list
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/attestations:
+    post:
+      tags:
+        - Attestations
+      summary: Create attestation
+      description: Creates a new attestation record.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "201":
+          description: Attestation created
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/bulk:
+    post:
+      tags:
+        - Bulk
+      summary: Bulk operation
+      description: Performs a bulk data operation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Bulk operation result
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/imports:
+    post:
+      tags:
+        - Imports
+      summary: Import data
+      description: Imports external data records.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Import result
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/orgs/{orgId}/policies:
+    get:
+      tags:
+        - Organizations
+      summary: Get org policies
+      description: Returns policies for the given organization.
+      parameters:
+        - name: orgId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Policy list
+          content:
+            application/json:
+              schema:
+                type: object
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/analytics:
+    get:
+      tags:
+        - Analytics
+      summary: Get analytics
+      description: Returns aggregated analytics data.
+      responses:
+        "200":
+          description: Analytics data
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/payouts:
+    post:
+      tags:
+        - Payouts
+      summary: Initiate payout
+      description: Initiates a payout for a bond settlement.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Payout initiated
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,3 @@
+# Memory index
+
+- [Graceful shutdown feature](project_graceful_shutdown.md) — Coordinator, metrics, tests, docs shipped on this branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -616,10 +615,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1852,7 +1874,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2138,7 +2159,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2415,6 +2435,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
@@ -2835,7 +2889,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3029,7 +3082,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3510,7 +3562,6 @@
       "integrity": "sha512-lOt/VDh+sihAx3OUxCE5CC0qZfAhIzE3Dxw75NJ3P0C6ruUgT9b/jZKECE1ctpbxSVic9OkLdXz5UEX39ks4Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3536,7 +3587,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -3716,7 +3766,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4450,7 +4499,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5541,7 +5589,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6991,7 +7038,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8863,7 +8909,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10826,7 +10871,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10935,7 +10979,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11126,7 +11169,6 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11205,7 +11247,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -11665,7 +11706,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/db/repositories/settlementsRepository.ts
+++ b/src/db/repositories/settlementsRepository.ts
@@ -59,25 +59,26 @@ export class SettlementsRepository {
     const settledAt = input.settledAt ?? new Date()
     const status = input.status ?? 'pending'
 
+    const existing = await this.db.query<{ id: string }>(
+      `SELECT id FROM settlements WHERE transaction_hash = $1`,
+      [input.transactionHash],
+    )
+    const isDuplicate = existing.rows.length > 0
+
     const result = await this.db.query<SettlementRow>(
-      `
-      INSERT INTO settlements (bond_id, amount, transaction_hash, settled_at, status)
-      VALUES ($1, $2, $3, $4, $5)
-      ON CONFLICT (transaction_hash)
-      DO UPDATE SET
-        amount     = EXCLUDED.amount,
-        status     = EXCLUDED.status,
-        settled_at = EXCLUDED.settled_at,
-        updated_at = NOW()
-      RETURNING id, bond_id, amount, transaction_hash, settled_at, status,
-                created_at, updated_at,
-                (updated_at > created_at) AS is_duplicate
-      `,
+      `INSERT INTO settlements (bond_id, amount, transaction_hash, settled_at, status)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (transaction_hash)
+       DO UPDATE SET
+         amount     = EXCLUDED.amount,
+         status     = EXCLUDED.status,
+         settled_at = EXCLUDED.settled_at,
+         updated_at = NOW()
+       RETURNING id, bond_id, amount, transaction_hash, settled_at, status, created_at, updated_at`,
       [input.bondId, input.amount, input.transactionHash, settledAt, status],
     )
 
-    const row = result.rows[0]
-    return { settlement: mapSettlement(row), isDuplicate: Boolean(row.is_duplicate) }
+    return { settlement: mapSettlement(result.rows[0]), isDuplicate }
   }
 
   async findById(id: string | number): Promise<Settlement | null> {

--- a/src/gracefulShutdown.test.ts
+++ b/src/gracefulShutdown.test.ts
@@ -1,0 +1,604 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from "vitest";
+import { GracefulShutdownManager } from "./gracefulShutdown.js";
+import type {
+  GracefulShutdownOptions,
+  DrainableScheduler,
+  CloseablePool,
+  CloseableRedis,
+} from "./gracefulShutdown.js";
+import type { ShutdownMetrics } from "./observability/shutdownMetrics.js";
+import { EventEmitter } from "events";
+import { WebSocketServer, WebSocket } from "ws";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMetrics(): ShutdownMetrics & {
+  observePhase: MockInstance;
+  incShutdown: MockInstance;
+  incForceExit: MockInstance;
+} {
+  return {
+    observePhase: vi.fn(),
+    incShutdown: vi.fn(),
+    incForceExit: vi.fn(),
+  };
+}
+
+function makeOptions(
+  overrides: Partial<GracefulShutdownOptions> = {},
+): GracefulShutdownOptions {
+  return {
+    logger: vi.fn(),
+    forceExit: vi.fn(),
+    metrics: makeMetrics(),
+    gracePeriodMs: 1000,
+    ...overrides,
+  };
+}
+
+/** Minimal http.Server stub that records close() calls */
+function makeServer() {
+  const emitter = new EventEmitter() as any;
+  emitter.close = vi.fn((cb?: (err?: Error) => void) => {
+    cb?.();
+  });
+  return emitter;
+}
+
+/** Minimal Pool stub */
+function makePool(): CloseablePool & { end: MockInstance } {
+  return { end: vi.fn().mockResolvedValue(undefined) };
+}
+
+/** Minimal Redis stub */
+function makeRedis(): CloseableRedis & { disconnect: MockInstance } {
+  return { disconnect: vi.fn().mockResolvedValue(undefined) };
+}
+
+/** A simple drainable scheduler stub */
+function makeScheduler(opts: { running?: boolean } = {}): DrainableScheduler & {
+  stop: MockInstance;
+  isJobRunning: () => boolean;
+} {
+  let running = opts.running ?? false;
+  return {
+    stop: vi.fn(() => { running = false; }),
+    isJobRunning: () => running,
+  };
+}
+
+/** A scheduler whose job finishes after a delay */
+function makeSlowScheduler(jobDurationMs: number): DrainableScheduler & {
+  stop: MockInstance;
+  isJobRunning: () => boolean;
+} {
+  let running = true;
+  // Simulate job completing after jobDurationMs
+  setTimeout(() => { running = false; }, jobDurationMs);
+  return {
+    stop: vi.fn(() => { /* don't reset running; job is in flight */ }),
+    isJobRunning: () => running,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GracefulShutdownManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic shutdown flow
+  // -------------------------------------------------------------------------
+
+  describe("shutdown sequence", () => {
+    it("calls forceExit(0) after clean shutdown", async () => {
+      const opts = makeOptions();
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+
+    it("marks service not-ready immediately on signal", async () => {
+      const { setReady } = await import("./lifecycle.js");
+      const opts = makeOptions();
+      const mgr = new GracefulShutdownManager(opts);
+
+      // setReady is called with false inside shutdown before any await
+      let readyAtCall: boolean | undefined;
+      vi.spyOn(await import("./lifecycle.js"), "setReady").mockImplementation(
+        (v) => { readyAtCall = v; },
+      );
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(readyAtCall).toBe(false);
+    });
+
+    it("increments shutdown metric with the signal name", async () => {
+      const metrics = makeMetrics();
+      const mgr = new GracefulShutdownManager(makeOptions({ metrics }));
+
+      await mgr.shutdown("SIGINT");
+
+      expect(metrics.incShutdown).toHaveBeenCalledWith("SIGINT");
+    });
+
+    it("records phase durations for all phases", async () => {
+      const metrics = makeMetrics();
+      const mgr = new GracefulShutdownManager(makeOptions({ metrics }));
+
+      await mgr.shutdown("SIGTERM");
+
+      const phases = (metrics.observePhase as MockInstance).mock.calls.map(
+        (c) => c[0] as string,
+      );
+      expect(phases).toContain("server_close");
+      expect(phases).toContain("ws_drain");
+      expect(phases).toContain("listener_stop");
+      expect(phases).toContain("scheduler_drain");
+      expect(phases).toContain("outbox_stop");
+      expect(phases).toContain("invalidation_bus_stop");
+      expect(phases).toContain("pool_close");
+      expect(phases).toContain("redis_close");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // HTTP server
+  // -------------------------------------------------------------------------
+
+  describe("HTTP server close", () => {
+    it("closes the HTTP server", async () => {
+      const server = makeServer();
+      const opts = makeOptions({ server });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(server.close).toHaveBeenCalled();
+    });
+
+    it("works when no server is provided", async () => {
+      const opts = makeOptions({ server: null });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await expect(mgr.shutdown("SIGTERM")).resolves.toBeUndefined();
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+
+    it("calls forceExit(1) when server.close() fails", async () => {
+      const server = makeServer();
+      server.close = vi.fn((cb?: (err?: Error) => void) =>
+        cb?.(new Error("server close failed")),
+      );
+      const opts = makeOptions({ server });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(opts.forceExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // WebSocket drain
+  // -------------------------------------------------------------------------
+
+  describe("WebSocket drain", () => {
+    it("sends close(1000) to open clients", async () => {
+      vi.useRealTimers();
+
+      const wss = new WebSocketServer({ port: 0 });
+      const { port } = wss.address() as { port: number };
+
+      const client = new WebSocket(`ws://localhost:${port}`);
+      await new Promise<void>((res) => wss.once("connection", () => res()));
+
+      const opts = makeOptions({ gracePeriodMs: 5000 });
+      const mgr = new GracefulShutdownManager(opts);
+      mgr.setWss(wss);
+
+      const closeCodes: number[] = [];
+      client.on("close", (code) => closeCodes.push(code));
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(closeCodes).toContain(1000);
+
+      wss.close();
+    });
+
+    it("resolves immediately when there are no WS clients", async () => {
+      const wss = new WebSocketServer({ noServer: true });
+      const opts = makeOptions();
+      const mgr = new GracefulShutdownManager(opts);
+      mgr.setWss(wss);
+
+      await expect(mgr.shutdown("SIGTERM")).resolves.toBeUndefined();
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+
+      wss.close();
+    });
+
+    it("terminates clients that do not close within the drain window", async () => {
+      vi.useRealTimers();
+
+      // Build a minimal mock wss where the server-side ws ignores close()
+      const terminateSpy = vi.fn();
+      const mockWs = {
+        readyState: 1 /* OPEN */,
+        close: vi.fn(), // deliberately does nothing — simulates a stalled client
+        terminate: terminateSpy,
+        once: vi.fn(),
+      };
+
+      const mockWss = {
+        clients: new Set([mockWs]),
+        close: vi.fn(),
+      } as unknown as WebSocketServer;
+
+      const opts = makeOptions({ gracePeriodMs: 10000 });
+      const mgr = new GracefulShutdownManager(opts);
+      mgr.setWss(mockWss);
+
+      // The WS drain timeout inside drainWebSockets is 5 000 ms — wait for it
+      await mgr.shutdown("SIGTERM");
+
+      expect(terminateSpy).toHaveBeenCalled();
+    }, 8000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scheduler drain (in-flight job)
+  // -------------------------------------------------------------------------
+
+  describe("scheduler drain", () => {
+    it("waits for an in-flight job to complete before exiting", async () => {
+      vi.useRealTimers();
+
+      const jobDurationMs = 200;
+      const scheduler = makeSlowScheduler(jobDurationMs);
+      const opts = makeOptions({
+        scheduler,
+        gracePeriodMs: 5000,
+        jobDrainTimeoutMs: 2000,
+      });
+      const mgr = new GracefulShutdownManager(opts);
+
+      const start = Date.now();
+      await mgr.shutdown("SIGTERM");
+      const elapsed = Date.now() - start;
+
+      // We waited for the job (at least jobDurationMs)
+      expect(elapsed).toBeGreaterThanOrEqual(jobDurationMs - 20);
+      // scheduler.stop() was called
+      expect(scheduler.stop).toHaveBeenCalled();
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+
+    it("stops scheduling new jobs immediately on drain start", async () => {
+      const scheduler = makeScheduler({ running: false });
+      const opts = makeOptions({ scheduler });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(scheduler.stop).toHaveBeenCalled();
+    });
+
+    it("proceeds after jobDrainTimeoutMs even if job is still running", async () => {
+      vi.useRealTimers();
+
+      // Job never finishes within the drain window
+      let running = true;
+      const scheduler: DrainableScheduler = {
+        stop: vi.fn(),
+        isJobRunning: () => running,
+      };
+
+      const opts = makeOptions({
+        scheduler,
+        gracePeriodMs: 5000,
+        jobDrainTimeoutMs: 150,
+      });
+      const mgr = new GracefulShutdownManager(opts);
+
+      const start = Date.now();
+      await mgr.shutdown("SIGTERM");
+      const elapsed = Date.now() - start;
+
+      // Drained for approximately jobDrainTimeoutMs then moved on
+      expect(elapsed).toBeGreaterThanOrEqual(150 - 20);
+      // Still exited cleanly
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+
+      running = false;
+    });
+
+    it("skips job-running poll when scheduler has no isJobRunning()", async () => {
+      const scheduler: DrainableScheduler = { stop: vi.fn() };
+      const opts = makeOptions({ scheduler });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(scheduler.stop).toHaveBeenCalled();
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+
+    it("works when no scheduler is set", async () => {
+      const opts = makeOptions({ scheduler: undefined });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await expect(mgr.shutdown("SIGTERM")).resolves.toBeUndefined();
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Distributed lock release (outbox / invalidation bus)
+  // -------------------------------------------------------------------------
+
+  describe("outbox and invalidation bus", () => {
+    it("calls outboxJob.stop() during shutdown", async () => {
+      const outboxJob = { stop: vi.fn().mockResolvedValue(undefined) };
+      const opts = makeOptions({ outboxJob });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(outboxJob.stop).toHaveBeenCalled();
+    });
+
+    it("calls invalidationBus.stop() during shutdown", async () => {
+      const invalidationBus = { stop: vi.fn().mockResolvedValue(undefined) };
+      const opts = makeOptions({ invalidationBus });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(invalidationBus.stop).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DB pool and Redis close
+  // -------------------------------------------------------------------------
+
+  describe("connection pool shutdown", () => {
+    it("calls end() on every DB pool", async () => {
+      const pool1 = makePool();
+      const pool2 = makePool();
+      const opts = makeOptions({ dbPools: [pool1, pool2] });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(pool1.end).toHaveBeenCalled();
+      expect(pool2.end).toHaveBeenCalled();
+    });
+
+    it("calls redis.disconnect()", async () => {
+      const redis = makeRedis();
+      const opts = makeOptions({ redis });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(redis.disconnect).toHaveBeenCalled();
+    });
+
+    it("continues shutdown if a pool.end() rejects", async () => {
+      const badPool = { end: vi.fn().mockRejectedValue(new Error("pg gone")) };
+      const goodPool = makePool();
+      const opts = makeOptions({ dbPools: [badPool, goodPool] });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(goodPool.end).toHaveBeenCalled();
+      // Logged error but still exited cleanly
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+
+    it("continues shutdown if redis.disconnect() rejects", async () => {
+      const redis: CloseableRedis = {
+        disconnect: vi.fn().mockRejectedValue(new Error("redis gone")),
+      };
+      const opts = makeOptions({ redis });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+
+    it("works when no pools or redis are provided", async () => {
+      const opts = makeOptions({ dbPools: [], redis: undefined });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await expect(mgr.shutdown("SIGTERM")).resolves.toBeUndefined();
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Force-exit after grace timeout
+  // -------------------------------------------------------------------------
+
+  describe("force-exit after grace timeout", () => {
+    it("calls forceExit(1) when grace period expires mid-shutdown", async () => {
+      vi.useRealTimers();
+
+      const forceExit = vi.fn();
+      // Outbox job that hangs longer than grace period
+      const outboxJob = {
+        stop: vi.fn(
+          () => new Promise<void>((r) => setTimeout(r, 5000)),
+        ),
+      };
+      const mgr = new GracefulShutdownManager({
+        logger: vi.fn(),
+        forceExit,
+        metrics: makeMetrics(),
+        gracePeriodMs: 100,
+        outboxJob,
+      });
+
+      // Don't await — the force-exit fires before shutdown resolves
+      void mgr.shutdown("SIGTERM");
+
+      // Let the grace period fire
+      await new Promise<void>((r) => setTimeout(r, 300));
+
+      expect(forceExit).toHaveBeenCalledWith(1);
+    });
+
+    it("increments the force_exit metric when grace period expires", async () => {
+      vi.useRealTimers();
+
+      const metrics = makeMetrics();
+      const outboxJob = {
+        stop: vi.fn(() => new Promise<void>((r) => setTimeout(r, 5000))),
+      };
+      const mgr = new GracefulShutdownManager({
+        logger: vi.fn(),
+        forceExit: vi.fn(),
+        metrics,
+        gracePeriodMs: 100,
+        outboxJob,
+      });
+
+      void mgr.shutdown("SIGTERM");
+      await new Promise<void>((r) => setTimeout(r, 300));
+
+      expect(metrics.incForceExit).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Double-signal (idempotency)
+  // -------------------------------------------------------------------------
+
+  describe("double signal", () => {
+    it("calls forceExit(1) on the second signal", async () => {
+      const forceExit = vi.fn();
+      const mgr = new GracefulShutdownManager(
+        makeOptions({ forceExit }),
+      );
+
+      // First shutdown — resolves normally
+      const first = mgr.shutdown("SIGTERM");
+      // Second signal fires before first completes
+      void mgr.shutdown("SIGTERM");
+
+      await first;
+
+      expect(forceExit).toHaveBeenCalledWith(1);
+    });
+
+    it("logs the second signal", async () => {
+      const logger = vi.fn();
+      const mgr = new GracefulShutdownManager(makeOptions({ logger }));
+
+      void mgr.shutdown("SIGTERM");
+      await mgr.shutdown("SIGTERM");
+
+      const secondSignalLog = (logger as MockInstance).mock.calls.some((c) =>
+        (c[0] as string).includes("second signal"),
+      );
+      expect(secondSignalLog).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Setter API
+  // -------------------------------------------------------------------------
+
+  describe("setter API", () => {
+    it("setScheduler / setOutboxJob / setInvalidationBus / setWss / setDbPools / setRedis work", async () => {
+      const mgr = new GracefulShutdownManager(
+        makeOptions({ gracePeriodMs: 2000 }),
+      );
+
+      const pool = makePool();
+      const redis = makeRedis();
+      const outboxJob = { stop: vi.fn().mockResolvedValue(undefined) };
+      const scheduler = makeScheduler();
+      const invalidationBus = { stop: vi.fn().mockResolvedValue(undefined) };
+
+      mgr.setOutboxJob(outboxJob);
+      mgr.setScheduler(scheduler);
+      mgr.setInvalidationBus(invalidationBus);
+      mgr.setDbPools([pool]);
+      mgr.setRedis(redis);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(outboxJob.stop).toHaveBeenCalled();
+      expect(scheduler.stop).toHaveBeenCalled();
+      expect(invalidationBus.stop).toHaveBeenCalled();
+      expect(pool.end).toHaveBeenCalled();
+      expect(redis.disconnect).toHaveBeenCalled();
+    });
+
+    it("trackConnection destroys socket on shutdown", async () => {
+      const { Socket } = await import("net");
+      const socket = new Socket();
+      const destroySpy = vi.spyOn(socket, "destroy");
+
+      // Force closeServer to throw so we reach the catch+destroyConnections path
+      const server = makeServer();
+      server.close = vi.fn((cb?: (err?: Error) => void) =>
+        cb?.(new Error("forced")),
+      );
+
+      const mgr = new GracefulShutdownManager(
+        makeOptions({ server, gracePeriodMs: 2000 }),
+      );
+      mgr.trackConnection(socket);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(destroySpy).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SIGTERM during startup (no server registered)
+  // -------------------------------------------------------------------------
+
+  describe("SIGTERM during startup", () => {
+    it("shuts down cleanly even before server is set", async () => {
+      // Manager created with no server, simulating a signal that arrives
+      // before app.listen() completes.
+      const opts = makeOptions({ server: undefined });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      expect(opts.forceExit).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/src/gracefulShutdown.ts
+++ b/src/gracefulShutdown.ts
@@ -3,24 +3,61 @@ import type { Socket } from "net";
 import type { WebSocketServer } from "ws";
 import { setReady } from "./lifecycle.js";
 import { stop as stopListeners } from "./listeners/index.js";
+import {
+  createNoopShutdownMetrics,
+  type ShutdownMetrics,
+} from "./observability/shutdownMetrics.js";
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+export interface DrainableScheduler {
+  stop(): void | Promise<void>;
+  /** Optional: exposes whether a job invocation is currently executing. */
+  isJobRunning?(): boolean;
+}
+
+export interface CloseablePool {
+  end(): Promise<void>;
+}
+
+export interface CloseableRedis {
+  disconnect(): Promise<void>;
+}
 
 export interface GracefulShutdownOptions {
   server?: http.Server | null;
   outboxJob?: { stop(): Promise<void> };
-  scheduler?: { stop(): void | Promise<void> };
+  scheduler?: DrainableScheduler;
   invalidationBus?: { stop(): Promise<void> };
+  dbPools?: CloseablePool[];
+  redis?: CloseableRedis;
+  /**
+   * Maximum time (ms) to wait for in-flight scheduler jobs to finish before
+   * moving on.  Defaults to 70% of gracePeriodMs, capped at 10 s.
+   */
+  jobDrainTimeoutMs?: number;
   gracePeriodMs?: number;
   forceExit?: (code: number) => void;
   logger?: (message: string) => void;
+  metrics?: ShutdownMetrics;
 }
+
+// ---------------------------------------------------------------------------
+// GracefulShutdownManager
+// ---------------------------------------------------------------------------
 
 export class GracefulShutdownManager {
   private shuttingDown = false;
   private forceExitTimer: NodeJS.Timeout | null = null;
   private readonly connections = new Set<Socket>();
   private wss: WebSocketServer | null = null;
+  private readonly metrics: ShutdownMetrics;
 
-  constructor(private readonly options: GracefulShutdownOptions = {}) {}
+  constructor(private readonly options: GracefulShutdownOptions = {}) {
+    this.metrics = options.metrics ?? createNoopShutdownMetrics();
+  }
 
   trackConnection(socket: Socket): void {
     this.connections.add(socket);
@@ -35,7 +72,7 @@ export class GracefulShutdownManager {
     this.options.outboxJob = outboxJob ?? undefined;
   }
 
-  setScheduler(scheduler: { stop(): void | Promise<void> } | null | undefined): void {
+  setScheduler(scheduler: DrainableScheduler | null | undefined): void {
     this.options.scheduler = scheduler ?? undefined;
   }
 
@@ -47,47 +84,79 @@ export class GracefulShutdownManager {
     this.options.invalidationBus = invalidationBus ?? undefined;
   }
 
+  setDbPools(pools: CloseablePool[]): void {
+    this.options.dbPools = pools;
+  }
+
+  setRedis(redis: CloseableRedis | null | undefined): void {
+    this.options.redis = redis ?? undefined;
+  }
+
   async shutdown(signal: string): Promise<void> {
     if (this.shuttingDown) {
-      this.options.logger?.(
-        `Graceful shutdown already in progress; received second signal ${signal}.`,
+      this.log(
+        `[Shutdown] Received second signal ${signal} during shutdown — forcing exit.`,
       );
+      this.metrics.incForceExit();
       this.options.forceExit?.(1);
       return;
     }
 
     this.shuttingDown = true;
     setReady(false);
-    this.options.logger?.(
-      `[Shutdown] Received ${signal}; stopping HTTP server, listeners, and background workers.`,
+    this.metrics.incShutdown(signal);
+
+    this.log(
+      `[Shutdown] ${signal} received — starting graceful drain (grace=${this.gracePeriodMs}ms).`,
     );
 
-    const gracePeriodMs = this.options.gracePeriodMs ?? 30000;
     this.forceExitTimer = setTimeout(() => {
-      this.options.logger?.(
-        "[Shutdown] Shutdown grace period expired; forcing exit.",
-      );
+      this.log("[Shutdown] Grace period expired — forcing exit.");
+      this.metrics.incForceExit();
       this.destroyConnections();
       this.options.forceExit?.(1);
-    }, gracePeriodMs);
+    }, this.gracePeriodMs);
 
     try {
-      await this.closeServer();
-      await this.drainWebSockets();
-      await stopListeners();
-      await this.options.outboxJob?.stop();
-      await Promise.resolve(this.options.scheduler?.stop());
-      await this.options.invalidationBus?.stop();
-      this.options.logger?.("[Shutdown] Graceful shutdown complete.");
+      await this.runPhase("server_close", () => this.closeServer());
+      await this.runPhase("ws_drain", () => this.drainWebSockets());
+      await this.runPhase("listener_stop", () => stopListeners());
+      await this.runPhase("scheduler_drain", () => this.drainScheduler());
+      await this.runPhase("outbox_stop", () =>
+        Promise.resolve(this.options.outboxJob?.stop()),
+      );
+      await this.runPhase("invalidation_bus_stop", () =>
+        Promise.resolve(this.options.invalidationBus?.stop()),
+      );
+      await this.runPhase("pool_close", () => this.closePools());
+      await this.runPhase("redis_close", () => this.closeRedis());
+
+      this.log("[Shutdown] Graceful shutdown complete.");
       this.clearForceExitTimer();
       this.options.forceExit?.(0);
     } catch (error) {
-      this.options.logger?.(
+      this.log(
         `[Shutdown] Error during shutdown: ${error instanceof Error ? error.message : error}`,
       );
       this.destroyConnections();
       this.clearForceExitTimer();
       this.options.forceExit?.(1);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase helpers
+  // ---------------------------------------------------------------------------
+
+  private async runPhase(phase: string, fn: () => Promise<void> | void): Promise<void> {
+    const start = Date.now();
+    this.log(`[Shutdown:${phase}] starting`);
+    try {
+      await fn();
+    } finally {
+      const durationSeconds = (Date.now() - start) / 1000;
+      this.metrics.observePhase(phase, durationSeconds);
+      this.log(`[Shutdown:${phase}] done (${(durationSeconds * 1000).toFixed(0)}ms)`);
     }
   }
 
@@ -97,24 +166,25 @@ export class GracefulShutdownManager {
     }
 
     return new Promise((resolve) => {
-      const drainTimeoutMs = 5000;
       const timeoutHandle = setTimeout(() => {
-        // Force close remaining connections
         for (const ws of this.wss!.clients) {
           ws.terminate();
         }
         resolve();
-      }, drainTimeoutMs);
+      }, 5000);
 
-      // Notify all connected clients of graceful shutdown
       for (const ws of this.wss!.clients) {
-        if (ws.readyState === 1) {
-          // WebSocket.OPEN
+        if (ws.readyState === 1 /* WebSocket.OPEN */) {
           ws.close(1000, "Server shutting down gracefully");
         }
       }
 
-      // Wait for clients to close
+      if (this.wss!.clients.size === 0) {
+        clearTimeout(timeoutHandle);
+        resolve();
+        return;
+      }
+
       let closed = 0;
       const checkAllClosed = () => {
         if (closed >= this.wss!.clients.size) {
@@ -129,13 +199,33 @@ export class GracefulShutdownManager {
           checkAllClosed();
         });
       }
-
-      // If no clients, resolve immediately
-      if (this.wss!.clients.size === 0) {
-        clearTimeout(timeoutHandle);
-        resolve();
-      }
     });
+  }
+
+  private async drainScheduler(): Promise<void> {
+    const scheduler = this.options.scheduler;
+    if (!scheduler) return;
+
+    // Stop new fires before waiting for the current one.
+    await Promise.resolve(scheduler.stop());
+
+    if (typeof scheduler.isJobRunning !== "function") return;
+
+    const maxWaitMs = Math.min(
+      this.options.jobDrainTimeoutMs ?? this.gracePeriodMs * 0.7,
+      10_000,
+    );
+    const deadline = Date.now() + maxWaitMs;
+
+    while (scheduler.isJobRunning() && Date.now() < deadline) {
+      await new Promise<void>((r) => setTimeout(r, 100));
+    }
+
+    if (scheduler.isJobRunning()) {
+      this.log(
+        `[Shutdown:scheduler_drain] Job still running after ${maxWaitMs}ms drain window — proceeding.`,
+      );
+    }
   }
 
   private closeServer(): Promise<void> {
@@ -154,6 +244,32 @@ export class GracefulShutdownManager {
     });
   }
 
+  private async closePools(): Promise<void> {
+    const pools = this.options.dbPools;
+    if (!pools?.length) return;
+    await Promise.allSettled(
+      pools.map((p) =>
+        p.end().catch((err: unknown) =>
+          this.log(
+            `[Shutdown:pool_close] pool.end() error: ${err instanceof Error ? err.message : err}`,
+          ),
+        ),
+      ),
+    );
+  }
+
+  private async closeRedis(): Promise<void> {
+    const redis = this.options.redis;
+    if (!redis) return;
+    try {
+      await redis.disconnect();
+    } catch (err) {
+      this.log(
+        `[Shutdown:redis_close] disconnect error: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
   private destroyConnections(): void {
     for (const socket of this.connections) {
       try {
@@ -170,5 +286,13 @@ export class GracefulShutdownManager {
       clearTimeout(this.forceExitTimer);
       this.forceExitTimer = null;
     }
+  }
+
+  private get gracePeriodMs(): number {
+    return this.options.gracePeriodMs ?? 30_000;
+  }
+
+  private log(message: string): void {
+    this.options.logger?.(message);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ import governanceRouter from './routes/governance.js'
 import disputesRouter from './routes/disputes.js'
 import evidenceRouter from './routes/evidence.js'
 import { loadConfig } from './config/index.js'
-import { pool } from './db/pool.js'
+import { pool, workerPool, replicaPool } from './db/pool.js'
+import { redisConnection } from './cache/redis.js'
+import { createShutdownMetrics } from './observability/shutdownMetrics.js'
 import { AnalyticsService } from './services/analytics/service.js'
 import { AnalyticsRefreshWorker, getAnalyticsRefreshIntervalMs } from './jobs/analyticsRefreshWorker.js'
 import { AnalyticsRefreshScheduler } from './jobs/analyticsRefreshScheduler.js'
@@ -78,6 +80,9 @@ if (process.env.NODE_ENV !== "test") {
       gracePeriodMs: config.shutdown.gracePeriodMs,
       logger: console.log,
       forceExit: (code) => process.exit(code),
+      dbPools: [pool, workerPool, replicaPool],
+      redis: redisConnection,
+      metrics: createShutdownMetrics(),
     });
 
     server.on("connection", (socket) => {
@@ -121,7 +126,10 @@ if (process.env.NODE_ENV !== "test") {
         stop() {
           refreshScheduler.stop()
           reconcilerScheduler.stop()
-        }
+        },
+        isJobRunning() {
+          return refreshScheduler.isJobRunning() || reconcilerScheduler.isJobRunning()
+        },
       } as any
     }
 

--- a/src/jobs/analyticsRefreshScheduler.ts
+++ b/src/jobs/analyticsRefreshScheduler.ts
@@ -76,6 +76,14 @@ export class AnalyticsRefreshScheduler {
     return this.intervalId !== null
   }
 
+  /**
+   * Check if a worker invocation is currently executing.
+   * Used by the shutdown coordinator to wait for in-flight work to drain.
+   */
+  isJobRunning(): boolean {
+    return this.isRunning
+  }
+
   getStatus(): SchedulerStatus {
     return {
       active: this.isActive(),

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -118,6 +118,14 @@ export class JobScheduler {
   }
 
   /**
+   * Check if a job invocation is currently executing.
+   * Used by the shutdown coordinator to wait for in-flight work to drain.
+   */
+  isJobRunning(): boolean {
+    return this.isRunning
+  }
+
+  /**
    * Run the job (internal).
    *
    * When a `distributedLock` is configured the job only runs if this worker

--- a/src/observability/shutdownMetrics.ts
+++ b/src/observability/shutdownMetrics.ts
@@ -1,0 +1,45 @@
+import client from 'prom-client'
+import { register } from '../middleware/metrics.js'
+
+export const shutdownPhaseDurationSeconds = new client.Histogram({
+  name: 'shutdown_phase_duration_seconds',
+  help: 'Duration of each graceful shutdown phase in seconds',
+  labelNames: ['phase'] as const,
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30],
+  registers: [register],
+})
+
+export const shutdownTotal = new client.Counter({
+  name: 'shutdown_total',
+  help: 'Total graceful shutdowns initiated, labelled by signal',
+  labelNames: ['signal'] as const,
+  registers: [register],
+})
+
+export const shutdownForceExitTotal = new client.Counter({
+  name: 'shutdown_force_exit_total',
+  help: 'Total times the shutdown coordinator had to force-exit after the grace period expired',
+  registers: [register],
+})
+
+export interface ShutdownMetrics {
+  observePhase(phase: string, durationSeconds: number): void
+  incShutdown(signal: string): void
+  incForceExit(): void
+}
+
+export function createShutdownMetrics(): ShutdownMetrics {
+  return {
+    observePhase: (phase, s) => shutdownPhaseDurationSeconds.observe({ phase }, s),
+    incShutdown: (signal) => shutdownTotal.inc({ signal }),
+    incForceExit: () => shutdownForceExitTotal.inc(),
+  }
+}
+
+export function createNoopShutdownMetrics(): ShutdownMetrics {
+  return {
+    observePhase: () => {},
+    incShutdown: () => {},
+    incForceExit: () => {},
+  }
+}

--- a/src/routes/payouts.test.ts
+++ b/src/routes/payouts.test.ts
@@ -57,6 +57,12 @@ const db = vi.hoisted(() => {
       return { rows: [], rowCount: 1 }
     }
 
+    if (sql.includes('FROM settlements') && sql.includes('transaction_hash')) {
+      const txHash = String(params[0])
+      const existing = settlementsByTx.get(txHash)
+      return { rows: existing ? [{ id: existing.id }] : [], rowCount: existing ? 1 : 0 }
+    }
+
     if (sql.includes('INSERT INTO settlements')) {
       if (failNextSettlement) {
         const error = failNextSettlement

--- a/tests/routes/attestations.test.ts
+++ b/tests/routes/attestations.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express, { type Express } from 'express'
 import request from 'supertest'
 import { createAttestationRouter } from '../../src/routes/attestations.js'
 import { errorHandler } from '../../src/middleware/errorHandler.js'
 import type { Attestation } from '../../src/db/repositories/attestationsRepository.js'
 import { setTenantId } from '../../src/utils/tenantContext.js'
+import { encodeCursor } from '../../src/lib/pagination.js'
+import { withReplica } from '../../src/db/pool.js'
+
+// Prevent tests from opening real database connections.
+vi.mock('../../src/db/pool.js', () => ({
+  pool: {},
+  replicaPool: {},
+  workerPool: {},
+  withReplica: vi.fn(async (fn: (client: unknown) => Promise<unknown>) => fn({})),
+}))
 
 const SUBJECT = '0x1111111111111111111111111111111111111111'
 const ATTESTER = '0x2222222222222222222222222222222222222222'
@@ -20,48 +30,61 @@ const makeAttestation = (id: number, subjectAddress = SUBJECT): Attestation => (
   createdAt: new Date(`2025-01-0${id}T00:00:00.000Z`),
 })
 
+/** Minimal row shape returned by a mocked pg client for attestation INSERT/SELECT. */
+const makeRow = (a: Attestation) => ({
+  id: a.id,
+  bond_id: a.bondId,
+  attester_address: a.attesterAddress,
+  subject_address: a.subjectAddress,
+  score: a.score,
+  note: a.note,
+  created_at: a.createdAt,
+})
+
 describe('attestation routes', () => {
   let app: Express
   let cacheService: {
     getAttestationsBySubjectPaginated: ReturnType<typeof vi.fn>
     invalidateForAttestation: ReturnType<typeof vi.fn>
   }
-  let transactionManager: {
-    withTransaction: ReturnType<typeof vi.fn>
-  }
-  let outbox: {
-    emit: ReturnType<typeof vi.fn>
-  }
+  let transactionManager: { withTransaction: ReturnType<typeof vi.fn> }
+  let outbox: { emit: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
-    // Set tenant context for tests
     setTenantId('test-tenant')
-    
+    vi.mocked(withReplica).mockImplementation(async (fn: any) => fn({}))
+
     cacheService = {
       getAttestationsBySubjectPaginated: vi.fn(),
       invalidateForAttestation: vi.fn(),
     }
-    outbox = {
-      emit: vi.fn(),
-    }
+    outbox = { emit: vi.fn() }
     transactionManager = {
       withTransaction: vi.fn(async (fn) => fn({ query: vi.fn(), release: vi.fn() })),
     }
 
     app = express()
     app.use(express.json())
-    app.use('/api/attestations', createAttestationRouter({
-      cacheService: cacheService as any,
-      transactionManager: transactionManager as any,
-      outbox: outbox as any,
-    }))
+    app.use(
+      '/api/attestations',
+      createAttestationRouter({
+        cacheService: cacheService as any,
+        transactionManager: transactionManager as any,
+        outbox: outbox as any,
+        skipTenantCheck: true,
+      }),
+    )
     app.use(errorHandler)
   })
 
   afterEach(() => {
-    // Clean up tenant context
     setTenantId(null)
+    vi.clearAllMocks()
   })
+
+  // ---------------------------------------------------------------------------
+  // GET /api/attestations/:address
+  // ---------------------------------------------------------------------------
 
   describe('GET /api/attestations/:address', () => {
     it('returns a repository-backed cursor page with a next cursor when more remain', async () => {
@@ -78,13 +101,7 @@ describe('attestation routes', () => {
         limit: 2,
         cursor: undefined,
       })
-      expect(res.body).toMatchObject({
-        address: SUBJECT,
-        page: {
-          limit: 2,
-          hasMore: true,
-        },
-      })
+      expect(res.body).toMatchObject({ address: SUBJECT, page: { limit: 2, hasMore: true } })
       expect(res.body.data).toHaveLength(2)
       expect(res.body.data[0].createdAt).toBe('2025-01-01T00:00:00.000Z')
       // A next cursor is emitted because hasMore is true.
@@ -112,9 +129,7 @@ describe('attestation routes', () => {
         hasMore: false,
       })
 
-      await request(app)
-        .get(`/api/attestations/${MIXED_SUBJECT}`)
-        .expect(200)
+      await request(app).get(`/api/attestations/${MIXED_SUBJECT}`).expect(200)
 
       expect(cacheService.getAttestationsBySubjectPaginated).toHaveBeenCalledWith(
         MIXED_SUBJECT.toLowerCase(),
@@ -122,7 +137,7 @@ describe('attestation routes', () => {
       )
     })
 
-    it('rejects invalid pagination', async () => {
+    it('rejects a limit that exceeds the maximum (999)', async () => {
       const res = await request(app)
         .get(`/api/attestations/${SUBJECT}?limit=999`)
         .expect(400)
@@ -130,104 +145,432 @@ describe('attestation routes', () => {
       expect(res.body.error).toBe('Validation failed')
       expect(cacheService.getAttestationsBySubjectPaginated).not.toHaveBeenCalled()
     })
-  })
 
-  describe('POST /api/attestations', () => {
-  it('persists an attestation, emits an outbox event, and invalidates cache', async () => {
-    const created = makeAttestation(7)
-    transactionManager.withTransaction.mockImplementationOnce(async (fn) => {
-      const client = {
-        query: vi.fn().mockResolvedValue({ rows: [{
-          id: created.id,
-          bond_id: created.bondId,
-          attester_address: created.attesterAddress,
-          subject_address: created.subjectAddress,
-          score: created.score,
-          note: created.note,
-          created_at: created.createdAt,
-        }] }),
-      }
-      return fn(client)
+    it('rejects limit=0 (below minimum)', async () => {
+      const res = await request(app)
+        .get(`/api/attestations/${SUBJECT}?limit=0`)
+        .expect(400)
+
+      expect(res.body.error).toBe('Validation failed')
+      expect(cacheService.getAttestationsBySubjectPaginated).not.toHaveBeenCalled()
     })
 
-    const res = await request(app)
-      .post('/api/attestations')
-      .set('x-tenant-id', 'test-tenant')
-      .send({
+    it('rejects a malformed Ethereum address in the path', async () => {
+      const res = await request(app).get('/api/attestations/0xshort').expect(400)
+
+      expect(res.body.error).toBe('Validation failed')
+    })
+
+    it('rejects a plaintext (non-Ethereum, non-Stellar) path parameter', async () => {
+      const res = await request(app).get('/api/attestations/not-an-address').expect(400)
+
+      expect(res.body.error).toBe('Validation failed')
+    })
+
+    it('forwards a decoded cursor to the cache service', async () => {
+      const cursor = encodeCursor('2025-01-01T00:00:00.000Z', '5')
+
+      cacheService.getAttestationsBySubjectPaginated.mockResolvedValue({
+        attestations: [],
+        hasMore: false,
+      })
+
+      await request(app)
+        .get(`/api/attestations/${SUBJECT}?cursor=${cursor}&limit=10`)
+        .expect(200)
+
+      expect(cacheService.getAttestationsBySubjectPaginated).toHaveBeenCalledWith(SUBJECT, {
+        limit: 10,
+        cursor: { t: '2025-01-01T00:00:00.000Z', i: '5' },
+      })
+    })
+
+    it('treats an empty cursor param (?cursor=) as no cursor', async () => {
+      cacheService.getAttestationsBySubjectPaginated.mockResolvedValue({
+        attestations: [],
+        hasMore: false,
+      })
+
+      await request(app).get(`/api/attestations/${SUBJECT}?cursor=`).expect(200)
+
+      expect(cacheService.getAttestationsBySubjectPaginated).toHaveBeenCalledWith(SUBJECT, {
+        limit: 20,
+        cursor: undefined,
+      })
+    })
+
+    it('returns serialized attestations with all fields required by the reputation scorer', async () => {
+      cacheService.getAttestationsBySubjectPaginated.mockResolvedValue({
+        attestations: [makeAttestation(3)],
+        hasMore: false,
+      })
+
+      const res = await request(app).get(`/api/attestations/${SUBJECT}`).expect(200)
+
+      const item = res.body.data[0]
+      // Fields consumed by src/services/reputation/attestationScore.ts and downstream scorers.
+      expect(item).toMatchObject({
+        id: 3,
         bondId: 10,
-        attesterAddress: ATTESTER.toUpperCase().replace('X', 'x'),
-        subject: SUBJECT,
-        key: 'kyc',
-        value: 'verified',
+        attesterAddress: ATTESTER,
+        subjectAddress: SUBJECT,
         score: 90,
       })
-      .expect(201)
-
-    expect(res.body).toMatchObject({
-      id: 7,
-      bondId: 10,
-      attesterAddress: ATTESTER,
-      subjectAddress: SUBJECT,
-      score: 90,
+      expect(typeof item.createdAt).toBe('string')
     })
-    expect(outbox.emit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-      aggregateType: 'attestation',
-      aggregateId: '7',
-      eventType: 'attestation.created',
-    }))
-    expect(cacheService.invalidateForAttestation).toHaveBeenCalledWith(expect.objectContaining({
-      id: 7,
-      subjectAddress: SUBJECT,
-    }))
+
+    it('propagates unexpected cache errors as 500', async () => {
+      cacheService.getAttestationsBySubjectPaginated.mockRejectedValue(new Error('redis down'))
+
+      const res = await request(app).get(`/api/attestations/${SUBJECT}`).expect(500)
+
+      expect(res.body.error).toBeDefined()
+    })
   })
 
-    it('rejects duplicate attestations', async () => {
+  // ---------------------------------------------------------------------------
+  // POST /api/attestations
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/attestations', () => {
+    it('persists an attestation, emits an outbox event, and invalidates cache', async () => {
+      const created = makeAttestation(7)
+      transactionManager.withTransaction.mockImplementationOnce(async (fn) =>
+        fn({ query: vi.fn().mockResolvedValue({ rows: [makeRow(created)] }) }),
+      )
+
+      const res = await request(app)
+        .post('/api/attestations')
+        .set('x-tenant-id', 'test-tenant')
+        .send({
+          bondId: 10,
+          attesterAddress: ATTESTER.toUpperCase().replace('X', 'x'),
+          subject: SUBJECT,
+          key: 'kyc',
+          value: 'verified',
+          score: 90,
+        })
+        .expect(201)
+
+      expect(res.body).toMatchObject({
+        id: 7,
+        bondId: 10,
+        attesterAddress: ATTESTER,
+        subjectAddress: SUBJECT,
+        score: 90,
+      })
+      expect(outbox.emit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          aggregateType: 'attestation',
+          aggregateId: '7',
+          eventType: 'attestation.created',
+        }),
+      )
+      expect(cacheService.invalidateForAttestation).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 7, subjectAddress: SUBJECT }),
+      )
+    })
+
+    it('emits a payload with all fields required by the reputation scorer', async () => {
+      const created = makeAttestation(4)
+      transactionManager.withTransaction.mockImplementationOnce(async (fn) =>
+        fn({ query: vi.fn().mockResolvedValue({ rows: [makeRow(created)] }) }),
+      )
+
+      await request(app)
+        .post('/api/attestations')
+        .set('x-tenant-id', 'test-tenant')
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT, value: 'verified', score: 90 })
+        .expect(201)
+
+      expect(outbox.emit).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            id: 4,
+            bondId: 10,
+            attesterAddress: ATTESTER,
+            subjectAddress: SUBJECT,
+            score: 90,
+            createdAt: created.createdAt.toISOString(),
+          }),
+        }),
+      )
+    })
+
+    it('rejects duplicate attestations with 409', async () => {
       transactionManager.withTransaction.mockRejectedValueOnce({ code: '23505' })
 
       const res = await request(app)
         .post('/api/attestations')
-        .send({
-          bondId: 10,
-          attesterAddress: ATTESTER,
-          subject: SUBJECT,
-          value: 'verified',
-          score: 90,
-        })
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT, value: 'verified', score: 90 })
         .expect(409)
 
       expect(res.body.error).toBe('Duplicate attestation')
       expect(cacheService.invalidateForAttestation).not.toHaveBeenCalled()
     })
 
-    it('rejects oversized values', async () => {
+    it('rejects oversized values (> 2048 chars)', async () => {
       await request(app)
         .post('/api/attestations')
-        .send({
-          bondId: 10,
-          attesterAddress: ATTESTER,
-          subject: SUBJECT,
-          value: 'x'.repeat(2049),
-          score: 90,
-        })
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT, value: 'x'.repeat(2049), score: 90 })
         .expect(400)
 
       expect(transactionManager.withTransaction).not.toHaveBeenCalled()
     })
 
-    it('rejects oversized keys', async () => {
+    it('rejects oversized keys (> 128 chars)', async () => {
       await request(app)
         .post('/api/attestations')
-        .send({
-          bondId: 10,
-          attesterAddress: ATTESTER,
-          subject: SUBJECT,
-          key: 'k'.repeat(129),
-          value: 'verified',
-          score: 90,
-        })
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT, key: 'k'.repeat(129), value: 'v', score: 90 })
         .expect(400)
 
       expect(transactionManager.withTransaction).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when bondId is missing', async () => {
+      const res = await request(app)
+        .post('/api/attestations')
+        .send({ attesterAddress: ATTESTER, subject: SUBJECT, value: 'verified' })
+        .expect(400)
+
+      expect(res.body.error).toBe('Validation failed')
+      expect(transactionManager.withTransaction).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when attesterAddress is missing', async () => {
+      const res = await request(app)
+        .post('/api/attestations')
+        .send({ bondId: 10, subject: SUBJECT, value: 'verified' })
+        .expect(400)
+
+      expect(res.body.error).toBe('Validation failed')
+      expect(transactionManager.withTransaction).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 with an error for each missing required field when both bondId and attesterAddress are absent', async () => {
+      const res = await request(app)
+        .post('/api/attestations')
+        .send({ subject: SUBJECT, value: 'verified' })
+        .expect(400)
+
+      expect(res.body.error).toBe('Validation failed')
+      const paths = (res.body.details as Array<{ path: string }>).map((d) => d.path)
+      expect(paths).toContain('bondId')
+      expect(paths).toContain('attesterAddress')
+    })
+
+    it('returns 400 when subject is missing', async () => {
+      await request(app)
+        .post('/api/attestations')
+        .send({ bondId: 10, attesterAddress: ATTESTER, value: 'verified' })
+        .expect(400)
+    })
+
+    it('returns 400 when value is missing', async () => {
+      await request(app)
+        .post('/api/attestations')
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT })
+        .expect(400)
+    })
+
+    it('returns 400 when score exceeds 100', async () => {
+      await request(app)
+        .post('/api/attestations')
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT, value: 'ok', score: 101 })
+        .expect(400)
+    })
+
+    it('defaults score to 100 when omitted', async () => {
+      const created = { ...makeAttestation(5), score: 100 }
+      let capturedParams: unknown[] = []
+
+      transactionManager.withTransaction.mockImplementationOnce(async (fn) => {
+        const client = {
+          query: vi.fn().mockImplementation((_sql: string, params: unknown[]) => {
+            capturedParams = params
+            return Promise.resolve({ rows: [makeRow(created)] })
+          }),
+        }
+        return fn(client)
+      })
+
+      const res = await request(app)
+        .post('/api/attestations')
+        .set('x-tenant-id', 'test-tenant')
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT, value: 'verified' })
+        .expect(201)
+
+      expect(res.body.score).toBe(100)
+      // INSERT params order: bondId, attesterAddress, subjectAddress, score, note
+      expect(capturedParams[3]).toBe(100)
+    })
+
+    it('propagates unexpected transaction errors as 500', async () => {
+      transactionManager.withTransaction.mockRejectedValueOnce(new Error('connection lost'))
+
+      const res = await request(app)
+        .post('/api/attestations')
+        .send({ bondId: 10, attesterAddress: ATTESTER, subject: SUBJECT, value: 'verified' })
+        .expect(500)
+
+      expect(res.body.error).toBeDefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Legacy attestation router (passed a repository object directly)
+  // ---------------------------------------------------------------------------
+
+  describe('legacy attestation router', () => {
+    let legacyApp: Express
+    let legacyRepo: {
+      countBySubject: ReturnType<typeof vi.fn>
+      findBySubject: ReturnType<typeof vi.fn>
+      create: ReturnType<typeof vi.fn>
+      revoke: ReturnType<typeof vi.fn>
+    }
+
+    beforeEach(() => {
+      legacyRepo = {
+        countBySubject: vi.fn().mockReturnValue(3),
+        findBySubject: vi.fn().mockReturnValue({ attestations: [], total: 0 }),
+        create: vi.fn(),
+        revoke: vi.fn(),
+      }
+
+      legacyApp = express()
+      legacyApp.use(express.json())
+      legacyApp.use('/api/attestations', createAttestationRouter(legacyRepo as any))
+      legacyApp.use(errorHandler)
+    })
+
+    describe('GET /:identity/count', () => {
+      it('returns the attestation count for an identity', async () => {
+        const res = await request(legacyApp)
+          .get('/api/attestations/0xABCD/count')
+          .expect(200)
+
+        expect(res.body).toEqual({ identity: '0xABCD', count: 3, includeRevoked: false })
+        expect(legacyRepo.countBySubject).toHaveBeenCalledWith('0xABCD', false)
+      })
+
+      it('passes includeRevoked=true to the repository', async () => {
+        legacyRepo.countBySubject.mockReturnValue(5)
+
+        const res = await request(legacyApp)
+          .get('/api/attestations/0xABCD/count?includeRevoked=true')
+          .expect(200)
+
+        expect(legacyRepo.countBySubject).toHaveBeenCalledWith('0xABCD', true)
+        expect(res.body.count).toBe(5)
+        expect(res.body.includeRevoked).toBe(true)
+      })
+    })
+
+    describe('GET /:identity', () => {
+      it('returns paginated attestations for an identity', async () => {
+        const fakeAtt = { id: 1, verifier: '0xVERIF' }
+        legacyRepo.findBySubject.mockReturnValue({ attestations: [fakeAtt], total: 1 })
+
+        const res = await request(legacyApp)
+          .get('/api/attestations/0xABCD?limit=10&page=1')
+          .expect(200)
+
+        expect(res.body.identity).toBe('0xABCD')
+        expect(res.body.attestations).toHaveLength(1)
+        expect(res.body.total).toBe(1)
+        expect(legacyRepo.findBySubject).toHaveBeenCalledWith(
+          '0xABCD',
+          expect.objectContaining({ limit: 10, offset: 0 }),
+        )
+      })
+
+      it('falls back to countBySubject when the repo does not return a numeric total', async () => {
+        legacyRepo.findBySubject.mockReturnValue({ attestations: [] }) // no total property
+        legacyRepo.countBySubject.mockReturnValue(7)
+
+        const res = await request(legacyApp).get('/api/attestations/0xABCD').expect(200)
+
+        expect(legacyRepo.countBySubject).toHaveBeenCalled()
+        expect(res.body.total).toBe(7)
+      })
+
+      it('passes includeRevoked=true to findBySubject', async () => {
+        legacyRepo.findBySubject.mockReturnValue({ attestations: [], total: 0 })
+
+        await request(legacyApp)
+          .get('/api/attestations/0xABCD?includeRevoked=true')
+          .expect(200)
+
+        expect(legacyRepo.findBySubject).toHaveBeenCalledWith(
+          '0xABCD',
+          expect.objectContaining({ includeRevoked: true }),
+        )
+      })
+
+      it('propagates pagination and repo errors as 500', async () => {
+        // The legacy GET handler does not convert PaginationValidationError to a
+        // structured 400; unknown errors reach the global error handler as 500.
+        legacyRepo.findBySubject.mockImplementation(() => { throw new Error('db error') })
+
+        await request(legacyApp).get('/api/attestations/0xABCD').expect(500)
+      })
+    })
+
+    describe('POST / (legacy create)', () => {
+      it('creates an attestation and returns 201', async () => {
+        const body = { subject: '0xSUBJ', verifier: '0xVERIF', weight: 1.5, claim: 'verified' }
+        legacyRepo.create.mockReturnValue({ id: 42, ...body })
+
+        const res = await request(legacyApp)
+          .post('/api/attestations')
+          .send(body)
+          .expect(201)
+
+        expect(legacyRepo.create).toHaveBeenCalledWith(body)
+        expect(res.body.id).toBe(42)
+      })
+
+      it('propagates repo errors as 500', async () => {
+        legacyRepo.create.mockImplementation(() => { throw new Error('insert failed') })
+
+        await request(legacyApp)
+          .post('/api/attestations')
+          .send({ subject: '0xSUBJ', verifier: '0xV', weight: 1, claim: 'c' })
+          .expect(500)
+      })
+    })
+
+    describe('DELETE /:id (revoke)', () => {
+      it('revokes an attestation and returns the result when found', async () => {
+        const revoked = { id: '5', verifier: '0xV', revoked: true }
+        legacyRepo.revoke.mockReturnValue(revoked)
+
+        const res = await request(legacyApp).delete('/api/attestations/5').expect(200)
+
+        expect(legacyRepo.revoke).toHaveBeenCalledWith('5')
+        expect(res.body).toMatchObject({ id: '5', revoked: true })
+      })
+
+      it('returns 404 when the attestation is not found', async () => {
+        legacyRepo.revoke.mockReturnValue(undefined)
+
+        await request(legacyApp).delete('/api/attestations/999').expect(404)
+
+        expect(legacyRepo.revoke).toHaveBeenCalledWith('999')
+      })
+
+      it('allows any caller with a valid ID to revoke — author enforcement is not at the route layer', async () => {
+        // The legacy router delegates entirely to repo.revoke(id) with no attesterAddress
+        // check. Author-only enforcement must be added at the auth middleware or service layer.
+        legacyRepo.revoke.mockReturnValue({ id: '3', revoked: true })
+
+        const res = await request(legacyApp).delete('/api/attestations/3').expect(200)
+
+        expect(res.body.revoked).toBe(true)
+      })
     })
   })
 })


### PR DESCRIPTION
closes #468 

- Adds `DrainableScheduler`, `CloseablePool`, and `CloseableRedis` interfaces to `GracefulShutdownManager`, enabling structured teardown of db pools and Redis on shutdown
- Introduces `jobDrainTimeoutMs` to wait for in-flight scheduler jobs before proceeding (defaults to 70% of grace period, capped at 10 s)
- Adds Prometheus metrics (`shutdown_phase_duration_seconds`, `shutdown_total`, `shutdown_force_exit_total`) via new `src/observability/shutdownMetrics.ts`; noop implementation for tests/environments without prom-client
- Wires up all new options in `src/index.ts` and updates both schedulers (`analyticsRefreshScheduler`, `scheduler`) to expose `isJobRunning()`
- Adds a 604-line test suite (`src/gracefulShutdown.test.ts`) and `docs/graceful-shutdown.md`
- Improves attestation route tests: mocks db pool to prevent real connections, adds cursor-pagination coverage, and introduces `skipTenantCheck` opt-in for integration tests

## Test plan

- [ ] `pnpm test src/gracefulShutdown.test.ts` — all shutdown lifecycle scenarios pass
- [ ] `pnpm test tests/routes/attestations.test.ts` — create/revoke/query + pagination paths pass
- [ ] `pnpm lint` passes
- [ ] Verify `/metrics` endpoint exposes `shutdown_phase_duration_seconds`, `shutdown_total`, `shutdown_force_exit_total` after wiring up `createShutdownMetrics()` in prod
