### PR TITLE
Fix/wallet debit decimal safety

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -35,6 +35,30 @@ Stores every blockchain wallet address that has been registered with the Credenc
 
 ---
 
+### `wallets`
+
+Stores on-chain wallet balances managed by the protocol. Each wallet maps a blockchain address to a mutable balance.
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `UUID` | NO | `gen_random_uuid()` | Surrogate primary key |
+| `address` | `TEXT` | NO | — | Blockchain wallet address (unique) |
+| `balance` | `NUMERIC(36,18)` | NO | `0` | Current balance; 36 total digits, 18 after the decimal point |
+| `currency` | `TEXT` | NO | `'USD'` | Token/currency denomination |
+| `created_at` | `TIMESTAMPTZ` | NO | `NOW()` | Row creation time |
+| `updated_at` | `TIMESTAMPTZ` | NO | `NOW()` | Auto-updated on every `UPDATE` |
+
+**Constraints**
+- `PRIMARY KEY (id)`
+- `UNIQUE (address)`
+- `CHECK (balance >= 0)` — prevents negative balances at the database level
+
+**Balance arithmetic**
+
+All balance mutations use PostgreSQL `NUMERIC` arithmetic (`balance::NUMERIC ± $n::NUMERIC`) so no precision is lost in the database layer. The application layer (`WalletsRepository.debit()`) uses `compareDecimals()` from `src/lib/decimalMath.ts` — a BigInt-scaled exact comparison — for the sufficiency check. `Number()` is intentionally avoided: it loses precision beyond ~15 significant digits and can silently allow an overdraft on large or high-scale balances (e.g. `Number("10000000000000001") === Number("10000000000000002")`).
+
+---
+
 ### `bonds`
 
 Records staking/locking events. Each row represents one bond period for an identity.

--- a/src/db/repositories/walletsRepository.ts
+++ b/src/db/repositories/walletsRepository.ts
@@ -7,6 +7,10 @@ import {
   LockTimeoutError,
 } from "../transaction.js";
 import { WalletTransactionsRepository } from "./walletTransactionsRepository.js";
+import {
+  compareDecimals,
+  isValidPositiveDecimal,
+} from "../../lib/decimalMath.js";
 
 /**
  * Thrown when a debit would reduce a wallet's balance below zero.
@@ -217,6 +221,11 @@ export class WalletsRepository {
       );
     }
 
+    // Reject malformed, zero, or negative amounts before acquiring the row lock.
+    if (!isValidPositiveDecimal(amount)) {
+      throw new Error(`Invalid credit amount: "${amount}"`);
+    }
+
     return this.txManager.withTransaction(
       async (client) => {
         // Lock the row
@@ -303,6 +312,11 @@ export class WalletsRepository {
       );
     }
 
+    // Reject malformed, zero, or negative amounts before acquiring the row lock.
+    if (!isValidPositiveDecimal(amount)) {
+      throw new Error(`Invalid debit amount: "${amount}"`);
+    }
+
     return this.txManager.withTransaction(
       async (client) => {
         // Lock the row so concurrent debits queue up rather than racing.
@@ -323,11 +337,10 @@ export class WalletsRepository {
         const current = mapWallet(lockResult.rows[0]);
         const previousBalance = current.balance;
 
-        // Check if sufficient balance exists
-        const availableNum = Number(current.balance);
-        const requestedNum = Number(amount);
-
-        if (requestedNum > availableNum) {
+        // Number() loses precision beyond ~15 significant digits and can silently
+        // permit an overdraft on large or high-scale balances. compareDecimals()
+        // uses BigInt-scaled integer arithmetic and is always exact.
+        if (compareDecimals(amount, current.balance) > 0) {
           throw new InsufficientBalanceError(id, current.balance, amount);
         }
 

--- a/src/lib/decimalMath.ts
+++ b/src/lib/decimalMath.ts
@@ -231,38 +231,6 @@ export function roundToScale(
 }
 
 /**
- * Compare two decimal strings exactly using BigInt-scaled integer arithmetic.
- *
- * IEEE 754 floating-point loses precision beyond ~15 significant digits, so
- * Number() comparisons on wallet balances can silently permit overdrafts at
- * scale. This function never converts to float.
- *
- * @returns -1 if a < b, 0 if a === b, 1 if a > b.
- *
- * @example
- * compareDecimals("10.50", "10.5")                     // 0
- * compareDecimals("10000000000000001", "10000000000000002") // -1
- * compareDecimals("0.000000002", "0.000000001")         // 1
- */
-export function compareDecimals(a: string, b: string): -1 | 0 | 1 {
-  const pa = parseDecimalString(a)
-  const pb = parseDecimalString(b)
-
-  const scale = Math.max(pa.fracStr.length, pb.fracStr.length)
-  // Pad both to the same scale so BigInt magnitudes are directly comparable.
-  const aInt = BigInt((pa.intStr || '0') + pa.fracStr.padEnd(scale, '0'))
-  const bInt = BigInt((pb.intStr || '0') + pb.fracStr.padEnd(scale, '0'))
-
-  if (pa.negative === pb.negative) {
-    const cmp = aInt > bInt ? 1 : aInt < bInt ? -1 : 0
-    return (pa.negative ? -cmp : cmp) as -1 | 0 | 1
-  }
-  // Different signs — negative is always less, unless both magnitudes are zero.
-  if (aInt === 0n && bInt === 0n) return 0
-  return pa.negative ? -1 : 1
-}
-
-/**
  * Return true iff value is a valid decimal string representing a number
  * strictly greater than zero (positive, non-zero, non-negative).
  *

--- a/src/lib/decimalMath.ts
+++ b/src/lib/decimalMath.ts
@@ -231,6 +231,58 @@ export function roundToScale(
 }
 
 /**
+ * Compare two decimal strings exactly using BigInt-scaled integer arithmetic.
+ *
+ * IEEE 754 floating-point loses precision beyond ~15 significant digits, so
+ * Number() comparisons on wallet balances can silently permit overdrafts at
+ * scale. This function never converts to float.
+ *
+ * @returns -1 if a < b, 0 if a === b, 1 if a > b.
+ *
+ * @example
+ * compareDecimals("10.50", "10.5")                     // 0
+ * compareDecimals("10000000000000001", "10000000000000002") // -1
+ * compareDecimals("0.000000002", "0.000000001")         // 1
+ */
+export function compareDecimals(a: string, b: string): -1 | 0 | 1 {
+  const pa = parseDecimalString(a)
+  const pb = parseDecimalString(b)
+
+  const scale = Math.max(pa.fracStr.length, pb.fracStr.length)
+  // Pad both to the same scale so BigInt magnitudes are directly comparable.
+  const aInt = BigInt((pa.intStr || '0') + pa.fracStr.padEnd(scale, '0'))
+  const bInt = BigInt((pb.intStr || '0') + pb.fracStr.padEnd(scale, '0'))
+
+  if (pa.negative === pb.negative) {
+    const cmp = aInt > bInt ? 1 : aInt < bInt ? -1 : 0
+    return (pa.negative ? -cmp : cmp) as -1 | 0 | 1
+  }
+  // Different signs — negative is always less, unless both magnitudes are zero.
+  if (aInt === 0n && bInt === 0n) return 0
+  return pa.negative ? -1 : 1
+}
+
+/**
+ * Return true iff value is a valid decimal string representing a number
+ * strictly greater than zero (positive, non-zero, non-negative).
+ *
+ * @example
+ * isValidPositiveDecimal("0.000000001") // true
+ * isValidPositiveDecimal("0")           // false
+ * isValidPositiveDecimal("-1")          // false
+ * isValidPositiveDecimal("abc")         // false
+ */
+export function isValidPositiveDecimal(value: string): boolean {
+  try {
+    const { negative, intStr, fracStr } = parseDecimalString(value)
+    if (negative) return false
+    return BigInt((intStr || '0') + (fracStr || '')) > 0n
+  } catch {
+    return false
+  }
+}
+
+/**
  * Multiply two decimal strings exactly, returning a decimal string.
  *
  * No rounding is applied. The result scale equals the sum of the two

--- a/tests/repositories/walletsRepository.test.ts
+++ b/tests/repositories/walletsRepository.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Unit tests for WalletsRepository using a mock Pool.
+ *
+ * No live database or pg-mem required — all SQL is intercepted by a
+ * synchronous mock so tests remain fast and deterministic.
+ *
+ * Critical coverage:
+ * - Overdraft-by-precision regression: Number() collapses two distinct
+ *   large integers to the same float, silently allowing an overdraft.
+ *   compareDecimals() rejects this correctly.
+ * - Exact-balance debit succeeds (boundary condition).
+ * - Upfront validation rejects zero / negative / non-numeric amounts
+ *   before the row lock is ever acquired.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Pool, PoolClient } from 'pg';
+import {
+  WalletsRepository,
+  InsufficientBalanceError,
+} from '../../src/db/repositories/walletsRepository.js';
+
+// ---------------------------------------------------------------------------
+// BigInt-exact arithmetic helpers (used only inside the mock UPDATE handler)
+// ---------------------------------------------------------------------------
+
+function decimalAdd(a: string, b: string): string {
+  const [aInt, aFrac = ''] = a.split('.');
+  const [bInt, bFrac = ''] = b.split('.');
+  const scale = Math.max(aFrac.length, bFrac.length);
+  const aScaled = BigInt(aInt + aFrac.padEnd(scale, '0'));
+  const bScaled = BigInt(bInt + bFrac.padEnd(scale, '0'));
+  const sum = aScaled + bScaled;
+  if (scale === 0) return sum.toString();
+  const factor = 10n ** BigInt(scale);
+  return `${sum / factor}.${(sum % factor).toString().padStart(scale, '0')}`;
+}
+
+function decimalSub(a: string, b: string): string {
+  const [aInt, aFrac = ''] = a.split('.');
+  const [bInt, bFrac = ''] = b.split('.');
+  const scale = Math.max(aFrac.length, bFrac.length);
+  const aScaled = BigInt(aInt + aFrac.padEnd(scale, '0'));
+  const bScaled = BigInt(bInt + bFrac.padEnd(scale, '0'));
+  const diff = aScaled - bScaled;
+  if (scale === 0) return diff.toString();
+  const factor = 10n ** BigInt(scale);
+  return `${diff / factor}.${(diff % factor).toString().padStart(scale, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Mock Pool
+// ---------------------------------------------------------------------------
+
+interface MockWalletRow {
+  id: string;
+  address: string;
+  balance: string;
+  currency: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/**
+ * Build a mock Pool whose connected clients intercept the exact SQL patterns
+ * emitted by WalletsRepository.debit() and credit().
+ */
+function makeMockPool(walletStore: Map<string, MockWalletRow>): Pool {
+  const makeClient = (): PoolClient => {
+    const query = vi.fn().mockImplementation(
+      async (text: string | { text: string }, values?: unknown[]) => {
+        const sql = (typeof text === 'string' ? text : text.text).trim();
+
+        // Transaction lifecycle + lock-timeout commands
+        if (
+          /^BEGIN/i.test(sql) ||
+          /^SET LOCAL/i.test(sql) ||
+          /^COMMIT/i.test(sql) ||
+          /^ROLLBACK/i.test(sql)
+        ) {
+          return { rows: [], rowCount: 0 };
+        }
+
+        // SELECT … FOR UPDATE (lock the row)
+        if (/SELECT.*FROM wallets/is.test(sql) && /FOR UPDATE/i.test(sql)) {
+          const id = values![0] as string;
+          const row = walletStore.get(id);
+          return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
+        }
+
+        // UPDATE wallets SET balance = … (debit or credit)
+        if (/UPDATE wallets/is.test(sql) && /SET balance/i.test(sql)) {
+          const [id, amount] = values as [string, string];
+          const row = walletStore.get(id);
+          if (!row) return { rows: [], rowCount: 0 };
+
+          const isDebit = /balance::NUMERIC - /i.test(sql);
+          const newBalance = isDebit
+            ? decimalSub(row.balance, amount)
+            : decimalAdd(row.balance, amount);
+
+          const updated = { ...row, balance: newBalance, updated_at: new Date() };
+          walletStore.set(id, updated);
+          return { rows: [updated], rowCount: 1 };
+        }
+
+        // INSERT INTO wallet_transactions — upstream ledger recording added in the same tx
+        if (/INSERT INTO wallet_transactions/i.test(sql)) {
+          const [walletId, type, amount, previousBalance, newBalance] = values as string[];
+          return {
+            rows: [{
+              id: crypto.randomUUID(),
+              wallet_id: walletId,
+              type,
+              amount,
+              previous_balance: previousBalance,
+              new_balance: newBalance,
+              created_at: new Date(),
+            }],
+            rowCount: 1,
+          };
+        }
+
+        return { rows: [], rowCount: 0 };
+      },
+    );
+
+    return { query, release: vi.fn() } as unknown as PoolClient;
+  };
+
+  return {
+    connect: vi.fn().mockImplementation(async () => makeClient()),
+  } as unknown as Pool;
+}
+
+function seedWallet(
+  store: Map<string, MockWalletRow>,
+  override: Partial<MockWalletRow> & { id: string; balance: string },
+): MockWalletRow {
+  const row: MockWalletRow = {
+    address: '0xTest',
+    currency: 'USD',
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...override,
+  };
+  store.set(row.id, row);
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WalletsRepository', () => {
+  let store: Map<string, MockWalletRow>;
+  let pool: Pool;
+  let repo: WalletsRepository;
+
+  beforeEach(() => {
+    store = new Map();
+    pool = makeMockPool(store);
+    repo = new WalletsRepository({} as any, pool);
+  });
+
+  // =========================================================================
+  // debit()
+  // =========================================================================
+
+  describe('debit()', () => {
+    it('throws without a pool', async () => {
+      const noPoolRepo = new WalletsRepository({} as any);
+      await expect(noPoolRepo.debit('any', '1')).rejects.toThrow(
+        'requires a Pool instance',
+      );
+    });
+
+    it('rejects non-numeric amount before acquiring lock', async () => {
+      await expect(repo.debit('w1', 'abc')).rejects.toThrow('Invalid debit amount');
+    });
+
+    it('rejects negative amount before acquiring lock', async () => {
+      await expect(repo.debit('w1', '-1')).rejects.toThrow('Invalid debit amount');
+    });
+
+    it('rejects zero amount before acquiring lock', async () => {
+      await expect(repo.debit('w1', '0')).rejects.toThrow('Invalid debit amount');
+    });
+
+    it('rejects empty string before acquiring lock', async () => {
+      await expect(repo.debit('w1', '')).rejects.toThrow('Invalid debit amount');
+    });
+
+    it('throws when wallet is not found', async () => {
+      await expect(repo.debit('missing-id', '1')).rejects.toThrow('not found');
+    });
+
+    it('throws InsufficientBalanceError when amount > balance', async () => {
+      seedWallet(store, { id: 'w1', balance: '100' });
+      await expect(repo.debit('w1', '101')).rejects.toBeInstanceOf(
+        InsufficientBalanceError,
+      );
+    });
+
+    it('succeeds when amount < balance and returns correct shape', async () => {
+      seedWallet(store, { id: 'w1', balance: '100' });
+      const result = await repo.debit('w1', '30');
+      expect(result.previousBalance).toBe('100');
+      expect(result.newBalance).toBe('70');
+      expect(result.debitedAmount).toBe('30');
+      expect(result.wallet.balance).toBe('70');
+    });
+
+    it('succeeds on exact-balance debit (amount === balance)', async () => {
+      seedWallet(store, { id: 'w1', balance: '50.25' });
+      const result = await repo.debit('w1', '50.25');
+      expect(result.newBalance).toBe('0.00');
+    });
+
+    // -----------------------------------------------------------------------
+    // Precision regression: the overdraft that Number() would allow
+    // -----------------------------------------------------------------------
+
+    it('precision regression — rejects overdraft invisible to Number()', async () => {
+      // Numbers just above MAX_SAFE_INTEGER lose the last bit in IEEE 754.
+      // Both 9007199254740992 (MAX_SAFE_INTEGER+1) and 9007199254740993
+      // (MAX_SAFE_INTEGER+2) round to the same float, so Number()-based
+      // comparison treats them as equal and would allow the overdraft.
+      const balance = '9007199254740992'; // MAX_SAFE_INTEGER + 1
+      const amount  = '9007199254740993'; // MAX_SAFE_INTEGER + 2
+      expect(Number(balance) === Number(amount)).toBe(true); // confirm the float collision
+
+      seedWallet(store, { id: 'w1', balance });
+      await expect(repo.debit('w1', amount)).rejects.toBeInstanceOf(
+        InsufficientBalanceError,
+      );
+    });
+
+    it('precision regression — allows exact large-integer debit', async () => {
+      const balance = '9007199254740993';
+      const amount  = '9007199254740993';
+      seedWallet(store, { id: 'w1', balance });
+      const result = await repo.debit('w1', amount);
+      expect(result.previousBalance).toBe(balance);
+    });
+
+    it('sub-unit precision — rejects 0.000000002 from balance 0.000000001', async () => {
+      seedWallet(store, { id: 'w1', balance: '0.000000001' });
+      await expect(repo.debit('w1', '0.000000002')).rejects.toBeInstanceOf(
+        InsufficientBalanceError,
+      );
+    });
+
+    it('sub-unit precision — accepts 0.000000001 from balance 0.000000002', async () => {
+      seedWallet(store, { id: 'w1', balance: '0.000000002' });
+      const result = await repo.debit('w1', '0.000000001');
+      expect(result.newBalance).toBe('0.000000001');
+    });
+
+    it('handles 30+ digit balances without loss', async () => {
+      // 36-digit integer balance (beyond Number() precision)
+      const balance = '123456789012345678901234567890123456';
+      const amount  = '1';
+      seedWallet(store, { id: 'w1', balance });
+      const result = await repo.debit('w1', amount);
+      expect(result.newBalance).toBe('123456789012345678901234567890123455');
+    });
+
+    it('rejects overdraft on 30+ digit balance by 1 unit', async () => {
+      const balance = '123456789012345678901234567890123456';
+      const amount  = '123456789012345678901234567890123457';
+      seedWallet(store, { id: 'w1', balance });
+      await expect(repo.debit('w1', amount)).rejects.toBeInstanceOf(
+        InsufficientBalanceError,
+      );
+    });
+
+    it('InsufficientBalanceError carries the correct fields', async () => {
+      seedWallet(store, { id: 'w1', balance: '50' });
+      const err = await repo.debit('w1', '100').catch((e) => e);
+      expect(err).toBeInstanceOf(InsufficientBalanceError);
+      expect(err.walletId).toBe('w1');
+      expect(err.available).toBe('50');
+      expect(err.requested).toBe('100');
+    });
+  });
+
+  // =========================================================================
+  // credit()
+  // =========================================================================
+
+  describe('credit()', () => {
+    it('throws without a pool', async () => {
+      const noPoolRepo = new WalletsRepository({} as any);
+      await expect(noPoolRepo.credit('any', '1')).rejects.toThrow(
+        'requires a Pool instance',
+      );
+    });
+
+    it('rejects non-numeric amount before acquiring lock', async () => {
+      await expect(repo.credit('w1', 'xyz')).rejects.toThrow('Invalid credit amount');
+    });
+
+    it('rejects negative amount before acquiring lock', async () => {
+      await expect(repo.credit('w1', '-5')).rejects.toThrow('Invalid credit amount');
+    });
+
+    it('rejects zero amount before acquiring lock', async () => {
+      await expect(repo.credit('w1', '0')).rejects.toThrow('Invalid credit amount');
+    });
+
+    it('throws when wallet is not found', async () => {
+      await expect(repo.credit('missing-id', '1')).rejects.toThrow('not found');
+    });
+
+    it('credits the balance correctly and returns updated wallet', async () => {
+      seedWallet(store, { id: 'w1', balance: '100' });
+      const wallet = await repo.credit('w1', '50');
+      expect(wallet.balance).toBe('150');
+    });
+
+    it('credits a zero-balance wallet', async () => {
+      seedWallet(store, { id: 'w1', balance: '0' });
+      const wallet = await repo.credit('w1', '0.000000001');
+      expect(wallet.balance).toBe('0.000000001');
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       "src/**/*.spec.ts",
       "src/**/__tests__/**/*.ts",
       "tests/integration/**/*.test.ts",
+      "tests/repositories/**/*.test.ts",
       "tests/routes/**/*.test.ts",
       "monitoring/**/*.test.ts",
     ],


### PR DESCRIPTION
Here is the PR description text extracted from the provided image so you can copy and paste it:

the write atomic, but an atomic write of a wrong decision is still wrong.

Fix: The comparison is replaced with compareDecimals(), a new BigInt-scaled exact primitive in src/lib/decimalMath.ts. Both debit() and credit() also gain upfront isValidPositiveDecimal() guards that reject zero, negative, or malformed amounts before the row lock is ever acquired.

closes #500 