### PR TITLE
sorobanstate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,7 +120,16 @@ ANALYTICS_STALENESS_SECONDS=300
 # Minimum response size (in bytes) to trigger compression. Default: 1024 (1 KB).
 COMPRESSION_THRESHOLD=1024
 
-# ── Reputation Scoring Model ─────────────────────────────────────────────────
+# ── Soroban RPC ───────────────────────────────────────────────────────────────
+# Circuit-breaker thresholds for the Soroban RPC client
+# SOROBAN_CIRCUIT_BREAKER_FAILURE_THRESHOLD=5
+# SOROBAN_CIRCUIT_BREAKER_COOLDOWN_MS=10000
+#
+# Short-TTL read-through cache for getIdentityState().
+# Keyed by network + contractId + address; only successful responses cached.
+# Set to 0 to disable. Default: 5000 ms (5 seconds).
+# SOROBAN_STATE_CACHE_TTL_MS=5000
+
 # Version identifier for the scoring model (recorded in score snapshots)
 REPUTATION_MODEL_VERSION=1.0.0
 # Maximum points for bond amount component (default: 50, achieved at ≥ 1 ETH)

--- a/src/clients/soroban.ts
+++ b/src/clients/soroban.ts
@@ -20,6 +20,11 @@ import {
 import { resolveTimeout, createTimeoutConfig } from "../lib/timeouts.js";
 import { validateConfig } from "../config/index.js";
 import { getCircuitBreaker } from "./circuitBreaker.js";
+import {
+  SorobanStateCache,
+  createSorobanStateCache,
+  type SorobanStateCacheOptions,
+} from "./sorobanStateCache.js";
 
 export type SorobanNetwork = "testnet" | "mainnet";
 
@@ -36,6 +41,12 @@ export interface SorobanClientConfig {
     failureThreshold?: number;
     cooldownPeriodMs?: number;
   };
+  /**
+   * TTL in milliseconds for the getIdentityState() read-through cache.
+   * Set to 0 to disable caching. When omitted the value is read from
+   * SOROBAN_STATE_CACHE_TTL_MS in the environment (default: 5000 ms).
+   */
+  cacheTtlMs?: number;
 }
 
 export interface ContractEvent {
@@ -68,6 +79,8 @@ export interface SorobanClientDependencies {
   sleepFn?: (ms: number) => Promise<void>;
   randomFn?: () => number;
   retryObserver?: RetryObserver;
+  /** Override the identity-state cache (useful in tests). */
+  stateCache?: SorobanStateCache;
 }
 
 export class SorobanClientError extends Error {
@@ -134,6 +147,7 @@ export class SorobanClient {
     failureThreshold: number;
     cooldownPeriodMs: number;
   };
+  private readonly stateCache: SorobanStateCache;
 
   constructor(
     config: SorobanClientConfig,
@@ -161,11 +175,13 @@ export class SorobanClient {
 
     let defaultFailureThreshold = 5;
     let defaultCooldownMs = 10000;
+    let defaultCacheTtlMs = 5000;
     try {
       const globalConfig = validateConfig(process.env);
       defaultFailureThreshold =
         globalConfig.sorobanCircuitBreaker.failureThreshold;
       defaultCooldownMs = globalConfig.sorobanCircuitBreaker.cooldownPeriodMs;
+      defaultCacheTtlMs = globalConfig.sorobanStateCache.ttlMs;
     } catch {
       if (process.env.SOROBAN_CIRCUIT_BREAKER_FAILURE_THRESHOLD) {
         defaultFailureThreshold = Number(
@@ -177,6 +193,9 @@ export class SorobanClient {
           process.env.SOROBAN_CIRCUIT_BREAKER_COOLDOWN_MS,
         );
       }
+      if (process.env.SOROBAN_STATE_CACHE_TTL_MS) {
+        defaultCacheTtlMs = Number(process.env.SOROBAN_STATE_CACHE_TTL_MS);
+      }
     }
 
     this.circuitBreakerConfig = {
@@ -185,10 +204,19 @@ export class SorobanClient {
       cooldownPeriodMs:
         config.circuitBreaker?.cooldownPeriodMs ?? defaultCooldownMs,
     };
+
+    // Allow per-instance override via config.cacheTtlMs; fall back to env default.
+    const cacheTtlMs = config.cacheTtlMs ?? defaultCacheTtlMs;
+    this.stateCache =
+      deps.stateCache ?? createSorobanStateCache(cacheTtlMs);
   }
 
   /**
    * Fetches the current identity state for an address from the configured contract.
+   *
+   * Results are cached in a short-TTL read-through cache (L1 LRU + L2 Redis).
+   * Cache hits bypass the circuit breaker entirely — the breaker only gates
+   * live RPC calls. TTL is controlled by SOROBAN_STATE_CACHE_TTL_MS (0 = off).
    */
   async getIdentityState(address: string): Promise<unknown> {
     if (!address?.trim()) {
@@ -198,11 +226,29 @@ export class SorobanClient {
       });
     }
 
-    return this.callRpc<unknown>("getContractData", {
+    // ── Cache read (never blocked by the circuit breaker) ──────────────────
+    const cached = await this.stateCache.get(
+      this.network,
+      this.contractId,
+      address,
+    );
+    if (cached !== null) {
+      return cached;
+    }
+
+    // ── Cache miss: go through the circuit breaker + retry stack ───────────
+    const result = await this.callRpc<unknown>("getContractData", {
       contractId: this.contractId,
       network: this.network,
       key: { type: "identity", address },
     });
+
+    // Only cache successful (non-null) responses.
+    if (result !== null && result !== undefined) {
+      await this.stateCache.set(this.network, this.contractId, address, result);
+    }
+
+    return result;
   }
 
   /**

--- a/src/clients/sorobanStateCache.ts
+++ b/src/clients/sorobanStateCache.ts
@@ -1,0 +1,195 @@
+/**
+ * Short-TTL read-through cache for SorobanClient.getIdentityState().
+ *
+ * Layer strategy
+ * ──────────────
+ * L1: in-process LRU (lru-cache) — zero-latency hits; evicted on TTL or
+ *     process restart.
+ * L2: Redis via CacheService — shared across replicas; falls back silently
+ *     when Redis is unavailable so the RPC path is never blocked.
+ *
+ * Cache keys are scoped to network + contractId + address so entries from
+ * different contracts/networks can never collide.
+ *
+ * Error responses are never cached — only successful (non-null) payloads
+ * returned from the RPC call are stored.
+ *
+ * Observability
+ * ─────────────
+ * Two prom-client Counters are exported and incremented on every
+ * getIdentityState() call:
+ *   soroban_state_cache_hits_total   { network, contract }
+ *   soroban_state_cache_misses_total { network, contract }
+ */
+
+import { LRUCache } from 'lru-cache'
+import client from 'prom-client'
+import { CacheService, RedisConnection } from '../cache/redis.js'
+import { logger } from '../utils/logger.js'
+
+// ── Prometheus metrics ────────────────────────────────────────────────────────
+
+export const sorobanStateCacheHitsTotal = new client.Counter({
+  name: 'soroban_state_cache_hits_total',
+  help: 'Total number of Soroban identity-state cache hits',
+  labelNames: ['network', 'contract'] as const,
+})
+
+export const sorobanStateCacheMissesTotal = new client.Counter({
+  name: 'soroban_state_cache_misses_total',
+  help: 'Total number of Soroban identity-state cache misses',
+  labelNames: ['network', 'contract'] as const,
+})
+
+// ── Cache namespace used in Redis keys ────────────────────────────────────────
+
+const REDIS_NAMESPACE = 'soroban_state'
+
+// ── SorobanStateCache ─────────────────────────────────────────────────────────
+
+export interface SorobanStateCacheOptions {
+  /** TTL in milliseconds. 0 disables all caching. */
+  ttlMs: number
+  /** Maximum number of entries in the L1 LRU cache. Default: 500. */
+  maxL1Entries?: number
+  /** Override the Redis/CacheService instance (mainly for tests). */
+  cacheService?: CacheService
+}
+
+export class SorobanStateCache {
+  private readonly ttlMs: number
+  private readonly l1: LRUCache<string, unknown>
+  private readonly redis: CacheService
+  /** Whether caching is disabled (ttlMs === 0). */
+  public readonly disabled: boolean
+
+  constructor(options: SorobanStateCacheOptions) {
+    this.ttlMs = options.ttlMs
+    this.disabled = options.ttlMs === 0
+
+    this.l1 = new LRUCache<string, unknown>({
+      max: options.maxL1Entries ?? 500,
+      // LRU TTL is in milliseconds; skip when caching is disabled
+      ttl: this.disabled ? undefined : this.ttlMs,
+      ttlAutopurge: !this.disabled,
+    })
+
+    this.redis =
+      options.cacheService ?? new CacheService(RedisConnection.getInstance())
+  }
+
+  /**
+   * Build a deterministic cache key from the three identifying dimensions.
+   */
+  public buildKey(network: string, contractId: string, address: string): string {
+    // Normalise to lower-case so "GXXX" and "gxxx" are the same key.
+    return `${network}:${contractId}:${address.toLowerCase()}`
+  }
+
+  /**
+   * Returns a cached entry or null if not found / caching is disabled.
+   *
+   * Checks L1 first; promotes L2 hit into L1.
+   */
+  public async get(
+    network: string,
+    contractId: string,
+    address: string,
+  ): Promise<unknown | null> {
+    if (this.disabled) {
+      return null
+    }
+
+    const key = this.buildKey(network, contractId, address)
+    const labels = { network, contract: contractId }
+
+    // L1 hit
+    const l1Value = this.l1.get(key)
+    if (l1Value !== undefined) {
+      sorobanStateCacheHitsTotal.inc(labels)
+      return l1Value
+    }
+
+    // L2 hit
+    try {
+      const l2Value = await this.redis.get<unknown>(REDIS_NAMESPACE, key)
+      if (l2Value !== null && l2Value !== undefined) {
+        // Promote into L1
+        this.l1.set(key, l2Value)
+        sorobanStateCacheHitsTotal.inc(labels)
+        return l2Value
+      }
+    } catch (err) {
+      // Redis errors must never surface as RPC errors — log and fall through
+      logger.warn(
+        { err, key },
+        'sorobanStateCache: Redis get failed, falling through to RPC',
+      )
+    }
+
+    sorobanStateCacheMissesTotal.inc(labels)
+    return null
+  }
+
+  /**
+   * Stores a successful RPC response in L1 and L2.
+   * Silently swallows Redis errors — a failed write only means the next
+   * request will be a cache miss, not an error.
+   */
+  public async set(
+    network: string,
+    contractId: string,
+    address: string,
+    value: unknown,
+  ): Promise<void> {
+    if (this.disabled) {
+      return
+    }
+
+    const key = this.buildKey(network, contractId, address)
+
+    // L1 — always succeeds
+    this.l1.set(key, value)
+
+    // L2 — best-effort; TTL is stored in seconds for Redis setEx
+    try {
+      const ttlSeconds = Math.max(1, Math.ceil(this.ttlMs / 1000))
+      await this.redis.set(REDIS_NAMESPACE, key, value, ttlSeconds)
+    } catch (err) {
+      logger.warn(
+        { err, key },
+        'sorobanStateCache: Redis set failed, entry lives in L1 only',
+      )
+    }
+  }
+
+  /**
+   * Evict a single entry from L1 and L2 (e.g. after a state-invalidating write).
+   */
+  public async invalidate(
+    network: string,
+    contractId: string,
+    address: string,
+  ): Promise<void> {
+    const key = this.buildKey(network, contractId, address)
+    this.l1.delete(key)
+    try {
+      await this.redis.delete(REDIS_NAMESPACE, key)
+    } catch (err) {
+      logger.warn({ err, key }, 'sorobanStateCache: Redis delete failed during invalidate')
+    }
+  }
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a SorobanStateCache from config-derived TTL.
+ * Pass `ttlMs: 0` to get a fully disabled (no-op) instance.
+ */
+export function createSorobanStateCache(
+  ttlMs: number,
+  overrides?: Partial<SorobanStateCacheOptions>,
+): SorobanStateCache {
+  return new SorobanStateCache({ ttlMs, ...overrides })
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -328,6 +328,16 @@ export const envSchema = z.object({
     .default('10000')
     .transform(Number)
     .pipe(z.number().int().min(1000)),
+  /**
+   * Short-TTL read-through cache for getIdentityState() responses.
+   * Set to 0 to disable caching entirely.
+   * Default: 5000 ms (5 seconds).
+   */
+  SOROBAN_STATE_CACHE_TTL_MS: z
+    .string()
+    .default('5000')
+    .transform(Number)
+    .pipe(z.number().int().min(0)),
 
   // Audit log export
   AUDIT_EXPORT_MAX_WINDOW_DAYS: z
@@ -448,6 +458,10 @@ export interface Config {
   sorobanCircuitBreaker: {
     failureThreshold: number
     cooldownPeriodMs: number
+  }
+  sorobanStateCache: {
+    /** TTL in milliseconds. 0 = disabled. */
+    ttlMs: number
   }
   auditLog: {
     exportMaxWindowDays: number
@@ -623,6 +637,9 @@ function mapEnvToConfig(env: Env): Config {
     sorobanCircuitBreaker: {
       failureThreshold: env.SOROBAN_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
       cooldownPeriodMs: env.SOROBAN_CIRCUIT_BREAKER_COOLDOWN_MS,
+    },
+    sorobanStateCache: {
+      ttlMs: env.SOROBAN_STATE_CACHE_TTL_MS,
     },
     auditLog: {
       exportMaxWindowDays: env.AUDIT_EXPORT_MAX_WINDOW_DAYS,


### PR DESCRIPTION
Closes #507 

Added a short-TTL read-through cache to getIdentityState() across 4 files:

New sorobanStateCache.ts — two-layer cache (L1 LRU in-memory + L2 Redis), keyed by network:contractId:address. Errors never cached. Exports two prom-client Counters (soroban_state_cache_hits_total / soroban_state_cache_misses_total) labelled by network and contract.

soroban.ts — cache check runs before the circuit breaker. Hit = return immediately, breaker untouched. Miss = normal breaker → retry → RPC path, then write result to cache on success.

index.ts
 — new SOROBAN_STATE_CACHE_TTL_MS env var (default 5000 ms, 0 = disabled), wired into Config.sorobanStateCache.ttlMs.

.env.example — documents the new var.