### PR TITLE
Add structured audit log for admin operations

### DIFF
--- a/init-db/001_schema.sql
+++ b/init-db/001_schema.sql
@@ -9,7 +9,9 @@ CREATE TABLE IF NOT EXISTS audit_logs (
 	details_json JSONB NOT NULL DEFAULT '{}'::jsonb,
 	status TEXT NOT NULL CHECK (status IN ('success', 'failure')),
 	ip_address TEXT,
-	error_message TEXT
+	error_message TEXT,
+	tenant_id TEXT,
+	request_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS audit_logs_actor_time_idx

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@types/express": "^4.17.21",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
-        "@types/node": "^20.19.33",
+        "@types/node": "^20.19.37",
         "@types/pg": "^8.16.0",
         "@types/redis": "^4.0.10",
         "@types/supertest": "^6.0.3",
@@ -110,6 +110,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -613,29 +614,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1880,6 +1858,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2157,6 +2136,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2442,59 +2422,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2885,7 +2812,7 @@
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2895,8 +2822,9 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3090,6 +3018,7 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -3614,6 +3543,7 @@
       "integrity": "sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3639,6 +3569,7 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -3818,6 +3749,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4264,7 +4196,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4553,6 +4484,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5643,6 +5575,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7060,6 +6993,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8942,6 +8876,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -10893,6 +10828,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -11000,6 +10936,7 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11036,7 +10973,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -11193,6 +11130,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11271,6 +11209,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -11730,6 +11669,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/db/repositories/auditLogsRepository.ts
+++ b/src/db/repositories/auditLogsRepository.ts
@@ -57,6 +57,7 @@ const mapAuditLog = (row: AuditLogRow): AuditLogEntry => ({
   ipAddress: row.ip_address ?? undefined,
   errorMessage: row.error_message ?? undefined,
   tenantId: row.tenant_id,
+  requestId: row.request_id ?? undefined,
   seq: row.seq ?? undefined,
   prevHash: row.prev_hash !== undefined ? row.prev_hash : null,
   rowHash: row.row_hash ?? undefined,
@@ -122,6 +123,7 @@ export function computeRowHash(
   detailsJson: string,
   status: string,
   tenantId: string,
+  requestId: string = '',
 ): string {
   const input = [
     prevHash ?? 'GENESIS',
@@ -134,6 +136,7 @@ export function computeRowHash(
     detailsJson,
     status,
     tenantId,
+    requestId,
   ].join('|')
 
   return createHash('sha256').update(input, 'utf8').digest('hex')
@@ -195,13 +198,14 @@ export class PostgresAuditLogsRepository implements AuditLogRepository {
         ip_address,
         error_message,
         tenant_id,
+        request_id,
         prev_hash,
         row_hash
       )
       SELECT
         $1,
         ns.seq_val,
-        $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11,
+        $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12,
         p.row_hash,
         encode(
           sha256(
@@ -215,7 +219,8 @@ export class PostgresAuditLogsRepository implements AuditLogRepository {
               $6 || '|' ||
               $7 || '|' ||
               $8 || '|' ||
-              $11,
+              $11 || '|' ||
+              COALESCE($12, ''),
               'UTF8'
             )
           ),
@@ -236,6 +241,7 @@ export class PostgresAuditLogsRepository implements AuditLogRepository {
         ip_address,
         error_message,
         tenant_id,
+        request_id,
         seq,
         prev_hash,
         row_hash
@@ -252,6 +258,7 @@ export class PostgresAuditLogsRepository implements AuditLogRepository {
         input.ipAddress ?? null,
         input.errorMessage ?? null,
         input.tenantId,
+        input.requestId ?? null,
       ],
     )
 
@@ -361,6 +368,7 @@ export class InMemoryAuditLogsRepository implements AuditLogRepository {
       detailsStr,
       statusVal,
       input.tenantId,
+      input.requestId ?? '',
     )
 
     const entry: AuditLogEntry = {
@@ -383,6 +391,7 @@ export class InMemoryAuditLogsRepository implements AuditLogRepository {
       ipAddress: input.ipAddress,
       errorMessage: input.errorMessage,
       tenantId: input.tenantId,
+      requestId: input.requestId,
       seq,
       prevHash,
       rowHash,

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -53,6 +53,7 @@ export function createAdminRouter(): Router {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
+      const requestId = (req as any).requestId
 
       const { page, limit, offset } = parsePaginationParams(req.query as Record<string, unknown>, { defaultLimit: 50 })
 
@@ -72,6 +73,7 @@ export function createAdminRouter(): Router {
         user.email,
         { page, limit, offset },
         filters,
+        requestId
       );
 
       res.status(200).json({
@@ -93,6 +95,7 @@ export function createAdminRouter(): Router {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
+      const requestId = (req as any).requestId
       const assignRequest = req.body as AssignRoleRequest
 
       // Validate request body
@@ -104,6 +107,7 @@ export function createAdminRouter(): Router {
         user.id,
         user.email,
         assignRequest,
+        requestId
       );
 
       res.status(200).json({
@@ -123,6 +127,7 @@ export function createAdminRouter(): Router {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
+      const requestId = (req as any).requestId
       const revokeRequest = req.body as RevokeApiKeyRequest
 
       // Validate request body
@@ -134,6 +139,7 @@ export function createAdminRouter(): Router {
         user.id,
         user.email,
         revokeRequest,
+        requestId
       );
 
       res.status(200).json({
@@ -154,6 +160,7 @@ export function createAdminRouter(): Router {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
+      const requestId = (req as any).requestId
       const body = req.body as Partial<IssueImpersonationTokenRequest>
 
       if (!body.targetUserId) {
@@ -175,6 +182,7 @@ export function createAdminRouter(): Router {
           ttlSeconds: body.ttlSeconds,
         },
         req.ip,
+        requestId
       );
 
       res.status(201).json({ success: true, data: issued });
@@ -197,6 +205,7 @@ export function createAdminRouter(): Router {
   router.post('/impersonate/:tokenId/revoke', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next) => {
     const authReq = req as AuthenticatedRequest
     const user = authReq.user!
+    const requestId = (req as any).requestId
     const { tokenId } = req.params
 
     if (!tokenId) {
@@ -205,7 +214,7 @@ export function createAdminRouter(): Router {
     }
 
     try {
-      await impersonationService.revokeToken(user.id, user.email, user.tenantId, tokenId, req.ip)
+      await impersonationService.revokeToken(user.id, user.email, user.tenantId, tokenId, req.ip, requestId)
       res.status(200).json({ success: true })
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
@@ -267,6 +276,7 @@ export function createAdminRouter(): Router {
       try {
         const authReq = req as AuthenticatedRequest;
         const user = authReq.user!;
+        const requestId = (req as any).requestId
 
         if (!req.query.startDate || !req.query.endDate) {
           throw new ValidationError(
@@ -305,6 +315,7 @@ export function createAdminRouter(): Router {
         startDate,
         endDate,
         user,
+        requestId
       );
 
       let count = 0;
@@ -319,6 +330,7 @@ export function createAdminRouter(): Router {
         startDate,
         endDate,
         count,
+        requestId
       );
       res.end();
     } catch (error) {
@@ -337,10 +349,28 @@ export function createAdminRouter(): Router {
    */
   router.get('/events/failed', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next) => {
     try {
+      const authReq = req as AuthenticatedRequest
+      const admin = authReq.user!
+      const requestId = (req as any).requestId
       const { page, limit, offset } = parsePaginationParams(req.query as Record<string, unknown>)
       const filters: any = {}
       if (req.query.status) filters.status = req.query.status
       if (req.query.type) filters.type = req.query.type
+
+      // Log the list action
+      void auditLogService.logAction(
+        admin.tenantId,
+        admin.id,
+        admin.email,
+        AuditAction.LIST_FAILED_EVENTS,
+        admin.id,
+        undefined,
+        { filters, limit, offset },
+        undefined,
+        undefined,
+        req.ip,
+        requestId
+      )
 
       const { events, total } = await replayService.listFailedEvents(filters, limit, offset)
       const paginationMeta = buildPaginationMeta(total, page, limit)
@@ -365,13 +395,15 @@ export function createAdminRouter(): Router {
       const authReq = req as AuthenticatedRequest
       const admin = authReq.user!
       const id = req.params.id
+      const requestId = (req as any).requestId
 
       const result = await replayService.replayEvent(
         id,
         admin.id,
         admin.email,
         admin.tenantId,
-        req.ip
+        req.ip,
+        requestId
       )
 
       res.status(200).json(result)
@@ -386,10 +418,29 @@ export function createAdminRouter(): Router {
    */
   router.post('/replay', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next) => {
     try {
-      const { requestId } = req.body as { requestId: string };
-      if (!requestId) {
+      const authReq = req as AuthenticatedRequest;
+      const admin = authReq.user!;
+      const requestId = (req as any).requestId;
+      const { requestId: targetRequestId } = req.body as { requestId: string };
+      if (!targetRequestId) {
         throw new ValidationError('Missing requestId');
       }
+
+      // Log the replay request
+      void auditLogService.logAction(
+        admin.tenantId,
+        admin.id,
+        admin.email,
+        AuditAction.REPLAY_REQUEST,
+        targetRequestId,
+        undefined,
+        { requestId: targetRequestId },
+        undefined,
+        undefined,
+        req.ip,
+        requestId
+      );
+
       const diff = await withReplaySnapshot(pool, async (client, snapshot) => {
         const identityRepo = new IdentityRepository(client);
         const bondsRepo = new BondsRepository(client);
@@ -411,7 +462,7 @@ export function createAdminRouter(): Router {
         const identitiesDiff = computeDiff(currentIdentities, snapshot.identities);
         const bondsDiff = computeDiff(currentBonds, snapshot.bonds);
         return { identities: identitiesDiff, bonds: bondsDiff };
-      }, requestId);
+      }, targetRequestId);
       res.status(200).json({ success: true, data: diff });
     } catch (error) {
       next(error);

--- a/src/routes/admin/outbox.ts
+++ b/src/routes/admin/outbox.ts
@@ -10,7 +10,7 @@ import {
   requireApiKey,
   requireUserAuth,
 } from '../../middleware/auth.js'
-import { auditLogService } from '../../services/audit/index.js'
+import { auditLogService, AuditAction } from '../../services/audit/index.js'
 
 const quarantineReasons = new Set<OutboxQuarantineReason>([
   'malformed_json',
@@ -50,6 +50,9 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
     requireAdminRole,
     async (req: Request, res: Response, next: NextFunction) => {
       try {
+        const authReq = req as AuthenticatedRequest
+        const admin = authReq.user!
+        const requestId = (req as any).requestId
         const { page, limit, offset } = parsePaginationParams(req.query as Record<string, unknown>, {
           defaultLimit: 50,
         })
@@ -58,6 +61,21 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
           res.status(400).json({ error: 'InvalidReason', message: `Unsupported quarantine reason: ${reason}` })
           return
         }
+
+        // Log the list action
+        void auditLogService.logAction(
+          admin.tenantId,
+          admin.id,
+          admin.email,
+          AuditAction.LIST_OUTBOX_QUARANTINE,
+          admin.id,
+          undefined,
+          { reason, limit, offset },
+          undefined,
+          undefined,
+          req.ip,
+          requestId
+        )
 
         const { entries, total } = await repository.listQuarantine(
           pool,
@@ -84,6 +102,7 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
       try {
         const id = BigInt(req.params.id)
         const payload = req.body?.payload
+        const requestId = (req as any).requestId
         if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
           res.status(400).json({ error: 'InvalidPayload', message: 'payload must be a JSON object' })
           return
@@ -104,7 +123,7 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
           tenantId,
           actorId,
           actorEmail,
-          action: 'OUTBOX_REINJECT',
+          action: AuditAction.OUTBOX_REINJECT,
           resourceType: 'outbox_quarantine',
           resourceId: id.toString(),
           details: {
@@ -113,6 +132,7 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
           },
           status: 'success',
           ipAddress: req.ip,
+          requestId,
         })
 
         res.status(201).json({

--- a/src/routes/admin/webhooks.ts
+++ b/src/routes/admin/webhooks.ts
@@ -30,8 +30,9 @@ export function createWebhookAdminRouter(): Router {
     try {
       const { id } = req.params
       const admin = (req as AuthenticatedRequest).user!
+      const requestId = (req as any).requestId
       
-      const webhook = await webhookService.rotateSecret(id, { id: admin.id, email: admin.email, tenantId: admin.tenantId })
+      const webhook = await webhookService.rotateSecret(id, { id: admin.id, email: admin.email, tenantId: admin.tenantId }, requestId)
       
       res.json({
         success: true,
@@ -59,8 +60,9 @@ export function createWebhookAdminRouter(): Router {
     try {
       const { id } = req.params
       const admin = (req as AuthenticatedRequest).user!
+      const requestId = (req as any).requestId
 
-      await webhookService.revokePreviousSecret(id, { id: admin.id, email: admin.email, tenantId: admin.tenantId })
+      await webhookService.revokePreviousSecret(id, { id: admin.id, email: admin.email, tenantId: admin.tenantId }, requestId)
       
       res.json({
         success: true,

--- a/src/services/admin/index.ts
+++ b/src/services/admin/index.ts
@@ -36,7 +36,8 @@ export class AdminService {
     adminId: string,
     adminEmail: string,
     pagination: PaginationOptions = {},
-    filters?: { role?: UserRole; active?: boolean }
+    filters?: { role?: UserRole; active?: boolean },
+    requestId?: string
   ): Promise<ListUsersResponse> {
     const page = pagination.page ?? 1
     const limit = pagination.limit ?? 50
@@ -49,7 +50,7 @@ export class AdminService {
       limit,
       offset,
       filters,
-    })
+    }, undefined, undefined, undefined, requestId)
 
     // Get all users
     const users = userRepo.list().map((user) => this.formatUser(user))
@@ -89,7 +90,8 @@ export class AdminService {
   async assignRole(
     adminId: string,
     adminEmail: string,
-    request: AssignRoleRequest
+    request: AssignRoleRequest,
+    requestId?: string
   ): Promise<AssignRoleResponse> {
     const { userId, role } = request
 
@@ -107,7 +109,9 @@ export class AdminService {
         undefined,
         { requestedRole: role },
         'failure',
-        `Invalid role: ${role}`
+        `Invalid role: ${role}`,
+        undefined,
+        requestId
       )
       throw new Error(`Invalid role: ${role}`)
     }
@@ -123,7 +127,9 @@ export class AdminService {
         undefined,
         { requestedRole: role },
         'failure',
-        'User not found'
+        'User not found',
+        undefined,
+        requestId
       )
       throw new Error(`User not found: ${userId}`)
     }
@@ -141,7 +147,10 @@ export class AdminService {
       userId,
       updated.email,
       { oldRole, newRole: role, targetUserEmail: updated.email },
-      'success'
+      'success',
+      undefined,
+      undefined,
+      requestId
     )
 
     return {
@@ -163,7 +172,8 @@ export class AdminService {
   async revokeApiKey(
     adminId: string,
     adminEmail: string,
-    request: RevokeApiKeyRequest
+    request: RevokeApiKeyRequest,
+    requestId?: string
   ): Promise<RevokeApiKeyResponse> {
     const { userId, apiKey } = request
 
@@ -180,7 +190,9 @@ export class AdminService {
         undefined,
         { revokedKey: apiKey },
         'failure',
-        'User not found'
+        'User not found',
+        undefined,
+        requestId
       )
       throw new Error(`User not found: ${userId}`)
     }
@@ -198,7 +210,9 @@ export class AdminService {
         user.email,
         { revokedKey: apiKey, targetUserEmail: user.email },
         'failure',
-        'API key does not belong to this user'
+        'API key does not belong to this user',
+        undefined,
+        requestId
       )
       throw new Error('API key does not belong to this user')
     }
@@ -216,7 +230,10 @@ export class AdminService {
       userId,
       user.email,
       { revokedKey: apiKey, targetUserEmail: user.email },
-      'success'
+      'success',
+      undefined,
+      undefined,
+      requestId
     )
 
     return {
@@ -275,7 +292,8 @@ export class AdminService {
     adminEmail: string,
     startDate: Date,
     endDate: Date,
-    user: AuthenticatedRequest['user']
+    user: AuthenticatedRequest['user'],
+    requestId?: string
   ) {
     const tenantId = user?.tenantId || 'tenant-admin'
 
@@ -284,7 +302,7 @@ export class AdminService {
       startDate: startDate.toISOString(),
       endDate: endDate.toISOString(),
       phase: 'initiation',
-    })
+    }, undefined, undefined, undefined, requestId)
 
     const options: { allowSuperScope?: boolean } = {}
     if (user?.role === UserRole.SUPER_ADMIN) {

--- a/src/services/audit/index.ts
+++ b/src/services/audit/index.ts
@@ -47,6 +47,7 @@ export class AuditLogService {
     status?: AuditStatus,
     errorMessage?: string,
     ipAddress?: string,
+    requestId?: string,
   ): Promise<AuditLogEntry> {
     if (typeof inputOrTenantId !== 'string') {
       return this.repository.append(inputOrTenantId)
@@ -75,6 +76,7 @@ export class AuditLogService {
       status,
       errorMessage,
       ipAddress,
+      requestId,
     })
   }
 

--- a/src/services/audit/types.ts
+++ b/src/services/audit/types.ts
@@ -35,6 +35,11 @@ export enum AuditAction {
   POLICY_RULE_DELETED = 'POLICY_RULE_DELETED',
   ROTATE_WEBHOOK_SECRET = 'ROTATE_WEBHOOK_SECRET',
   REVOKE_WEBHOOK_SECRET = 'REVOKE_WEBHOOK_SECRET',
+  LIST_FAILED_EVENTS = 'LIST_FAILED_EVENTS',
+  REPLAY_EVENT = 'REPLAY_EVENT',
+  REPLAY_REQUEST = 'REPLAY_REQUEST',
+  LIST_OUTBOX_QUARANTINE = 'LIST_OUTBOX_QUARANTINE',
+  OUTBOX_REINJECT = 'OUTBOX_REINJECT',
 }
 
 export type AuditStatus = 'success' | 'failure'
@@ -50,6 +55,7 @@ export interface AuditLogInput {
   ipAddress?: string
   errorMessage?: string
   tenantId: string
+  requestId?: string
 }
 
 export interface AuditLogFilters {
@@ -84,6 +90,7 @@ export interface AuditLogEntry {
   ipAddress?: string
   status: AuditStatus
   errorMessage?: string
+  requestId?: string
   tenantId: string
   /** Sequence number for deterministic chain ordering */
   seq?: number

--- a/src/services/impersonation/index.ts
+++ b/src/services/impersonation/index.ts
@@ -40,6 +40,7 @@ export class ImpersonationService {
     tenantId: string,
     request: IssueImpersonationTokenRequest,
     ipAddress?: string,
+    requestId?: string
   ): Promise<IssueImpersonationTokenResponse> {
     const { targetUserId, reason, ttlSeconds } = request
 
@@ -55,6 +56,7 @@ export class ImpersonationService {
         'failure',
         'reason is required',
         ipAddress,
+        requestId
       )
       throw new Error('reason is required and must not be empty')
     }
@@ -72,6 +74,7 @@ export class ImpersonationService {
         'failure',
         'target user not found',
         ipAddress,
+        requestId
       )
       throw new Error(`User not found: ${targetUserId}`)
     }
@@ -112,6 +115,7 @@ export class ImpersonationService {
       'success',
       undefined,
       ipAddress,
+      requestId
     )
 
     return { tokenId, targetUserId, targetUserEmail: target.email, expiresAt: expiresAt.toISOString(), ttlSeconds: ttl }
@@ -126,6 +130,7 @@ export class ImpersonationService {
     tenantId: string,
     tokenId: string,
     ipAddress?: string,
+    requestId?: string
   ): Promise<void> {
     const record = await this.repo.findById(tokenId)
 
@@ -154,6 +159,7 @@ export class ImpersonationService {
       'success',
       undefined,
       ipAddress,
+      requestId
     )
   }
 

--- a/src/services/members/service.ts
+++ b/src/services/members/service.ts
@@ -50,6 +50,7 @@ export class MemberService {
     adminId: string,
     adminEmail: string,
     request: InviteMemberRequest,
+    requestId?: string
   ): Promise<InviteMemberResponse> {
     const { orgId, userId, email, role = 'member' } = request
 
@@ -63,6 +64,8 @@ export class MemberService {
         { orgId, role },
         'failure',
         'Member already active in this organisation',
+        undefined,
+        requestId
       )
       throw new Error('Member is already active in this organisation')
     }
@@ -76,6 +79,9 @@ export class MemberService {
       userId, email,
       { orgId, role: member.role, memberId: member.id },
       'success',
+      undefined,
+      undefined,
+      requestId
     )
 
     return {

--- a/src/services/replayService.test.ts
+++ b/src/services/replayService.test.ts
@@ -85,7 +85,7 @@ describe('ReplayService', () => {
     vi.mocked(cache.get).mockResolvedValue(event)
     mockRepo.findById.mockResolvedValue(updatedEvent)
 
-    const result = await replayService.replayEvent('123', 'admin-1', 'admin@example.com', '127.0.0.1')
+    const result = await replayService.replayEvent('123', 'admin-1', 'admin@example.com', 'tenant-1', '127.0.0.1')
 
     expect(result.success).toBe(true)
     expect(mockHandler.handle).toHaveBeenCalledWith(event.eventData)
@@ -103,7 +103,7 @@ describe('ReplayService', () => {
     }
     vi.mocked(cache.get).mockResolvedValue(event)
 
-    const result = await replayService.replayEvent('123', 'admin-1', 'admin@example.com')
+    const result = await replayService.replayEvent('123', 'admin-1', 'admin@example.com', 'tenant-1')
 
     expect(result.success).toBe(false)
     expect(result.message).toBe('Event already replayed')
@@ -119,7 +119,7 @@ describe('ReplayService', () => {
     }
     vi.mocked(cache.get).mockResolvedValue(event)
 
-    await expect(replayService.replayEvent('123', 'admin-1', 'admin@example.com'))
+    await expect(replayService.replayEvent('123', 'admin-1', 'admin@example.com', 'tenant-1'))
       .rejects.toThrow('No handler registered for event type: unknown_event')
   })
 })

--- a/src/services/replayService.ts
+++ b/src/services/replayService.ts
@@ -1,5 +1,5 @@
 import { FailedInboundEventsRepository, FailedInboundEvent } from '../db/repositories/failedInboundEventsRepository.js'
-import { auditLogService } from './audit/index.js'
+import { auditLogService, AuditAction } from './audit/index.js'
 import { cache } from '../cache/redis.js'
 import { invalidateCache } from '../cache/invalidation.js'
 
@@ -71,7 +71,8 @@ export class ReplayService {
     adminId: string,
     adminEmail: string,
     tenantId: string,
-    ipAddress?: string
+    ipAddress?: string,
+    requestId?: string
   ): Promise<{ success: boolean; message: string }> {
     const event = await this.getFailedEvent(id)
     if (!event) {
@@ -106,13 +107,14 @@ export class ReplayService {
         tenantId,
         adminId,
         adminEmail,
-        'REPLAY_EVENT' as any,
+        AuditAction.REPLAY_EVENT,
         id,
         'system',
         { eventType: event.eventType, status: 'success' },
         'success',
         undefined,
-        ipAddress
+        ipAddress,
+        requestId
       )
 
       return { success: true, message: 'Event successfully replayed' }
@@ -125,13 +127,14 @@ export class ReplayService {
         tenantId,
         adminId,
         adminEmail,
-        'REPLAY_EVENT' as any,
+        AuditAction.REPLAY_EVENT,
         id,
         'system',
         { eventType: event.eventType, status: 'failure' },
         'failure',
         errorMessage,
-        ipAddress
+        ipAddress,
+        requestId
       )
 
       throw new Error(`Replay failed: ${errorMessage}`)

--- a/src/services/webhooks/service.ts
+++ b/src/services/webhooks/service.ts
@@ -22,7 +22,7 @@ export class WebhookService {
    * Rotate a webhook's signing secret.
    * Moves current secret to previousSecret and generates a new one.
    */
-  async rotateSecret(id: string, admin?: { id: string, email: string, tenantId: string }): Promise<WebhookConfig> {
+  async rotateSecret(id: string, admin?: { id: string, email: string, tenantId: string }, requestId?: string): Promise<WebhookConfig> {
     const webhook = await this.store.get(id)
     if (!webhook) {
       throw new Error('Webhook not found')
@@ -43,7 +43,11 @@ export class WebhookService {
         AuditAction.ROTATE_WEBHOOK_SECRET,
         id,
         webhook.url,
-        { rotatedAt: webhook.secretUpdatedAt }
+        { rotatedAt: webhook.secretUpdatedAt },
+        undefined,
+        undefined,
+        undefined,
+        requestId
       )
     }
 
@@ -53,7 +57,7 @@ export class WebhookService {
   /**
    * Revoke the previous secret for a webhook.
    */
-  async revokePreviousSecret(id: string, admin?: { id: string, email: string, tenantId: string }): Promise<WebhookConfig> {
+  async revokePreviousSecret(id: string, admin?: { id: string, email: string, tenantId: string }, requestId?: string): Promise<WebhookConfig> {
     const webhook = await this.store.get(id)
     if (!webhook) {
       throw new Error('Webhook not found')
@@ -69,7 +73,12 @@ export class WebhookService {
         admin.email,
         AuditAction.REVOKE_WEBHOOK_SECRET,
         id,
-        webhook.url
+        webhook.url,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        requestId
       )
     }
 


### PR DESCRIPTION
Close: #553

I've added structured audit logging for all admin endpoints, ensuring that every admin operation is tracked with the necessary details (actor, action, target, timestamp, request ID, etc.)!

Here's a recap of the changes:

1. Updated Audit Actions Enum ( src/services/audit/types.ts ): Added the missing audit actions for the uncovered endpoints.
2. Enhanced Admin Routes ( src/routes/admin/index.ts ): Added audit logs for the failed events list, replay endpoint, and request replay feature.
3. Improved Replay Service ( src/services/replayService.ts ): Updated to use the enum and accept request ID.
4. Updated Outbox Admin Routes ( src/routes/admin/outbox.ts ): Added audit log for quarantine list and updated reinject to use enum.
5. Fixed Tests ( src/services/replayService.test.ts ): Updated to match the new function signature.
Now, all admin operations under /api/admin are properly audited, ensuring a secure and traceable system!