### PR TITLE
feat(webhooks): add replay protection to HMAC verification

### DIFF
--- a/src/lib/webhookVerifier.test.ts
+++ b/src/lib/webhookVerifier.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from 'node:crypto'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   parseSignatureHeader,
   computeHmac,
@@ -103,8 +103,20 @@ describe('safeCompareHex', () => {
 // ---------------------------------------------------------------------------
 
 describe('verifySignature', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-06-25T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   const secret = 'test-secret'
-  const body = '{"event":"bond.created"}'
+  const body = JSON.stringify({
+    event: 'bond.created',
+    timestamp: '2026-06-25T12:00:00.000Z'
+  })
   const validSig = sign(body, secret)
 
   it('returns missing_secret when secret is null', () => {
@@ -166,5 +178,72 @@ describe('verifySignature', () => {
   it('returns ok:true for sha256= prefix with uppercase', () => {
     const result = verifySignature(`SHA256=${validSig}`, body, secret)
     expect(result).toEqual({ ok: true })
+  })
+
+  describe('replay protection with fake timers', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['Date'] })
+      vi.setSystemTime(new Date('2026-06-25T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('rejects payload when timestamp is missing', () => {
+      const payload = '{"event":"bond.created","data":{}}'
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret)
+      expect(result).toEqual({ ok: false, reason: 'missing_timestamp' })
+    })
+
+    it('rejects payload when timestamp is malformed', () => {
+      const payload = '{"event":"bond.created","timestamp":"not-a-date","data":{}}'
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret)
+      expect(result).toEqual({ ok: false, reason: 'invalid_timestamp' })
+    })
+
+    it('rejects payload when timestamp is expired (older than default 5 mins)', () => {
+      const payload = '{"event":"bond.created","timestamp":"2026-06-25T11:54:59.000Z","data":{}}' // 5m 1s ago
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret)
+      expect(result).toEqual({ ok: false, reason: 'expired' })
+    })
+
+    it('rejects payload when timestamp is in the future (newer than default 5 mins)', () => {
+      const payload = '{"event":"bond.created","timestamp":"2026-06-25T12:05:01.000Z","data":{}}' // 5m 1s in future
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret)
+      expect(result).toEqual({ ok: false, reason: 'expired' })
+    })
+
+    it('accepts payload when timestamp is exactly at the limit of 5 mins past', () => {
+      const payload = '{"event":"bond.created","timestamp":"2026-06-25T11:55:00.000Z","data":{}}' // exactly 5 mins ago
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret)
+      expect(result).toEqual({ ok: true })
+    })
+
+    it('accepts payload when timestamp is exactly at the limit of 5 mins future', () => {
+      const payload = '{"event":"bond.created","timestamp":"2026-06-25T12:05:00.000Z","data":{}}' // exactly 5 mins future
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret)
+      expect(result).toEqual({ ok: true })
+    })
+
+    it('rejects payload when timestamp is outside custom tolerance window', () => {
+      const payload = '{"event":"bond.created","timestamp":"2026-06-25T11:58:59.000Z","data":{}}' // 1m 1s ago
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret, undefined, { tolerance: 60000 }) // 1 min tolerance
+      expect(result).toEqual({ ok: false, reason: 'expired' })
+    })
+
+    it('accepts payload when timestamp is within custom tolerance window', () => {
+      const payload = '{"event":"bond.created","timestamp":"2026-06-25T11:59:01.000Z","data":{}}' // 59s ago
+      const sig = sign(payload, secret)
+      const result = verifySignature(sig, payload, secret, undefined, { tolerance: 60000 }) // 1 min tolerance
+      expect(result).toEqual({ ok: true })
+    })
   })
 })

--- a/src/lib/webhookVerifier.ts
+++ b/src/lib/webhookVerifier.ts
@@ -1,8 +1,18 @@
-﻿import { createHmac, timingSafeEqual } from 'node:crypto'
+import { createHmac, timingSafeEqual } from 'node:crypto'
 
 export type VerifyResult =
   | { ok: true }
-  | { ok: false; reason: 'missing_secret' | 'missing_signature' | 'malformed_signature' | 'invalid_signature' }
+  | {
+      ok: false
+      reason:
+        | 'missing_secret'
+        | 'missing_signature'
+        | 'malformed_signature'
+        | 'invalid_signature'
+        | 'expired'
+        | 'missing_timestamp'
+        | 'invalid_timestamp'
+    }
 
 export function parseSignatureHeader(raw: string | null | undefined): string | null {
   if (raw == null) return null
@@ -28,7 +38,8 @@ export function verifySignature(
   rawSignature: string | null | undefined,
   body: string,
   currentSecret: string | null | undefined,
-  previousSecret?: string | null | undefined
+  previousSecret?: string | null | undefined,
+  options?: { tolerance?: number }
 ): VerifyResult {
   if (!currentSecret && !previousSecret) return { ok: false, reason: 'missing_secret' }
   if (rawSignature == null || rawSignature === '') {
@@ -37,6 +48,28 @@ export function verifySignature(
 
   const received = parseSignatureHeader(rawSignature)
   if (!received) return { ok: false, reason: 'malformed_signature' }
+
+  // Replay Protection / Timestamp Verification
+  try {
+    const payload = JSON.parse(body)
+    if (!payload || typeof payload !== 'object' || !('timestamp' in payload)) {
+      return { ok: false, reason: 'missing_timestamp' }
+    }
+    if (typeof payload.timestamp !== 'string') {
+      return { ok: false, reason: 'invalid_timestamp' }
+    }
+    const timestamp = new Date(payload.timestamp).getTime()
+    if (isNaN(timestamp)) {
+      return { ok: false, reason: 'invalid_timestamp' }
+    }
+    const now = Date.now()
+    const tolerance = options?.tolerance ?? 300000 // default 5 minutes (300,000 ms)
+    if (Math.abs(now - timestamp) > tolerance) {
+      return { ok: false, reason: 'expired' }
+    }
+  } catch {
+    return { ok: false, reason: 'missing_timestamp' }
+  }
 
   // Try current secret first
   if (currentSecret) {

--- a/src/middleware/webhookSignature.test.ts
+++ b/src/middleware/webhookSignature.test.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import request from 'supertest'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createHmac } from 'crypto'
 
 import { verifyWebhookSignature } from './webhookSignature.js'
@@ -10,6 +10,15 @@ function sign(body: string, secret: string): string {
 }
 
 describe('verifyWebhookSignature', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-06-25T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns 401 when signature header is missing', async () => {
     const app = express()
     app.use(express.text({ type: '*/*' }))
@@ -60,7 +69,10 @@ describe('verifyWebhookSignature', () => {
       (_req, res) => res.status(200).json({ ok: true }),
     )
 
-    const body = '{"hello":"world"}'
+    const body = JSON.stringify({
+      hello: 'world',
+      timestamp: '2026-06-25T12:00:00.000Z'
+    })
     const sig = sign(body, 'test-secret')
 
     const res = await request(app)
@@ -70,6 +82,95 @@ describe('verifyWebhookSignature', () => {
 
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ ok: true })
+  })
+
+  describe('replay protection with fake timers', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['Date'] })
+      vi.setSystemTime(new Date('2026-06-25T12:00:00.000Z'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('returns 401 when timestamp is missing', async () => {
+      const app = express()
+      app.use(express.text({ type: '*/*' }))
+      app.post(
+        '/webhook',
+        verifyWebhookSignature({
+          secret: 'test-secret',
+          getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+        }),
+        (_req, res) => res.status(200).json({ ok: true }),
+      )
+
+      const body = '{"hello":"world"}'
+      const sig = sign(body, 'test-secret')
+
+      const res = await request(app)
+        .post('/webhook')
+        .set('X-Webhook-Signature', `sha256=${sig}`)
+        .send(body)
+
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 401 when timestamp is expired', async () => {
+      const app = express()
+      app.use(express.text({ type: '*/*' }))
+      app.post(
+        '/webhook',
+        verifyWebhookSignature({
+          secret: 'test-secret',
+          getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+        }),
+        (_req, res) => res.status(200).json({ ok: true }),
+      )
+
+      const expiredBody = JSON.stringify({
+        event: 'bond.created',
+        timestamp: '2026-06-25T11:50:00.000Z', // 10 mins ago
+        data: {}
+      })
+      const sig = sign(expiredBody, 'test-secret')
+
+      const res = await request(app)
+        .post('/webhook')
+        .set('X-Webhook-Signature', `sha256=${sig}`)
+        .send(expiredBody)
+
+      expect(res.status).toBe(401)
+    })
+
+    it('allows request with valid signature and within custom tolerance', async () => {
+      const app = express()
+      app.use(express.text({ type: '*/*' }))
+      app.post(
+        '/webhook',
+        verifyWebhookSignature({
+          secret: 'test-secret',
+          tolerance: 60000, // 1 min tolerance
+          getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+        }),
+        (_req, res) => res.status(200).json({ ok: true }),
+      )
+
+      const body = JSON.stringify({
+        event: 'bond.created',
+        timestamp: '2026-06-25T11:59:30.000Z', // 30s ago
+        data: {}
+      })
+      const sig = sign(body, 'test-secret')
+
+      const res = await request(app)
+        .post('/webhook')
+        .set('X-Webhook-Signature', `sha256=${sig}`)
+        .send(body)
+
+      expect(res.status).toBe(200)
+    })
   })
 })
 

--- a/src/middleware/webhookSignature.ts
+++ b/src/middleware/webhookSignature.ts
@@ -16,6 +16,10 @@ export interface WebhookSignatureOptions {
    * If omitted: string body is used as-is, otherwise JSON.stringify(req.body).
    */
   getBody?: (req: Request) => string
+  /**
+   * Replay window tolerance in milliseconds (default: 300000).
+   */
+  tolerance?: number
 }
 
 function unauthorized(res: Response): void {
@@ -48,7 +52,9 @@ export function verifyWebhookSignature(options: WebhookSignatureOptions) {
       const rawSignature = extractHeader(req, signatureHeader)
       const body = getBody(req)
 
-      const result = verifySignature(rawSignature, body, secret)
+      const result = verifySignature(rawSignature, body, secret, undefined, {
+        tolerance: options.tolerance,
+      })
 
       if (!result.ok) {
         unauthorized(res)


### PR DESCRIPTION
##close #590 

## Summary

Adds timestamp-based replay protection for incoming webhooks.

HMAC verification now validates that webhook payloads contain a valid timestamp and rejects requests whose timestamps fall outside a configurable tolerance window (default: 5 minutes).

## Changes

* Added replay-window validation to `verifySignature`
* Added support for configurable tolerance values
* Added middleware support for forwarding tolerance configuration
* Added unit tests covering:

  * missing timestamp
  * invalid timestamp
  * expired timestamp
  * future timestamp
  * custom tolerance windows
* Added integration tests verifying `401 Unauthorized` responses for invalid replay scenarios

## Verification

* Vitest tests pass
* Added deterministic tests using mocked system time
* Existing signature verification behavior remains intact for valid payloads


