### PR TITLE
feat(health): expose git sha, build timestamp, and node version in health endpoints

### DIFF
--- a/MONITORING_QUICKSTART.md
+++ b/MONITORING_QUICKSTART.md
@@ -225,6 +225,11 @@ The `/api/health/ready` endpoint is dependency-aware and used as the Kubernetes 
 {
   "status": "ok",
   "service": "credence-backend",
+  "version": {
+    "gitSha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "buildTimestamp": "2026-06-25T20:00:00.000Z",
+    "nodeVersion": "v20.10.0"
+  },
   "dependencies": {
     "postgres":        { "status": "up", "latencyMs": 4 },
     "redis":           { "status": "up", "latencyMs": 1 },

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,7 +57,12 @@ GET /api/health
 ```json
 {
   "status": "ok",
-  "service": "credence-backend"
+  "service": "credence-backend",
+  "version": {
+    "gitSha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "buildTimestamp": "2026-06-25T20:00:00.000Z",
+    "nodeVersion": "v20.10.0"
+  }
 }
 ```
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3582,9 +3582,23 @@ paths:
                     type: string
                   service:
                     type: string
+                  version:
+                    type: object
+                    properties:
+                      gitSha:
+                        type: string
+                      buildTimestamp:
+                        type: string
+                      nodeVersion:
+                        type: string
+                    required:
+                      - gitSha
+                      - buildTimestamp
+                      - nodeVersion
                 required:
                   - status
                   - service
+                  - version
         "503":
           description: Unhealthy
           content:
@@ -3596,9 +3610,23 @@ paths:
                     type: string
                   service:
                     type: string
+                  version:
+                    type: object
+                    properties:
+                      gitSha:
+                        type: string
+                      buildTimestamp:
+                        type: string
+                      nodeVersion:
+                        type: string
+                    required:
+                      - gitSha
+                      - buildTimestamp
+                      - nodeVersion
                 required:
                   - status
                   - service
+                  - version
   /.well-known/jwks.json:
     get:
       summary: JWKS
@@ -4290,242 +4318,3 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DisputeTransitionError"
-  /.well-known/jwks.json:
-    get:
-      tags:
-        - Auth
-      summary: JWKS endpoint
-      description: Returns the JSON Web Key Set used to verify JWT tokens.
-      responses:
-        "200":
-          description: JWKS payload
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/health:
-    get:
-      tags:
-        - System
-      summary: Health check
-      description: Returns service health status.
-      responses:
-        "200":
-          description: Service is healthy
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/trust/{address}:
-    get:
-      tags:
-        - Trust
-      summary: Get trust record
-      description: Returns the trust record for a wallet address.
-      parameters:
-        - name: address
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Trust record found
-          content:
-            application/json:
-              schema:
-                type: object
-        "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/trust:
-    post:
-      tags:
-        - Trust
-      summary: Create trust record
-      description: Creates a trust record for a wallet address.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "201":
-          description: Trust record created
-          content:
-            application/json:
-              schema:
-                type: object
-        "400":
-          description: Validation error
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/attestations/{address}:
-    get:
-      tags:
-        - Attestations
-      summary: Get attestations for address
-      description: Returns attestations for a given subject address.
-      parameters:
-        - name: address
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Attestation list
-          content:
-            application/json:
-              schema:
-                type: object
-        "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/attestations:
-    post:
-      tags:
-        - Attestations
-      summary: Create attestation
-      description: Creates a new attestation record.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "201":
-          description: Attestation created
-          content:
-            application/json:
-              schema:
-                type: object
-        "400":
-          description: Validation error
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/bulk:
-    post:
-      tags:
-        - Bulk
-      summary: Bulk operation
-      description: Performs a bulk data operation.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "200":
-          description: Bulk operation result
-          content:
-            application/json:
-              schema:
-                type: object
-        "400":
-          description: Validation error
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/imports:
-    post:
-      tags:
-        - Imports
-      summary: Import data
-      description: Imports external data records.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "200":
-          description: Import result
-          content:
-            application/json:
-              schema:
-                type: object
-        "400":
-          description: Validation error
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/orgs/{orgId}/policies:
-    get:
-      tags:
-        - Organizations
-      summary: Get org policies
-      description: Returns policies for the given organization.
-      parameters:
-        - name: orgId
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Policy list
-          content:
-            application/json:
-              schema:
-                type: object
-        "404":
-          description: Not found
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/analytics:
-    get:
-      tags:
-        - Analytics
-      summary: Get analytics
-      description: Returns aggregated analytics data.
-      responses:
-        "200":
-          description: Analytics data
-          content:
-            application/json:
-              schema:
-                type: object
-  /api/payouts:
-    post:
-      tags:
-        - Payouts
-      summary: Initiate payout
-      description: Initiates a payout for a bond settlement.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        "200":
-          description: Payout initiated
-          content:
-            application/json:
-              schema:
-                type: object
-        "400":
-          description: Validation error
-          content:
-            application/json:
-              schema:
-                type: object

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -39,11 +39,11 @@ registry.registerPath({
   responses: {
     200: {
       description: 'Healthy',
-      content: { 'application/json': { schema: z.object({ status: z.string(), service: z.string() }) } },
+      content: { 'application/json': { schema: z.object({ status: z.string(), service: z.string(), version: z.object({ gitSha: z.string(), buildTimestamp: z.string(), nodeVersion: z.string() }) }) } },
     },
     503: {
       description: 'Unhealthy',
-      content: { 'application/json': { schema: z.object({ status: z.string(), service: z.string() }) } },
+      content: { 'application/json': { schema: z.object({ status: z.string(), service: z.string(), version: z.object({ gitSha: z.string(), buildTimestamp: z.string(), nodeVersion: z.string() }) }) } },
     },
   },
 });

--- a/src/__tests__/envelopeContract.test.ts
+++ b/src/__tests__/envelopeContract.test.ts
@@ -75,14 +75,16 @@ describe('Response envelope contract — /api/health', () => {
     return app
   }
 
-  it('liveness: { status: string, service: string }', async () => {
+  it('liveness: { status: string, service: string, version: object }', async () => {
     const { status, body } = await req(makeApp(), 'GET', '/api/health/live')
     expect(status).toBe(200)
     expect(typeof body.status).toBe('string')
     expect(typeof body.service).toBe('string')
+    expect(body.version).toBeDefined()
+    expect(typeof body.version).toBe('object')
   })
 
-  it('readiness success: { status: string, dependencies: object }', async () => {
+  it('readiness success: { status: string, version: object, dependencies: object }', async () => {
     const app = makeApp({
       postgres: async () => ({ status: 'up' }),
       redis: async () => ({ status: 'up' }),
@@ -92,6 +94,8 @@ describe('Response envelope contract — /api/health', () => {
     const { status, body } = await req(app, 'GET', '/api/health')
     expect(status).toBe(200)
     expect(typeof body.status).toBe('string')
+    expect(body.version).toBeDefined()
+    expect(typeof body.version).toBe('object')
     expect(body.dependencies).toBeDefined()
     expect(typeof body.dependencies).toBe('object')
   })

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -29,6 +29,10 @@ describe('Health routes', () => {
       expect(res.body.dependencies.horizonListener.status).toBe('up')
       expect(res.body.dependencies.outboxPublisher.status).toBe('up')
       expect(res.body.dependencies.horizon.status).toBe('up')
+      expect(res.body.version).toBeDefined()
+      expect(typeof res.body.version.gitSha).toBe('string')
+      expect(typeof res.body.version.buildTimestamp).toBe('string')
+      expect(typeof res.body.version.nodeVersion).toBe('string')
     })
 
     it('response includes latencyMs per dependency', async () => {
@@ -146,6 +150,10 @@ describe('Health routes', () => {
       expect(res.status).toBe(200)
       expect(res.body.status).toBe('ok')
       expect(res.body.service).toBe('credence-backend')
+      expect(res.body.version).toBeDefined()
+      expect(typeof res.body.version.gitSha).toBe('string')
+      expect(typeof res.body.version.buildTimestamp).toBe('string')
+      expect(typeof res.body.version.nodeVersion).toBe('string')
     })
 
     it('does not include dependencies in /live response', async () => {

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express'
 import { runHealthChecks } from '../services/health/index.js'
 import type { HealthProbe } from '../services/health/index.js'
+import { getVersionMetadata } from '../utils/version.js'
 
 export interface HealthRouterOptions {
   /** DB probe; when omitted, db is reported as not_configured. */
@@ -80,6 +81,7 @@ export function createHealthRouter(options: HealthRouterOptions = {}): Router {
     res.status(200).json({
       status: 'ok',
       service: 'credence-backend',
+      version: getVersionMetadata(),
     })
   })
 

--- a/src/services/health/checks.ts
+++ b/src/services/health/checks.ts
@@ -1,4 +1,5 @@
 import type { DependencyHealth, HealthProbe } from './types.js'
+import { getVersionMetadata } from '../../utils/version.js'
 
 const SERVICE_NAME = 'credence-backend'
 
@@ -20,6 +21,7 @@ export async function runHealthChecks(probes: {
 }): Promise<{
   status: 'ok' | 'degraded' | 'unhealthy'
   service: string
+  version: ReturnType<typeof getVersionMetadata>
   dependencies: {
     postgres: DependencyHealth
     redis: DependencyHealth
@@ -56,5 +58,5 @@ export async function runHealthChecks(probes: {
     status = 'ok'
   }
 
-  return { status, service: SERVICE_NAME, dependencies: deps }
+  return { status, service: SERVICE_NAME, version: getVersionMetadata(), dependencies: deps }
 }

--- a/src/services/health/types.ts
+++ b/src/services/health/types.ts
@@ -1,3 +1,5 @@
+import type { VersionMetadata } from '../../utils/version.js'
+
 /**
  * Health check result for a single dependency.
  * Status is intentionally minimal to avoid exposing internal details.
@@ -17,6 +19,7 @@ export interface DependencyHealth {
 export interface HealthResult {
   status: 'ok' | 'degraded' | 'unhealthy'
   service: string
+  version: VersionMetadata
   dependencies: {
     postgres: DependencyHealth
     redis: DependencyHealth

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,51 @@
+import { execSync } from 'node:child_process'
+import { statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+export interface VersionMetadata {
+  gitSha: string
+  buildTimestamp: string
+  nodeVersion: string
+}
+
+let cachedVersion: VersionMetadata | null = null
+
+export function getVersionMetadata(): VersionMetadata {
+  if (cachedVersion) {
+    return cachedVersion
+  }
+
+  // 1. Resolve Git SHA
+  let gitSha = process.env.GIT_SHA || process.env.COMMIT_SHA
+  if (!gitSha && process.env.NODE_ENV !== 'production') {
+    try {
+      gitSha = execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim()
+    } catch {
+      gitSha = 'unknown'
+    }
+  }
+  gitSha = gitSha || 'unknown'
+
+  // 2. Resolve Build Timestamp
+  let buildTimestamp = process.env.BUILD_TIMESTAMP
+  if (!buildTimestamp) {
+    try {
+      const __filename = fileURLToPath(import.meta.url)
+      const __dirname = dirname(__filename)
+      const pkgPath = join(__dirname, '../../package.json')
+      const stat = statSync(pkgPath)
+      buildTimestamp = stat.mtime.toISOString()
+    } catch {
+      buildTimestamp = new Date(Date.now() - process.uptime() * 1000).toISOString()
+    }
+  }
+
+  cachedVersion = {
+    gitSha,
+    buildTimestamp,
+    nodeVersion: process.version,
+  }
+
+  return cachedVersion
+}

--- a/tests/routes/health.test.ts
+++ b/tests/routes/health.test.ts
@@ -74,12 +74,13 @@ describe('Health route – dependency-aware checks with degradation reasons', ()
     expect(res.body.dependencies.redis.reason).toBeUndefined()
   })
 
-  it('schema is stable: always has status, service, dependencies keys', async () => {
+  it('schema is stable: always has status, service, version, dependencies keys', async () => {
     const app = appWithHealth({})
     const res = await request(app).get('/api/health')
     expect(res.status).toBe(200)
     expect(res.body).toHaveProperty('status')
     expect(res.body).toHaveProperty('service', 'credence-backend')
+    expect(res.body).toHaveProperty('version')
     expect(res.body).toHaveProperty('dependencies')
     expect(res.body.dependencies).toHaveProperty('postgres')
     expect(res.body.dependencies).toHaveProperty('redis')


### PR DESCRIPTION
##close #585 

## Description

This PR exposes build and runtime metadata on the health endpoints to improve support and operational troubleshooting.

The following information is now returned by the health endpoints:

* `gitSha`
* `buildTimestamp`
* `nodeVersion`

The implementation uses a shared version metadata helper and falls back safely when Git metadata or build-time environment variables are unavailable, keeping the feature production-safe and backward-compatible.

### Changes

* Added a shared version metadata helper (`src/utils/version.ts`).
* Included version metadata in:

  * `/api/health`
  * `/api/health/ready`
  * `/api/health/live`
* Updated the health response types.
* Updated the OpenAPI generation script and regenerated the OpenAPI specification.
* Added and updated unit, integration, and contract tests.
* Updated the API and monitoring documentation.

### Verification

* Targeted TypeScript compilation completed successfully.
* Health endpoint tests pass successfully.
* OpenAPI specification regenerated.
* No new required environment variables were introduced.
* Existing health endpoint response fields remain backward-compatible.

