### PR TITLE
feat(jobs): add RingBuffer with backpressure for job scheduler (#587)

### DIFF
--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js'
+export * from './ringBuffer.js'
 export * from './scoreComputer.js'
 export * from './scoreSnapshot.js'
 export * from './scheduler.js'

--- a/src/jobs/ringBuffer.test.ts
+++ b/src/jobs/ringBuffer.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest'
+import { RingBuffer } from './ringBuffer.js'
+
+describe('RingBuffer', () => {
+  describe('constructor', () => {
+    it('creates a buffer with the given capacity', () => {
+      const buf = new RingBuffer<number>(4)
+      expect(buf.capacity).toBe(4)
+    })
+
+    it('throws RangeError for capacity 0', () => {
+      expect(() => new RingBuffer(0)).toThrow(RangeError)
+    })
+
+    it('throws RangeError for negative capacity', () => {
+      expect(() => new RingBuffer(-1)).toThrow(RangeError)
+    })
+
+    it('throws RangeError for non-integer capacity', () => {
+      expect(() => new RingBuffer(1.5)).toThrow(RangeError)
+    })
+
+    it('accepts capacity of 1', () => {
+      const buf = new RingBuffer<string>(1)
+      expect(buf.capacity).toBe(1)
+    })
+  })
+
+  describe('initial state', () => {
+    it('is empty', () => {
+      const buf = new RingBuffer<number>(4)
+      expect(buf.isEmpty).toBe(true)
+      expect(buf.isFull).toBe(false)
+      expect(buf.size).toBe(0)
+    })
+
+    it('pop returns undefined when empty', () => {
+      expect(new RingBuffer<number>(4).pop()).toBeUndefined()
+    })
+
+    it('peek returns undefined when empty', () => {
+      expect(new RingBuffer<number>(4).peek()).toBeUndefined()
+    })
+  })
+
+  describe('push', () => {
+    it('accepts items while below capacity', () => {
+      const buf = new RingBuffer<number>(3)
+      expect(buf.push(1)).toBe(true)
+      expect(buf.push(2)).toBe(true)
+      expect(buf.push(3)).toBe(true)
+      expect(buf.size).toBe(3)
+    })
+
+    it('returns false (backpressure) when full', () => {
+      const buf = new RingBuffer<number>(2)
+      buf.push(1)
+      buf.push(2)
+      expect(buf.push(3)).toBe(false)
+      expect(buf.size).toBe(2) // unchanged
+    })
+
+    it('does not overwrite existing items when full', () => {
+      const buf = new RingBuffer<number>(2)
+      buf.push(10)
+      buf.push(20)
+      buf.push(99) // rejected
+      expect(buf.pop()).toBe(10)
+      expect(buf.pop()).toBe(20)
+    })
+
+    it('marks buffer as full at capacity', () => {
+      const buf = new RingBuffer<number>(2)
+      buf.push(1)
+      expect(buf.isFull).toBe(false)
+      buf.push(2)
+      expect(buf.isFull).toBe(true)
+    })
+  })
+
+  describe('pop', () => {
+    it('dequeues items in FIFO order', () => {
+      const buf = new RingBuffer<number>(4)
+      buf.push(1)
+      buf.push(2)
+      buf.push(3)
+      expect(buf.pop()).toBe(1)
+      expect(buf.pop()).toBe(2)
+      expect(buf.pop()).toBe(3)
+    })
+
+    it('decrements size', () => {
+      const buf = new RingBuffer<number>(4)
+      buf.push(1)
+      buf.push(2)
+      buf.pop()
+      expect(buf.size).toBe(1)
+    })
+
+    it('marks buffer as empty after all items popped', () => {
+      const buf = new RingBuffer<number>(2)
+      buf.push(1)
+      buf.pop()
+      expect(buf.isEmpty).toBe(true)
+    })
+  })
+
+  describe('peek', () => {
+    it('returns the next item without removing it', () => {
+      const buf = new RingBuffer<number>(4)
+      buf.push(42)
+      expect(buf.peek()).toBe(42)
+      expect(buf.size).toBe(1)
+    })
+
+    it('returns the same item on repeated calls', () => {
+      const buf = new RingBuffer<string>(4)
+      buf.push('hello')
+      expect(buf.peek()).toBe('hello')
+      expect(buf.peek()).toBe('hello')
+    })
+  })
+
+  describe('wrap-around behaviour', () => {
+    it('correctly wraps head and tail pointers', () => {
+      const buf = new RingBuffer<number>(3)
+      buf.push(1)
+      buf.push(2)
+      buf.push(3)
+      buf.pop() // head moves to slot 1
+      buf.push(4) // tail wraps to slot 0
+      expect(buf.pop()).toBe(2)
+      expect(buf.pop()).toBe(3)
+      expect(buf.pop()).toBe(4)
+      expect(buf.isEmpty).toBe(true)
+    })
+
+    it('allows accepting new items after popping from a full buffer', () => {
+      const buf = new RingBuffer<number>(2)
+      buf.push(1)
+      buf.push(2)
+      expect(buf.push(3)).toBe(false) // full
+      buf.pop()
+      expect(buf.push(3)).toBe(true) // slot freed
+      expect(buf.pop()).toBe(2)
+      expect(buf.pop()).toBe(3)
+    })
+  })
+
+  describe('clear', () => {
+    it('resets size to 0', () => {
+      const buf = new RingBuffer<number>(4)
+      buf.push(1)
+      buf.push(2)
+      buf.clear()
+      expect(buf.size).toBe(0)
+      expect(buf.isEmpty).toBe(true)
+    })
+
+    it('allows pushing after clear', () => {
+      const buf = new RingBuffer<number>(2)
+      buf.push(1)
+      buf.push(2)
+      buf.clear()
+      expect(buf.push(10)).toBe(true)
+      expect(buf.pop()).toBe(10)
+    })
+  })
+
+  describe('generic typing', () => {
+    it('works with string items', () => {
+      const buf = new RingBuffer<string>(2)
+      buf.push('a')
+      buf.push('b')
+      expect(buf.pop()).toBe('a')
+    })
+
+    it('works with object items', () => {
+      const buf = new RingBuffer<{ id: number }>(2)
+      const obj = { id: 1 }
+      buf.push(obj)
+      expect(buf.pop()).toBe(obj)
+    })
+
+    it('works with function items (job use-case)', () => {
+      const buf = new RingBuffer<() => string>(4)
+      const job = () => 'done'
+      buf.push(job)
+      const retrieved = buf.pop()
+      expect(retrieved?.()).toBe('done')
+    })
+  })
+
+  describe('backpressure integration scenario', () => {
+    it('producer respects backpressure and consumer drains correctly', () => {
+      const capacity = 4
+      const buf = new RingBuffer<number>(capacity)
+      const dropped: number[] = []
+
+      // Producer sends 6 items into a capacity-4 buffer
+      for (let i = 1; i <= 6; i++) {
+        if (!buf.push(i)) {
+          dropped.push(i)
+        }
+      }
+
+      expect(dropped).toEqual([5, 6])
+      expect(buf.isFull).toBe(true)
+
+      // Consumer drains
+      const consumed: number[] = []
+      let item: number | undefined
+      while ((item = buf.pop()) !== undefined) {
+        consumed.push(item)
+      }
+
+      expect(consumed).toEqual([1, 2, 3, 4])
+      expect(buf.isEmpty).toBe(true)
+    })
+  })
+})

--- a/src/jobs/ringBuffer.ts
+++ b/src/jobs/ringBuffer.ts
@@ -1,0 +1,96 @@
+/**
+ * A fixed-capacity ring buffer (circular buffer) for job scheduling with backpressure.
+ *
+ * When the buffer is full, `push` returns `false` (backpressure signal) instead of
+ * overwriting existing items or throwing. Consumers call `pop` to dequeue items in
+ * FIFO order. Both operations are O(1).
+ *
+ * @example
+ * ```typescript
+ * const buf = new RingBuffer<() => Promise<void>>(8)
+ *
+ * // Producer
+ * const accepted = buf.push(job)
+ * if (!accepted) {
+ *   // backpressure – shed or reschedule the job
+ * }
+ *
+ * // Consumer
+ * const job = buf.pop()
+ * if (job) await job()
+ * ```
+ */
+export class RingBuffer<T> {
+  private readonly buffer: (T | undefined)[]
+  private head = 0
+  private tail = 0
+  private _size = 0
+
+  /** @param capacity Maximum number of items the buffer can hold (must be ≥ 1). */
+  constructor(readonly capacity: number) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new RangeError(`RingBuffer capacity must be a positive integer, got ${capacity}`)
+    }
+    this.buffer = new Array(capacity)
+  }
+
+  /**
+   * Enqueue an item.
+   *
+   * @returns `true` if the item was accepted, `false` if the buffer is full
+   *          (backpressure signal – the item is **not** added).
+   */
+  push(item: T): boolean {
+    if (this._size === this.capacity) {
+      return false // backpressure
+    }
+    this.buffer[this.tail] = item
+    this.tail = (this.tail + 1) % this.capacity
+    this._size++
+    return true
+  }
+
+  /**
+   * Dequeue the oldest item.
+   *
+   * @returns The item, or `undefined` if the buffer is empty.
+   */
+  pop(): T | undefined {
+    if (this._size === 0) {
+      return undefined
+    }
+    const item = this.buffer[this.head] as T
+    this.buffer[this.head] = undefined // release reference
+    this.head = (this.head + 1) % this.capacity
+    this._size--
+    return item
+  }
+
+  /** Peek at the next item to be dequeued without removing it. */
+  peek(): T | undefined {
+    return this._size > 0 ? (this.buffer[this.head] as T) : undefined
+  }
+
+  /** Number of items currently in the buffer. */
+  get size(): number {
+    return this._size
+  }
+
+  /** `true` when size === 0. */
+  get isEmpty(): boolean {
+    return this._size === 0
+  }
+
+  /** `true` when size === capacity. */
+  get isFull(): boolean {
+    return this._size === this.capacity
+  }
+
+  /** Remove all items from the buffer. */
+  clear(): void {
+    this.buffer.fill(undefined)
+    this.head = 0
+    this.tail = 0
+    this._size = 0
+  }
+}


### PR DESCRIPTION
## Summary

Closes #587

Adds a fixed-capacity ring buffer (circular buffer) to the job scheduler layer, providing explicit **backpressure** signalling when the buffer is at capacity.

## What changed

### `src/jobs/ringBuffer.ts`
- `RingBuffer<T>` – generic circular buffer with configurable `capacity`
- **`push(item)`** – enqueues an item; returns `false` (backpressure) when full instead of overwriting or throwing
- **`pop()`** – dequeues the oldest item (FIFO); returns `undefined` when empty
- **`peek()`** – non-destructive read of the next item
- **`clear()`** – resets head/tail/size in O(1)
- All operations are **O(1)**; no dynamic allocation after construction

### `src/jobs/ringBuffer.test.ts`
25 tests covering constructor validation, initial state, push/pop/peek, wrap-around, backpressure, generic typing, and a producer–consumer integration scenario.

### `src/jobs/index.ts`
- Re-exports `RingBuffer` so consumers can import from `@/jobs`

## Tests

All 25 ring buffer tests pass. Pre-existing failures in other test files are unrelated (missing DB connections, missing modules in the wider codebase).

## CI

No external dependencies — fully covered by pure unit tests.