### PR TITLE
feat: Add migrate:dry-run command to preview migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ curl http://localhost:3000/api/health
 
 ### Services
 
-| Service    | Port  | Description              |
-|------------|-------|--------------------------|
-| `backend`  | 3000  | Express / TypeScript API |
-| `postgres` | 5432  | PostgreSQL 16            |
-| `redis`    | 6379  | Redis 7                  |
+| Service    | Port | Description              |
+| ---------- | ---- | ------------------------ |
+| `backend`  | 3000 | Express / TypeScript API |
+| `postgres` | 5432 | PostgreSQL 16            |
+| `redis`    | 6379 | Redis 7                  |
 
 All ports are configurable via `.env` (see `.env.example`).
 
@@ -120,7 +120,7 @@ docker compose exec postgres psql -U credence
 All configuration is driven by environment variables. Copy `.env.example` to `.env` and adjust as needed. Key variables:
 
 | Variable            | Default    | Description               |
-|---------------------|------------|---------------------------|
+| ------------------- | ---------- | ------------------------- |
 | `PORT`              | `3000`     | Backend listen port       |
 | `POSTGRES_USER`     | `credence` | PostgreSQL user           |
 | `POSTGRES_PASSWORD` | `credence` | PostgreSQL password       |
@@ -134,32 +134,33 @@ All configuration is driven by environment variables. Copy `.env.example` to `.e
 
 ## Scripts
 
-| Command                   | Description                              |
-|---------------------------|------------------------------------------|
-| `npm run dev`             | Start with tsx watch                     |
-| `npm run build`           | Compile TypeScript                       |
-| `npm start`               | Run compiled `dist/`                     |
-| `npm run lint`            | Run ESLint                               |
-| `npm test`                | Run test suite (vitest)                  |
-| `npm run test:watch`      | Run tests in watch mode                  |
-| `npm run test:coverage`   | Run tests with coverage                  |
-| `npm run migrate:create`  | Create new migration in `src/migrations/`|
-| `npm run migrate:dev`     | Build and run pending migrations (local) |
-| `npm run migrate`         | Run pending migrations (CI/production)   |
-| `npm run migrate:down`    | Rollback last migration                  |
+| Command                   | Description                                |
+| ------------------------- | ------------------------------------------ |
+| `npm run dev`             | Start with tsx watch                       |
+| `npm run build`           | Compile TypeScript                         |
+| `npm start`               | Run compiled `dist/`                       |
+| `npm run lint`            | Run ESLint                                 |
+| `npm test`                | Run test suite (vitest)                    |
+| `npm run test:watch`      | Run tests in watch mode                    |
+| `npm run test:coverage`   | Run tests with coverage                    |
+| `npm run migrate:create`  | Create new migration in `src/migrations/`  |
+| `npm run migrate:dev`     | Build and run pending migrations (local)   |
+| `npm run migrate`         | Run pending migrations (CI/production)     |
+| `npm run migrate:down`    | Rollback last migration                    |
+| `npm run migrate:dry-run` | Preview pending migrations without running |
 
 ## API (current)
 
-| Method | Path                          | Description                        |
-|--------|-------------------------------|------------------------------------|
-| GET    | `/api/health`                 | Health check                       |
-| GET    | `/api/health/cache`           | Redis cache health check           |
-| GET    | `/api/trust/:address`         | Trust score from reputation engine |
-| GET    | `/api/bond/:address`          | Bond status                        |
-| GET    | `/api/attestations/:address`  | List attestations for address      |
-| POST   | `/api/attestations`           | Create attestation                 |
-| GET    | `/api/verification/:address`  | Verification proof (stub)          |
-| GET    | `/api/analytics/summary`      | Aggregated analytics from materialized view |
+| Method | Path                         | Description                                 |
+| ------ | ---------------------------- | ------------------------------------------- |
+| GET    | `/api/health`                | Health check                                |
+| GET    | `/api/health/cache`          | Redis cache health check                    |
+| GET    | `/api/trust/:address`        | Trust score from reputation engine          |
+| GET    | `/api/bond/:address`         | Bond status                                 |
+| GET    | `/api/attestations/:address` | List attestations for address               |
+| POST   | `/api/attestations`          | Create attestation                          |
+| GET    | `/api/verification/:address` | Verification proof (stub)                   |
+| GET    | `/api/analytics/summary`     | Aggregated analytics from materialized view |
 
 Invalid input returns **400** with `{ "error": "Validation failed", "details": [{ "path", "message" }] }`. See [docs/VALIDATION.md](docs/VALIDATION.md).
 
@@ -186,7 +187,7 @@ Import via **File → Import** in Postman or Insomnia. See [docs/api.md](docs/ap
 
 The health API reports status per dependency (database, Redis, optional external) without exposing internal details.
 
-- **Readiness** (`GET /api/health` or `GET /api/health/ready`): Returns `200` when all *configured* critical dependencies (DB, Redis) are up; returns `503` if any critical dependency is down. When `DATABASE_URL` or `REDIS_URL` are not set, those dependencies are reported as `not_configured` and do not cause `503`.
+- **Readiness** (`GET /api/health` or `GET /api/health/ready`): Returns `200` when all _configured_ critical dependencies (DB, Redis) are up; returns `503` if any critical dependency is down. When `DATABASE_URL` or `REDIS_URL` are not set, those dependencies are reported as `not_configured` and do not cause `503`.
 - **Liveness** (`GET /api/health/live`): Returns `200` when the process is running (no dependency checks). Use for Kubernetes/orchestrator liveness probes.
 
 Response shape (readiness):
@@ -232,7 +233,6 @@ State shape is `IdentityState`: `address`, `bondedAmount`, `bondStart`, `bondDur
 
 Tests cover: no drift (no update), single drift (one address corrected), full resync (multiple drifts), chain missing, store-only addresses, and error handling.
 
-
 ## Monitoring
 
 Comprehensive monitoring with Prometheus and Grafana is available. See **[docs/monitoring.md](docs/monitoring.md)** for:
@@ -259,6 +259,7 @@ docker-compose up -d
 ```
 
 The Grafana dashboard includes:
+
 - HTTP metrics (request rate, latency, error rate, status codes)
 - Infrastructure health (DB, Redis status and check duration)
 - Business metrics (reputation calculations, identity verifications, bulk operations)
@@ -283,6 +284,7 @@ The service includes a Horizon withdrawal events listener that:
 - **Handles errors gracefully** with automatic retry and recovery
 
 See [docs/horizon-listener.md](./docs/horizon-listener.md) for detailed documentation.
+
 ## Caching
 
 The service includes a Redis-based caching layer with:
@@ -311,45 +313,45 @@ The config module (`src/config/index.ts`) centralizes all environment handling:
 ### Usage
 
 ```ts
-import { loadConfig } from './config/index.js'
+import { loadConfig } from "./config/index.js";
 
-const config = loadConfig()
-console.log(config.port)          // number
-console.log(config.db.url)        // string
-console.log(config.features)      // { trustScoring: boolean, bondEvents: boolean }
+const config = loadConfig();
+console.log(config.port); // number
+console.log(config.db.url); // string
+console.log(config.features); // { trustScoring: boolean, bondEvents: boolean }
 ```
 
 For testing, use `validateConfig()` which throws a `ConfigValidationError` instead of calling `process.exit`:
 
 ```ts
-import { validateConfig, ConfigValidationError } from './config/index.js'
+import { validateConfig, ConfigValidationError } from "./config/index.js";
 
 try {
-  const config = validateConfig({ DB_URL: 'bad' })
+  const config = validateConfig({ DB_URL: "bad" });
 } catch (err) {
   if (err instanceof ConfigValidationError) {
-    console.error(err.issues) // Zod issues array
+    console.error(err.issues); // Zod issues array
   }
 }
 ```
 
 ## Environment Variables
 
-| Variable               | Required   | Default        | Description                              |
-|------------------------|------------|----------------|------------------------------------------|
-| `PORT`                 | No         | `3000`         | Server port (1–65535)                    |
-| `NODE_ENV`             | No         | `development`  | `development`, `production`, or `test`   |
-| `LOG_LEVEL`            | No         | `info`         | `debug`, `info`, `warn`, or `error`      |
-| `DB_URL`               | **Yes**    | —              | PostgreSQL connection URL                |
-| `REDIS_URL`            | **Yes**    | —              | Redis connection URL                     |
-| `JWT_SECRET`           | **Yes**    | —              | JWT signing secret (≥ 32 chars)          |
-| `JWT_EXPIRY`           | No         | `1h`           | JWT token lifetime                       |
-| `ENABLE_TRUST_SCORING` | No         | `false`        | Enable trust scoring feature             |
-| `ENABLE_BOND_EVENTS`   | No         | `false`        | Enable bond event processing             |
-| `HORIZON_URL`          | No         | —              | Stellar Horizon API URL                  |
-| `CORS_ORIGIN`          | No         | `*`            | Allowed CORS origin                      |
-| `ANALYTICS_REFRESH_CRON` | No       | `*/5 * * * *`  | Refresh cadence for analytics materialized view |
-| `ANALYTICS_STALENESS_SECONDS` | No | `300`          | Max acceptable analytics staleness before marked stale |
+| Variable                      | Required | Default       | Description                                            |
+| ----------------------------- | -------- | ------------- | ------------------------------------------------------ |
+| `PORT`                        | No       | `3000`        | Server port (1–65535)                                  |
+| `NODE_ENV`                    | No       | `development` | `development`, `production`, or `test`                 |
+| `LOG_LEVEL`                   | No       | `info`        | `debug`, `info`, `warn`, or `error`                    |
+| `DB_URL`                      | **Yes**  | —             | PostgreSQL connection URL                              |
+| `REDIS_URL`                   | **Yes**  | —             | Redis connection URL                                   |
+| `JWT_SECRET`                  | **Yes**  | —             | JWT signing secret (≥ 32 chars)                        |
+| `JWT_EXPIRY`                  | No       | `1h`          | JWT token lifetime                                     |
+| `ENABLE_TRUST_SCORING`        | No       | `false`       | Enable trust scoring feature                           |
+| `ENABLE_BOND_EVENTS`          | No       | `false`       | Enable bond event processing                           |
+| `HORIZON_URL`                 | No       | —             | Stellar Horizon API URL                                |
+| `CORS_ORIGIN`                 | No       | `*`           | Allowed CORS origin                                    |
+| `ANALYTICS_REFRESH_CRON`      | No       | `*/5 * * * *` | Refresh cadence for analytics materialized view        |
+| `ANALYTICS_STALENESS_SECONDS` | No       | `300`         | Max acceptable analytics staleness before marked stale |
 
 ## Analytics materialized views
 
@@ -381,12 +383,14 @@ The project uses [node-pg-migrate](https://salsita.github.io/node-pg-migrate/) f
 ### Quick Start
 
 **Development (recommended):**
+
 ```bash
 # Build TypeScript and run all pending migrations
 npm run migrate:dev
 ```
 
 **Production/CI:**
+
 ```bash
 # Requires dist/ to be built first
 npm run build
@@ -406,6 +410,7 @@ This creates a timestamped `.ts` file in `src/migrations/`.
 ### Migration Workflow
 
 **Development:**
+
 ```bash
 # Build and run all pending migrations
 npm run migrate:dev
@@ -415,6 +420,7 @@ npm run migrate:dev -- --dry-run
 ```
 
 **Production/CI (requires build first):**
+
 ```bash
 npm run build
 npm run migrate
@@ -422,6 +428,7 @@ npm run migrate:down
 ```
 
 **Rollback:**
+
 ```bash
 # Development (builds first)
 npm run migrate:dev -- migrate:down
@@ -433,29 +440,29 @@ npm run migrate:down
 ### Migration File Structure
 
 ```typescript
-import { MigrationBuilder } from 'node-pg-migrate'
+import { MigrationBuilder } from "node-pg-migrate";
 
 export async function up(pgm: MigrationBuilder): Promise<void> {
   // Apply changes (create tables, add columns, etc.)
-  pgm.createTable('users', {
-    id: 'id',
-    email: { type: 'varchar(255)', notNull: true },
-  })
+  pgm.createTable("users", {
+    id: "id",
+    email: { type: "varchar(255)", notNull: true },
+  });
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
   // Reverse changes
-  pgm.dropTable('users')
+  pgm.dropTable("users");
 }
 ```
 
 ### Environment Variables
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | Required |
-| `MIGRATIONS_TABLE` | Table name for tracking migrations | `pgmigrations` |
-| `MIGRATIONS_SCHEMA` | Schema for migrations table | `public` |
+| Variable            | Description                        | Default        |
+| ------------------- | ---------------------------------- | -------------- |
+| `DATABASE_URL`      | PostgreSQL connection string       | Required       |
+| `MIGRATIONS_TABLE`  | Table name for tracking migrations | `pgmigrations` |
+| `MIGRATIONS_SCHEMA` | Schema for migrations table        | `public`       |
 
 ### CI/CD Integration
 
@@ -472,6 +479,7 @@ npm start
 ### Initial Schema
 
 The first migration (`src/migrations/001_initial_schema.ts`) creates:
+
 - `identities` - Identity and bond state
 - `attestations` - Attestation records
 - `reputation_scores` - Cached reputation scores
@@ -486,7 +494,6 @@ After running `npm run build`, migrations are executed from `dist/migrations/`.
 4. **Don't modify existing migrations** after they've been applied
 5. **Create new migrations** for schema changes
 6. **Back up production database** before running migrations
-
 
 ## Tech
 

--- a/docs/MIGRATION_SAFETY.md
+++ b/docs/MIGRATION_SAFETY.md
@@ -14,47 +14,75 @@ The migration system includes built-in guardrails to prevent potentially dangero
 ## Enhanced Guardrails
 
 For comprehensive migration guardrails including batching strategies, lock timeout management, and rollback procedures, see:
+
 - **[Migration Guardrails Guide](./MIGRATION_GUARDRAILS.md)** - Complete guide for long-running schema changes
 - **[Batching Utilities](../src/migrations/utils/batching.ts)** - Safe batch operations
 - **[Lock Timeout Management](../src/migrations/utils/lock-timeout.ts)** - Lock safety and timeout configuration
 - **[Rollback Checklist](../src/migrations/utils/rollback-checklist.ts)** - Comprehensive rollback procedures
+
+## Previewing Migrations with Dry-Run
+
+Before executing migrations, you can preview the SQL changes using the dry-run command:
+
+```bash
+npm run migrate:dry-run
+```
+
+This command shows:
+
+- The SQL statements that would be executed
+- Which migrations would be applied
+- The order of execution
+
+The dry-run command is useful for:
+
+- **Code review**: Share the SQL changes with the team before deployment
+- **Impact analysis**: Understand what changes will be made to the database
+- **Planning**: Verify migrations work as expected without risking production data
+- **Documentation**: Keep a record of what schema changes are being deployed
+
+**Note**: The dry-run command still requires a valid DATABASE_URL but does not modify any data.
 
 ## Safe Migration Patterns
 
 ### 1. Adding Columns
 
 **❌ Unsafe:**
+
 ```sql
 ALTER TABLE users ADD COLUMN email VARCHAR(255) NOT NULL;
 ```
 
 **✅ Safe:**
+
 ```typescript
 // Step 1: Add nullable column
-pgm.addColumn('users', 'email', { 
-  type: 'varchar(255)', 
+pgm.addColumn("users", "email", {
+  type: "varchar(255)",
   null: true,
-  comment: 'Added for email feature - will be NOT NULL after backfill'
-})
+  comment: "Added for email feature - will be NOT NULL after backfill",
+});
 
 // Step 2: Backfill data in application code or separate migration
 // Step 3: Add NOT NULL constraint in follow-up migration
-pgm.alterColumn('users', 'email', { notNull: true })
+pgm.alterColumn("users", "email", { notNull: true });
 ```
 
 ### 2. Creating Indexes
 
 **❌ Unsafe (blocks writes):**
+
 ```typescript
-pgm.createIndex('large_table', 'column_name')
+pgm.createIndex("large_table", "column_name");
 ```
 
 **✅ Safe (online):**
+
 ```typescript
-pgm.createIndex('large_table', 'column_name', { 
-  method: 'CONCURRENTLY',
-  name: 'idx_large_table_column'
-})
+pgm.createIndex("large_table", "column_name", {
+  method: "CONCURRENTLY",
+  name: "idx_large_table_column",
+});
 ```
 
 ### 3. Column Replacement
@@ -64,14 +92,14 @@ When replacing a column, use a multi-step approach:
 ```typescript
 // Migration 1: Add new column
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  pgm.addColumn('users', 'new_status', { 
-    type: 'varchar(50)', 
+  pgm.addColumn("users", "new_status", {
+    type: "varchar(50)",
     null: true,
-    comment: 'Replacing old_status field'
-  })
-  
+    comment: "Replacing old_status field",
+  });
+
   // Create index on new column
-  pgm.createIndex('users', 'new_status', { method: 'CONCURRENTLY' })
+  pgm.createIndex("users", "new_status", { method: "CONCURRENTLY" });
 }
 
 // Migration 2: Backfill data
@@ -81,32 +109,34 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
     UPDATE users 
     SET new_status = old_status 
     WHERE new_status IS NULL
-  `)
+  `);
 }
 
 // Migration 3: Switch references and drop old column
 export async function up(pgm: MigrationBuilder): Promise<void> {
   // Add NOT NULL constraint to new column
-  pgm.alterColumn('users', 'new_status', { notNull: true })
-  
+  pgm.alterColumn("users", "new_status", { notNull: true });
+
   // Update application code to use new column
-  
+
   // Drop old column (after verifying app works with new column)
-  pgm.dropColumn('users', 'old_status')
-  
+  pgm.dropColumn("users", "old_status");
+
   // Rename new column if needed
-  pgm.renameColumn('users', 'new_status', 'status')
+  pgm.renameColumn("users", "new_status", "status");
 }
 ```
 
 ### 4. Large Data Updates
 
 **❌ Unsafe (locks table):**
+
 ```typescript
-pgm.sql('UPDATE large_table SET status = "active" WHERE condition = true')
+pgm.sql('UPDATE large_table SET status = "active" WHERE condition = true');
 ```
 
 **✅ Safe (batched):**
+
 ```typescript
 // Use application-level batching or pg-batch
 // Or create a separate backfill script that runs in batches
@@ -118,7 +148,7 @@ pgm.sql(`
     WHERE condition = true 
     LIMIT 1000
   )
-`)
+`);
 ```
 
 ## Migration Guardrails
@@ -140,21 +170,25 @@ The system automatically checks for:
 ## Using the Migration Linter
 
 ### Check all migrations:
+
 ```bash
 npm run migrate:lint
 ```
 
 ### Check specific migration:
+
 ```bash
 npm run migrate:lint -- --file migrations/001_add_email.ts
 ```
 
 ### Strict mode (warnings as errors):
+
 ```bash
 npm run migrate:lint -- --strict
 ```
 
 ### Pre-flight check:
+
 ```bash
 npm run migrate:preflight -- --file migrations/001_add_email.ts
 ```
@@ -162,20 +196,25 @@ npm run migrate:preflight -- --file migrations/001_add_email.ts
 ## Deployment Best Practices
 
 ### 1. Staging Environment
+
 Always test migrations in a staging environment with production-like data size.
 
 ### 2. Migration Timing
+
 - Run potentially long-running migrations during low-traffic periods
 - Use `CONCURRENTLY` for index creation on large tables
 - Monitor database performance during migrations
 
 ### 3. Rollback Strategy
+
 Every migration must have a working `down()` function that:
+
 - Completely reverses the `up()` changes
 - Handles edge cases (like partially completed operations)
 - Has been tested in staging
 
 ### 4. Monitoring
+
 - Monitor database locks during migration execution
 - Watch replication lag in database clusters
 - Set up alerts for long-running migrations
@@ -201,18 +240,22 @@ Before deploying:
 ## Common Pitfalls
 
 ### 1. Adding NOT NULL columns without defaults
+
 **Problem**: Blocks writes to the table
 **Solution**: Add as NULL, backfill, then add constraint
 
 ### 2. Creating unique indexes on large tables
+
 **Problem**: Blocks writes and can take hours
 **Solution**: Use CONCURRENTLY or create non-unique index first
 
 ### 3. Large UPDATE/DELETE operations
+
 **Problem**: Locks rows and causes replication lag
 **Solution**: Use batching or application-level backfill
 
 ### 4. Missing rollback functions
+
 **Problem**: Cannot easily undo changes
 **Solution**: Always implement and test `down()` functions
 
@@ -237,6 +280,9 @@ npm run migrate:lint
 
 # Run pre-flight checks
 npm run migrate:preflight -- --file migrations/001_add_email.ts
+
+# Preview migrations (dry-run) without executing
+npm run migrate:dry-run
 
 # Run migration with safety checks
 npm run migrate:up

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "migrate": "node-pg-migrate -m dist/migrations up",
     "migrate:down": "node-pg-migrate -m dist/migrations down",
     "migrate:dev": "npm run build && npm run migrate",
+    "migrate:dry-run": "npm run build && tsx scripts/migrate-dry-run.ts",
     "migrate:lint": "tsx src/migrations/linter.ts check",
     "migrate:preflight": "tsx src/migrations/linter.ts pre-flight",
     "migrate:template": "tsx src/migrations/linter.ts template",

--- a/scripts/migrate-dry-run.ts
+++ b/scripts/migrate-dry-run.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * Dry-run migration CLI
+ *
+ * Prints the SQL that would be executed by the next migration without actually running it.
+ * Useful for reviewing changes before deployment.
+ */
+
+import { dryRunMigration } from "../src/migrations/runner.js";
+import { exit } from "process";
+
+async function main() {
+  try {
+    const result = await dryRunMigration({
+      skipPreflight: true,
+      verbose: true,
+    });
+
+    if (!result.success) {
+      console.error(`\n❌ Dry-run failed: ${result.error}`);
+      exit(1);
+    }
+
+    if (result.applied.length === 0) {
+      console.log("\n✅ No pending migrations");
+      exit(0);
+    }
+
+    console.log(
+      `\n✅ Dry-run completed. ${result.applied.length} migration(s) would be applied.`,
+    );
+    console.log("Migrations to be applied:");
+    result.applied.forEach((migration, index) => {
+      console.log(`  ${index + 1}. ${migration}`);
+    });
+    exit(0);
+  } catch (error) {
+    console.error(`❌ Error during dry-run: ${error}`);
+    exit(1);
+  }
+}
+
+main();

--- a/src/migrations/runner.ts
+++ b/src/migrations/runner.ts
@@ -1,110 +1,124 @@
 /**
  * Migration Runner
- * 
+ *
  * Programmatic interface for running database migrations.
  * Wraps node-pg-migrate to provide a TypeScript-friendly API.
  */
 
-import { runner, Migration } from 'node-pg-migrate'
-import { loadMigrationConfig, validateConfig, MigrationConfig } from './config.js'
-import { analyzeMigration, PreflightResult } from './guardrails.js'
+import { runner, Migration } from "node-pg-migrate";
+import {
+  loadMigrationConfig,
+  validateConfig,
+  MigrationConfig,
+} from "./config.js";
+import { analyzeMigration, PreflightResult } from "./guardrails.js";
 
-type RunnerOptions = Parameters<typeof runner>[0] & { ignorePattern?: string }
+type RunnerOptions = Parameters<typeof runner>[0] & { ignorePattern?: string };
 
 export interface MigrationOptions {
   /** Direction of migration: 'up' or 'down' */
-  direction: 'up' | 'down'
+  direction: "up" | "down";
   /** Number of migrations to run (default: all for up, 1 for down) */
-  count?: number
+  count?: number;
   /** Specific migration to run (optional) */
-  file?: string
+  file?: string;
   /** Whether to print verbose output */
-  verbose?: boolean
+  verbose?: boolean;
   /** Custom configuration (uses loadMigrationConfig() if not provided) */
-  config?: MigrationConfig
+  config?: MigrationConfig;
   /** Skip preflight safety checks (not recommended) */
-  skipPreflight?: boolean
+  skipPreflight?: boolean;
   /** Allow blocking operations (use with caution) */
-  allowBlocking?: boolean
+  allowBlocking?: boolean;
 }
 
 export interface MigrationResult {
   /** Whether the migration was successful */
-  success: boolean
+  success: boolean;
   /** List of migrations that were applied */
-  applied: string[]
+  applied: string[];
   /** Error message if failed */
-  error?: string
+  error?: string;
   /** Preflight check results */
-  preflight?: PreflightResult
+  preflight?: PreflightResult;
 }
 
 /**
  * Run database migrations programmatically
- * 
+ *
  * @param options Migration options
  * @returns MigrationResult with status and applied migrations
- * 
+ *
  * @example
  * ```typescript
  * // Run all pending migrations
  * const result = await runMigration({ direction: 'up' })
- * 
+ *
  * // Rollback last migration
  * const result = await runMigration({ direction: 'down' })
- * 
+ *
  * // Rollback 3 migrations
  * const result = await runMigration({ direction: 'down', count: 3 })
  * ```
  */
-export async function runMigration(options: MigrationOptions): Promise<MigrationResult> {
-  const config = options.config ?? loadMigrationConfig()
-  validateConfig(config)
+export async function runMigration(
+  options: MigrationOptions,
+): Promise<MigrationResult> {
+  const config = options.config ?? loadMigrationConfig();
+  validateConfig(config);
 
-  const applied: string[] = []
-  let preflightResult: PreflightResult | undefined
+  const applied: string[] = [];
+  let preflightResult: PreflightResult | undefined;
 
   // Run preflight checks unless explicitly skipped
   if (!options.skipPreflight) {
     if (options.file) {
-      preflightResult = analyzeMigration(options.file)
+      preflightResult = analyzeMigration(options.file);
     } else {
       // For directory-based migrations, we'd need to scan which migrations will run
       // For now, we'll skip directory preflight checks as it requires complex logic
       if (options.verbose !== false) {
-        console.log('⚠️  Skipping preflight checks for directory-based migrations')
+        console.log(
+          "⚠️  Skipping preflight checks for directory-based migrations",
+        );
       }
     }
 
     // Check preflight results
     if (preflightResult && !preflightResult.passed) {
-      const blockingIssues = preflightResult.issues.filter(issue => issue.type === 'blocking')
-      
+      const blockingIssues = preflightResult.issues.filter(
+        (issue) => issue.type === "blocking",
+      );
+
       if (blockingIssues.length > 0 && !options.allowBlocking) {
         return {
           success: false,
           applied,
-          error: `Blocking operations detected. Use allowBlocking: true to override. Issues: ${blockingIssues.map(i => i.message).join(', ')}`,
-          preflight: preflightResult
-        }
+          error: `Blocking operations detected. Use allowBlocking: true to override. Issues: ${blockingIssues.map((i) => i.message).join(", ")}`,
+          preflight: preflightResult,
+        };
       }
 
       if (preflightResult.issues.length > 0) {
         return {
           success: false,
           applied,
-          error: `Safety issues detected: ${preflightResult.issues.map(i => i.message).join(', ')}`,
-          preflight: preflightResult
-        }
+          error: `Safety issues detected: ${preflightResult.issues.map((i) => i.message).join(", ")}`,
+          preflight: preflightResult,
+        };
       }
     }
 
     // Log warnings if any
-    if (preflightResult && preflightResult.warnings.length > 0 && options.verbose !== false) {
-      console.log('⚠️  Migration warnings:')
-      preflightResult.warnings.forEach(warning => {
-        console.log(`  • ${warning.message}`)
-      })
+    if (
+      preflightResult &&
+      preflightResult.warnings.length > 0 &&
+      options.verbose !== false
+    ) {
+      console.log("⚠️  Migration warnings:");
+      preflightResult.warnings.forEach((warning) => {
+        console.log(`  • ${warning.message}`);
+      });
     }
   }
 
@@ -120,57 +134,137 @@ export async function runMigration(options: MigrationOptions): Promise<Migration
       file: options.file,
       verbose: options.verbose ?? true,
       // Only numbered migration files (e.g. 001_initial_schema.ts); skip tooling/templates.
-      ignorePattern: '^(?!\\d+_).*',
+      ignorePattern: "^(?!\\d+_).*",
       // Log applied migrations
       log: (message: string) => {
         if (options.verbose !== false) {
-          console.log(message)
+          console.log(message);
         }
       },
       // Track applied migrations
       logger: {
         info: (msg: string) => {
           if (options.verbose !== false) {
-            console.info(msg)
+            console.info(msg);
           }
           // Extract migration name from log messages
-          const match = msg.match(/migrating\s+'(.+)'/i)
+          const match = msg.match(/migrating\s+'(.+)'/i);
           if (match) {
-            applied.push(match[1])
+            applied.push(match[1]);
           }
         },
         warn: (msg: string) => console.warn(msg),
         error: (msg: string) => console.error(msg),
       },
-    } as RunnerOptions)
+    } as RunnerOptions);
 
     return {
       success: true,
       applied,
-      preflight: preflightResult
-    }
+      preflight: preflightResult,
+    };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
       applied,
       error: errorMessage,
-      preflight: preflightResult
-    }
+      preflight: preflightResult,
+    };
+  }
+}
+
+/**
+ * Preview database migrations without executing them
+ *
+ * Prints the SQL that would be executed by the next migration without actually running it.
+ * Useful for reviewing changes before deployment.
+ *
+ * @param options Migration options (same as runMigration but direction defaults to 'up')
+ * @returns MigrationResult with status and list of migrations that would be applied
+ *
+ * @example
+ * ```typescript
+ * // Preview all pending migrations
+ * const result = await dryRunMigration({ skipPreflight: true })
+ *
+ * // Preview specific number of migrations
+ * const result = await dryRunMigration({ count: 2 })
+ * ```
+ */
+export async function dryRunMigration(
+  options: Omit<MigrationOptions, "direction"> = {},
+): Promise<MigrationResult> {
+  const config = options.config ?? loadMigrationConfig();
+  validateConfig(config);
+
+  const applied: string[] = [];
+  const sqlStatements: string[] = [];
+
+  try {
+    await runner({
+      databaseUrl: config.databaseUrl,
+      dir: config.migrationsDir,
+      migrationsTable: config.migrationsTable,
+      schema: config.migrationsSchema,
+      createSchema: config.createSchema,
+      direction: "up",
+      count: options.count,
+      file: options.file,
+      dryRun: true,
+      verbose: options.verbose ?? true,
+      // Only numbered migration files (e.g. 001_initial_schema.ts); skip tooling/templates.
+      ignorePattern: "^(?!\\d+_).*",
+      // Collect SQL statements
+      log: (message: string) => {
+        if (options.verbose !== false) {
+          console.log(message);
+        }
+        // Collect SQL output
+        sqlStatements.push(message);
+      },
+      // Track migrations that would be applied
+      logger: {
+        info: (msg: string) => {
+          if (options.verbose !== false) {
+            console.info(msg);
+          }
+          // Extract migration name from log messages
+          const match = msg.match(/migrating\s+'(.+)'/i);
+          if (match) {
+            applied.push(match[1]);
+          }
+        },
+        warn: (msg: string) => console.warn(msg),
+        error: (msg: string) => console.error(msg),
+      },
+    } as RunnerOptions);
+
+    return {
+      success: true,
+      applied,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      applied,
+      error: errorMessage,
+    };
   }
 }
 
 /**
  * Get the status of all migrations
- * 
+ *
  * @returns List of migrations with their status
  */
 export async function getMigrationStatus(): Promise<{
-  applied: string[]
-  pending: string[]
+  applied: string[];
+  pending: string[];
 }> {
-  const config = loadMigrationConfig()
-  validateConfig(config)
+  const config = loadMigrationConfig();
+  validateConfig(config);
 
   try {
     // Run with dryRun to get status without applying
@@ -179,50 +273,53 @@ export async function getMigrationStatus(): Promise<{
       dir: config.migrationsDir,
       migrationsTable: config.migrationsTable,
       schema: config.migrationsSchema,
-      direction: 'up',
+      direction: "up",
       dryRun: true,
       verbose: false,
-      ignorePattern: '^(?!\\d+_).*',
+      ignorePattern: "^(?!\\d+_).*",
       log: () => {}, // Suppress logs
-    } as RunnerOptions)
+    } as RunnerOptions);
 
     // This is a simplified status check
     // In production, you might want to query the migrations table directly
     return {
       applied: [],
       pending: [],
-    }
+    };
   } catch (error) {
-    console.error('Failed to get migration status:', error)
+    console.error("Failed to get migration status:", error);
     return {
       applied: [],
       pending: [],
-    }
+    };
   }
 }
 
 /**
  * Create a new migration file from the template
- * 
+ *
  * @param name Name of the migration (will be prefixed with timestamp)
  * @returns Path to the created migration file
  */
 export async function createMigration(name: string): Promise<string> {
-  const config = loadMigrationConfig()
-  
+  const config = loadMigrationConfig();
+
   // Sanitize name: replace spaces with underscores, remove special chars
   const sanitizedName = name
     .toLowerCase()
-    .replace(/\s+/g, '_')
-    .replace(/[^a-z0-9_]/g, '')
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
 
   if (!sanitizedName) {
-    throw new Error('Migration name cannot be empty')
+    throw new Error("Migration name cannot be empty");
   }
 
-  const timestamp = new Date().toISOString().replace(/[-:T.Z]/g, '').slice(0, 14)
-  const filename = `${timestamp}_${sanitizedName}.ts`
-  const filepath = `${config.migrationsDir}/${filename}`
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[-:T.Z]/g, "")
+    .slice(0, 14);
+  const filename = `${timestamp}_${sanitizedName}.ts`;
+  const filepath = `${config.migrationsDir}/${filename}`;
 
   // Template content
   const template = `import { MigrationBuilder } from 'node-pg-migrate'
@@ -250,11 +347,11 @@ export async function down(pgm: MigrationBuilder): Promise<void> {
   // Example:
   // pgm.dropTable('users')
 }
-`
+`;
 
-  const fs = await import('fs/promises')
-  await fs.writeFile(filepath, template, 'utf-8')
-  
-  console.log(`Created migration: ${filepath}`)
-  return filepath
+  const fs = await import("fs/promises");
+  await fs.writeFile(filepath, template, "utf-8");
+
+  console.log(`Created migration: ${filepath}`);
+  return filepath;
 }


### PR DESCRIPTION
- Add dryRunMigration() function to src/migrations/runner.ts
- Create scripts/migrate-dry-run.ts CLI tool
- Add 'migrate:dry-run' npm script to package.json
- Update MIGRATION_SAFETY.md with dry-run documentation
- Update README.md scripts table with new command

The dry-run command prints the SQL that would be executed by the next migration without actually executing it. This improves the day-to-day experience for operators and enables better planning before applying schema changes.

Closes #580 