### PR TITLE
Closes #565: Add request-id propagation to downstream calls

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,7 +2,7 @@
 
 To facilitate debugging in our distributed environment, every request is assigned a `Request ID` and a `Correlation ID`.
 
-- **X-Request-ID**: Unique to every single HTTP call to this service.
+- **X-Request-ID**: Unique identifier for the HTTP call. If provided in the incoming request headers, we preserve it. We also propagate it to downstream RPC calls (using Connect-RPC interceptors) and emit it automatically in every log line during the request lifecycle.
 - **X-Correlation-ID**: Persists across services. If an upstream service sends one, we propagate it.
 
 ## Log Format

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@types/express": "^4.17.21",
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
-        "@types/node": "^20.19.33",
+        "@types/node": "^20.19.37",
         "@types/pg": "^8.16.0",
         "@types/redis": "^4.0.10",
         "@types/supertest": "^6.0.3",
@@ -2444,59 +2444,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
@@ -2885,7 +2832,7 @@
       "version": "20.19.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2895,7 +2842,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4264,7 +4211,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -11036,7 +10982,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/src/__tests__/requestId.test.ts
+++ b/src/__tests__/requestId.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { requestIdMiddleware } from '../middleware/requestId.js'
+import { createRequestIdInterceptor } from '../sdk/grpc/interceptors.js'
+import { tracingContext } from '../utils/logger.js'
+import { Request, Response } from 'express'
+
+describe('Request ID propagation', () => {
+  it('should generate a new request ID if x-request-id is not provided in headers', () => {
+    const req = {
+      header: vi.fn().mockReturnValue(null),
+      originalUrl: '/test',
+    } as unknown as Request
+
+    const res = {
+      setHeader: vi.fn(),
+    } as unknown as Response
+
+    const next = vi.fn().mockImplementation(() => {
+      const store = tracingContext.getStore()
+      expect(store).toBeDefined()
+      expect(store?.get('requestId')).toBeDefined()
+      expect(typeof store?.get('requestId')).toBe('string')
+      expect(store?.get('correlationId')).toBeDefined()
+    })
+
+    requestIdMiddleware(req, res, next)
+    expect(next).toHaveBeenCalled()
+    expect(res.setHeader).toHaveBeenCalledWith('x-request-id', expect.any(String))
+  })
+
+  it('should reuse x-request-id from headers if provided', () => {
+    const customRequestId = 'test-request-id-12345'
+    const req = {
+      header: vi.fn((name: string) => {
+        if (name === 'x-request-id') return customRequestId
+        return null
+      }),
+      originalUrl: '/test',
+    } as unknown as Request
+
+    const res = {
+      setHeader: vi.fn(),
+    } as unknown as Response
+
+    const next = vi.fn().mockImplementation(() => {
+      const store = tracingContext.getStore()
+      expect(store?.get('requestId')).toBe(customRequestId)
+    })
+
+    requestIdMiddleware(req, res, next)
+    expect(next).toHaveBeenCalled()
+    expect(res.setHeader).toHaveBeenCalledWith('x-request-id', customRequestId)
+  })
+
+  it('should propagate x-request-id to gRPC calls via interceptor using context store', () => {
+    const customRequestId = 'grpc-test-request-id'
+    const context = new Map<string, string>()
+    context.set('requestId', customRequestId)
+
+    tracingContext.run(context, () => {
+      const interceptor = createRequestIdInterceptor()
+      const next = vi.fn((req) => req)
+      const req = {
+        header: {
+          set: vi.fn(),
+        },
+      } as any
+
+      interceptor(next)(req)
+      expect(req.header.set).toHaveBeenCalledWith('x-request-id', customRequestId)
+    })
+  })
+
+  it('should propagate explicit request ID parameter in gRPC interceptor', () => {
+    const customRequestId = 'explicit-grpc-id'
+    const interceptor = createRequestIdInterceptor(customRequestId)
+    const next = vi.fn((req) => req)
+    const req = {
+      header: {
+        set: vi.fn(),
+      },
+    } as any
+
+    interceptor(next)(req)
+    expect(req.header.set).toHaveBeenCalledWith('x-request-id', customRequestId)
+  })
+})

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -14,7 +14,7 @@ export const requestIdMiddleware = (
   const correlationId = req.header('x-correlation-id') || randomUUID()
 
   // 2. Handle Request ID
-  const requestId = randomUUID()
+  const requestId = (req.header('x-request-id') as string) || randomUUID()
 
   // 3. Attach IDs to the request object
   req['correlationId'] = correlationId

--- a/src/sdk/grpc/client.ts
+++ b/src/sdk/grpc/client.ts
@@ -25,7 +25,7 @@
 import { createGrpcTransport } from '@connectrpc/connect-node'
 import { createClient } from '@connectrpc/connect'
 
-import { createSharedSecretInterceptor } from './interceptors.js'
+import { createSharedSecretInterceptor, createRequestIdInterceptor } from './interceptors.js'
 
 // Generated service descriptors — populated by `buf generate`.
 // If these imports fail, run `buf generate` first.
@@ -104,6 +104,7 @@ export function createCredenceGrpcClient(config: CredenceGrpcConfig): CredenceGr
     httpVersion: '2',
     interceptors: [
       createSharedSecretInterceptor(sharedSecret),
+      createRequestIdInterceptor(),
     ],
     // Apply a default deadline to every call.  Individual callers can
     // override this by passing a signal or deadline to the RPC method.

--- a/src/sdk/grpc/interceptors.ts
+++ b/src/sdk/grpc/interceptors.ts
@@ -20,6 +20,7 @@
 // The type import below uses a conditional so that this file compiles even
 // before code generation has been executed.
 import type { Interceptor } from '@connectrpc/connect'
+import { tracingContext } from '../../utils/logger.js'
 
 /**
  * INTERNAL_TOKEN_HEADER is the metadata key used to authenticate internal
@@ -55,11 +56,13 @@ export function createSharedSecretInterceptor(secret: string): Interceptor {
  * calls, enabling end-to-end distributed tracing.
  *
  * Pass the requestId string obtained from the Express requestIdMiddleware.
+ * If not provided, it falls back to the tracingContext store.
  */
-export function createRequestIdInterceptor(requestId: string): Interceptor {
+export function createRequestIdInterceptor(requestId?: string): Interceptor {
   return (next) => (req) => {
-    if (requestId) {
-      req.header.set('x-request-id', requestId)
+    const id = requestId || tracingContext.getStore()?.get('requestId')
+    if (id) {
+      req.header.set('x-request-id', id)
     }
     return next(req)
   }


### PR DESCRIPTION
Description
This Pull Request addresses issue #565 by adding x-request-id propagation to downstream RPC calls and ensuring incoming x-request-id headers are preserved for distributed request tracing.

 

Changes Made
1. Express Middleware
Updated 

requestId.ts
 to extract and preserve the incoming x-request-id header if it exists. A new UUID is only generated if the header is absent.
2. Connect-RPC / gRPC Clients
Updated createRequestIdInterceptor in 

interceptors.ts
 to make the requestId parameter optional. If not provided, it falls back to the current request ID stored in the AsyncLocalStorage tracingContext.
Registered createRequestIdInterceptor() in the interceptor list inside 

client.ts
 so all downstream internal client calls automatically carry the request ID.
3. Verification & Testing
Added unit tests in 

requestId.test.ts
 validating:
Generation of a new request ID when the header is missing.
Retention of the incoming x-request-id header when provided.
Automatic propagation of request ID from tracing context to gRPC metadata.
Dynamic vs explicit parameter overriding in the gRPC interceptor.
Verified linting (npm run lint) and type checks build successfully.
4. Documentation
Updated the tracing section in 

observability.md
 to explain the new propagation and retention behavior.
 
 
 
 closes #565 