### PR TITLE
feat(rate-limit): add per-tenant rate limit hit metrics and docs

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -804,6 +804,7 @@ open http://localhost:3001
 | `identity_verifications_total` | Counter | status | Total identity verifications |
 | `bulk_verifications_total` | Counter | status | Total bulk verification requests |
 | `bulk_verification_batch_size` | Histogram | - | Batch size distribution |
+| `rate_limit_hits_total` | Counter | tenant, tier | Total rate limit hits grouped by tenant and tier |
 | `identity_sync_duration_seconds` | Histogram | operation | Identity sync duration |
 
 ### Default Metrics (from prom-client)

--- a/docs/security.md
+++ b/docs/security.md
@@ -146,6 +146,13 @@ The catch-block fallback in `src/app.ts` also derives `failOpen` from `NODE_ENV`
 | `key_id` | API key id, or `none` |
 | `reason` | `tenant_limit`, `key_limit`, `redis_unavailable` |
 
+`rate_limit_hits_total` (counter) is emitted for each request that exceeds either the tenant or per-key quota. Labels:
+
+| Label | Values |
+|-------|--------|
+| `tenant` | Resolved tenant identifier, or `unknown` for unauthenticated requests |
+| `tier` | `free`, `pro`, `enterprise` |
+
 ### Environment variables
 
 | Variable | Default | Description |

--- a/src/middleware/__tests__/rateLimit.test.ts
+++ b/src/middleware/__tests__/rateLimit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import express, { Request, Response, NextFunction } from 'express'
+import request from 'supertest'
+import { createRateLimitMiddleware } from '../rateLimit.js'
+import { register } from '../metrics.js'
+
+function createApp(getRedis: any, config: any) {
+  const app = express()
+  app.use(createRateLimitMiddleware(config, { getRedis }))
+  app.get('/ok', (_req, res) => res.status(200).json({ ok: true }))
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(err.status ?? 500).json({ error: err.message, code: err.code })
+  })
+  return app
+}
+
+beforeEach(() => {
+  register.resetMetrics()
+})
+
+describe('rate limit middleware', () => {
+  it('increments tenant-level hit metrics when tenant quota is exceeded', async () => {
+    const config = {
+      enabled: true,
+      windowSec: 60,
+      maxFree: 1,
+      maxPro: 100,
+      maxEnterprise: 1000,
+      failOpen: false,
+    }
+
+    const requests: Record<string, number> = {}
+    const getRedis = () => ({
+      incr: async (key: string) => {
+        requests[key] = (requests[key] ?? 0) + 1
+        return requests[key]
+      },
+      expire: async () => 60,
+      ttl: async () => 60,
+    })
+
+    const app = createApp(getRedis, config)
+
+    // First request should pass
+    await request(app)
+      .get('/ok')
+      .set('X-API-Key', 'ak-123')
+      .set('Authorization', 'Bearer token-1')
+
+    const secondResponse = await request(app)
+      .get('/ok')
+      .set('X-API-Key', 'ak-123')
+      .set('Authorization', 'Bearer token-1')
+
+    expect(secondResponse.status).toBe(429)
+    expect(secondResponse.body.code).toBe('rate_limit_exceeded')
+
+    const metrics = await register.metrics()
+    expect(metrics).toContain('rate_limit_hits_total')
+    expect(metrics).toContain('tenant="ak:')
+    expect(metrics).toContain('tier="free"')
+  })
+
+  it('uses unknown tenant label when tenant cannot be resolved', async () => {
+    const config = {
+      enabled: true,
+      windowSec: 60,
+      maxFree: 1,
+      maxPro: 100,
+      maxEnterprise: 1000,
+      failOpen: false,
+    }
+
+    const state: Record<string, number> = {}
+    const getRedis = () => ({
+      incr: async (key: string) => {
+        state[key] = (state[key] ?? 0) + 1
+        return state[key]
+      },
+      expire: async () => 60,
+      ttl: async () => 60,
+    })
+
+    const app = express()
+    app.use(createRateLimitMiddleware(config, { getRedis }))
+    app.get('/ok', (_req, res) => res.status(200).json({ ok: true }))
+    app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+      res.status(err.status ?? 500).json({ error: err.message, code: err.code })
+    })
+
+    const firstResponse = await request(app).get('/ok')
+    expect(firstResponse.status).toBe(200)
+
+    const secondResponse = await request(app).get('/ok')
+
+    expect(secondResponse.status).toBe(429)
+    const metrics = await register.metrics()
+    expect(metrics).toContain('rate_limit_hits_total')
+    expect(metrics).toContain('tenant="unknown"')
+    expect(metrics).toContain('tier="free"')
+  })
+})

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -16,6 +16,13 @@ export const rateLimitRejectedTotal = new client.Counter({
   registers: [register],
 })
 
+export const rateLimitHitsTotal = new client.Counter({
+  name: 'rate_limit_hits_total',
+  help: 'Total number of rate limit hits grouped by tenant and subscription tier',
+  labelNames: ['tenant', 'tier'],
+  registers: [register],
+})
+
 // ── Public types ──────────────────────────────────────────────────────────────
 
 export interface RateLimitConfig {
@@ -173,6 +180,7 @@ export function createRateLimitMiddleware(
 
       if (tenantCount > tierMax) {
         rateLimitRejectedTotal.inc({ tier, key_id: keyId ?? 'none', reason: 'tenant_limit' })
+        rateLimitHitsTotal.inc({ tenant: tenantId ?? 'unknown', tier })
         setRateLimitHeaders(res, { limit: tierMax, remaining: 0, reset: now + tenantTtl, retryAfter: tenantTtl })
         next(new AppError('Rate limit exceeded. Try again later.', ErrorCode.RATE_LIMIT_EXCEEDED, 429, { retryAfter: tenantTtl, limit: tierMax, windowSec }))
         return
@@ -184,6 +192,7 @@ export function createRateLimitMiddleware(
 
         if (keyCount > keyMax) {
           rateLimitRejectedTotal.inc({ tier, key_id: keyId!, reason: 'key_limit' })
+          rateLimitHitsTotal.inc({ tenant: tenantId ?? 'unknown', tier })
           setRateLimitHeaders(res, { limit: keyMax, remaining: 0, reset: now + keyTtl, retryAfter: keyTtl })
           next(new AppError('Rate limit exceeded. Try again later.', ErrorCode.RATE_LIMIT_EXCEEDED, 429, { retryAfter: keyTtl, limit: keyMax, windowSec }))
           return


### PR DESCRIPTION
## Add per-tenant rate limit hit metrics

- Adds `rate_limit_hits_total` Prometheus counter.
- Emits tenant/tier labels for every rate limit rejection.
- Includes `tenant="unknown"` fallback when the request has no resolved tenant.
- Updates monitoring.md and security.md with the new metric and label semantics.

Closes: #551