### PR TITLE
fix: update husky pre-commit hook for v10 compatibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,8 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
 
 # Run Gitleaks protect on staged changes
 # The hook will prevent commit if a secret is detected.
 # Skip if gitleaks is not installed
-if command -v gitleaks &> /dev/null; then
+if command -v gitleaks >/dev/null 2>&1; then
   gitleaks protect --staged
 fi

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,13 +46,17 @@ Accepted in any case (EIP-55 checksummed or all lower-case).
 
 ### `GET /api/health`
 
-Returns service liveness.
+Returns readiness status for the service and its critical dependencies.
 
 ```
 GET /api/health
 ```
 
-**Response `200`**
+**Response `200`** when all configured critical dependencies are healthy.
+
+**Response `503`** when any critical dependency is down.
+
+**Response `200`** example:
 
 ```json
 {
@@ -62,6 +66,34 @@ GET /api/health
     "gitSha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
     "buildTimestamp": "2026-06-25T20:00:00.000Z",
     "nodeVersion": "v20.10.0"
+  },
+  "dependencies": {
+    "postgres": { "status": "up", "latencyMs": 3 },
+    "redis": { "status": "up", "latencyMs": 2 },
+    "horizonListener": { "status": "up", "latencyMs": 4 },
+    "outboxPublisher": { "status": "up", "latencyMs": 5, "lagSeconds": 0 },
+    "horizon": { "status": "up", "latencyMs": 3 }
+  }
+}
+```
+
+**Response `503`** example when outbox lag exceeds threshold:
+
+```json
+{
+  "status": "unhealthy",
+  "service": "credence-backend",
+  "version": {
+    "gitSha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "buildTimestamp": "2026-06-25T20:00:00.000Z",
+    "nodeVersion": "v20.10.0"
+  },
+  "dependencies": {
+    "postgres": { "status": "up", "latencyMs": 3 },
+    "redis": { "status": "up", "latencyMs": 2 },
+    "horizonListener": { "status": "up", "latencyMs": 4 },
+    "outboxPublisher": { "status": "down", "lagSeconds": 61 },
+    "horizon": { "status": "up", "latencyMs": 3 }
   }
 }
 ```

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -14,9 +14,11 @@ The monitoring stack consists of:
 The health router separates liveness and readiness:
 
 - `GET /api/health/live`: process-level liveness only (always `200` while process is up).
-- `GET /api/health` and `GET /api/health/ready`: deep readiness checks for Postgres, Redis, Horizon listener heartbeat, and outbox publisher lease heartbeat.
+- `GET /api/health` and `GET /api/health/ready`: deep readiness checks for Postgres, Redis, Horizon listener heartbeat, and outbox publisher state.
 
-Readiness responses include per-check status (`up`, `down`, `not_configured`) and safe diagnostic fields (for example heartbeat age) without exposing secrets such as connection strings.
+The outbox readiness check now also evaluates the age of the oldest unpublished outbox event. If that lag exceeds `60` seconds, readiness fails and the dependency is reported as `down` with a `lagSeconds` value.
+
+Readiness responses include per-check status (`up`, `down`, `not_configured`) and safe diagnostic fields (for example heartbeat age or outbox lag) without exposing secrets such as connection strings.
 
 ## Architecture
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,3 @@
+/** Maximum tolerated age of the oldest unpublished outbox event before readiness fails. */
+export const OUTBOX_MAX_LAG_SECONDS = 60
+export const OUTBOX_MAX_LAG_MS = OUTBOX_MAX_LAG_SECONDS * 1000

--- a/src/db/outbox/repository.ts
+++ b/src/db/outbox/repository.ts
@@ -385,6 +385,19 @@ export class OutboxRepository {
     }
   }
 
+  async getOldestPendingEventLagSeconds(db: Queryable): Promise<number> {
+    const result = await db.query<{ lag_seconds: string | null }>(
+      `SELECT EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::text AS lag_seconds
+       FROM event_outbox
+       WHERE status IN ('pending', 'processing')`
+    )
+
+    const lagSeconds = result.rows[0]?.lag_seconds
+    return lagSeconds !== null && lagSeconds !== undefined
+      ? Number(lagSeconds)
+      : 0
+  }
+
   /**
    * Mark an event as successfully published.
    */

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import request from 'supertest'
 import express from 'express'
 import { createHealthRouter } from './health.js'
+import { OUTBOX_MAX_LAG_SECONDS } from '../config/constants.js'
 
 function appWithHealth(probes: Parameters<typeof createHealthRouter>[0] = {}) {
   const app = express()
@@ -94,6 +95,18 @@ describe('Health routes', () => {
       expect(res.status).toBe(503)
       expect(res.body.status).toBe('unhealthy')
       expect(res.body.dependencies.outboxPublisher.reason).toBe('not_running')
+    })
+
+    it('returns 503 when outbox publisher lag exceeds threshold', async () => {
+      const app = appWithHealth({
+        ...allUp,
+        outboxPublisher: async () => ({ status: 'down', lagSeconds: OUTBOX_MAX_LAG_SECONDS + 1 }),
+      })
+      const res = await request(app).get('/api/health')
+      expect(res.status).toBe(503)
+      expect(res.body.status).toBe('unhealthy')
+      expect(res.body.dependencies.outboxPublisher.status).toBe('down')
+      expect(res.body.dependencies.outboxPublisher.lagSeconds).toBe(OUTBOX_MAX_LAG_SECONDS + 1)
     })
 
     it('returns 503 when horizon circuit breaker is OPEN', async () => {

--- a/src/services/health/outbox.ts
+++ b/src/services/health/outbox.ts
@@ -1,0 +1,26 @@
+import { OUTBOX_MAX_LAG_SECONDS } from '../../config/constants.js'
+import { OutboxRepository } from '../../db/outbox/repository.js'
+import type { Queryable } from '../../db/repositories/queryable.js'
+import { logger } from '../../utils/logger.js'
+
+export interface OutboxPublisherLag {
+  status: 'up' | 'down'
+  lagSeconds: number
+}
+
+export async function evaluateOutboxPublisherLag(
+  db: Queryable,
+  maxLagSeconds: number = OUTBOX_MAX_LAG_SECONDS,
+): Promise<OutboxPublisherLag> {
+  try {
+    const repository = new OutboxRepository()
+    const lagSeconds = await repository.getOldestPendingEventLagSeconds(db)
+    return {
+      status: lagSeconds > maxLagSeconds ? 'down' : 'up',
+      lagSeconds,
+    }
+  } catch (error) {
+    logger.error({ message: '[Health] Outbox lag check failed', error })
+    return { status: 'down', lagSeconds: 0 }
+  }
+}

--- a/src/services/health/probes.test.ts
+++ b/src/services/health/probes.test.ts
@@ -6,6 +6,8 @@ import {
   createHorizonListenerProbe,
   createOutboxPublisherProbe,
 } from './probes.js'
+import { OUTBOX_MAX_LAG_SECONDS } from '../../config/constants.js'
+import { OutboxRepository } from '../../db/outbox/repository.js'
 import {
   resetWorkerHealthState,
   setHorizonListenerConfigured,
@@ -19,6 +21,10 @@ import {
 beforeEach(() => {
   resetWorkerHealthState()
   vi.useRealTimers()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 // ─── DB probe ────────────────────────────────────────────────────────────────
@@ -214,10 +220,38 @@ describe('createOutboxPublisherProbe', () => {
     setOutboxPublisherConfigured(true)
     setOutboxPublisherRunning(true)
     recordOutboxPublisherHeartbeat()
+    vi.spyOn(OutboxRepository.prototype, 'getOldestPendingEventLagSeconds').mockResolvedValue(0)
+
     const probe = createOutboxPublisherProbe(60_000)
     const result = await probe()
     expect(result.status).toBe('up')
     expect(typeof result.latencyMs).toBe('number')
+  })
+
+  it('returns up when outbox lag is exactly at threshold', async () => {
+    setOutboxPublisherConfigured(true)
+    setOutboxPublisherRunning(true)
+    recordOutboxPublisherHeartbeat()
+    vi.spyOn(OutboxRepository.prototype, 'getOldestPendingEventLagSeconds').mockResolvedValue(OUTBOX_MAX_LAG_SECONDS)
+
+    const probe = createOutboxPublisherProbe(60_000)
+    const result = await probe()
+
+    expect(result.status).toBe('up')
+    expect(result.lagSeconds).toBe(OUTBOX_MAX_LAG_SECONDS)
+  })
+
+  it('returns down when outbox lag exceeds threshold', async () => {
+    setOutboxPublisherConfigured(true)
+    setOutboxPublisherRunning(true)
+    recordOutboxPublisherHeartbeat()
+    vi.spyOn(OutboxRepository.prototype, 'getOldestPendingEventLagSeconds').mockResolvedValue(OUTBOX_MAX_LAG_SECONDS + 1)
+
+    const probe = createOutboxPublisherProbe(60_000)
+    const result = await probe()
+
+    expect(result.status).toBe('down')
+    expect(result.lagSeconds).toBe(OUTBOX_MAX_LAG_SECONDS + 1)
   })
 })
 

--- a/src/services/health/probes.ts
+++ b/src/services/health/probes.ts
@@ -8,6 +8,8 @@ import {
   setHorizonListenerConfigured,
   setOutboxPublisherConfigured,
 } from "./runtimeState.js";
+import { evaluateOutboxPublisherLag } from "./outbox.js";
+import { OUTBOX_MAX_LAG_SECONDS } from "../../config/constants.js";
 
 /** Default timeout (ms) for each dependency check to avoid hanging. */
 const CHECK_TIMEOUT_MS = 5000;
@@ -178,18 +180,20 @@ export function createOutboxPublisherProbe(
       return { status: "not_configured" };
     }
     if (!state.running) {
-      return { status: "down", reason: "not_running", latencyMs: elapsed(start) };
+      return { status: "down", reason: "not_running", latencyMs: elapsed(start), lagSeconds: 0 };
     }
     if (state.lastHeartbeatAt === null) {
-      return { status: "down", reason: "no_heartbeat", latencyMs: elapsed(start) };
+      return { status: "down", reason: "no_heartbeat", latencyMs: elapsed(start), lagSeconds: 0 };
     }
 
     const ageMs = Date.now() - state.lastHeartbeatAt;
+    const lagResult = await evaluateOutboxPublisherLag(pool);
     if (ageMs > maxStaleMs) {
       return {
         status: "down",
         reason: "stale_heartbeat",
         latencyMs: elapsed(start),
+        lagSeconds: lagResult.lagSeconds,
         details: {
           heartbeatAgeMs: ageMs,
           maxHeartbeatAgeMs: maxStaleMs,
@@ -197,9 +201,21 @@ export function createOutboxPublisherProbe(
       };
     }
 
+    if (lagResult.status === "down") {
+      return {
+        status: "down",
+        latencyMs: elapsed(start),
+        lagSeconds: lagResult.lagSeconds,
+        details: {
+          maxLagSeconds: OUTBOX_MAX_LAG_SECONDS,
+        },
+      };
+    }
+
     return {
       status: "up",
       latencyMs: elapsed(start),
+      lagSeconds: lagResult.lagSeconds,
       details: {
         heartbeatAgeMs: ageMs,
         maxHeartbeatAgeMs: maxStaleMs,

--- a/src/services/health/types.ts
+++ b/src/services/health/types.ts
@@ -12,6 +12,8 @@ export interface DependencyHealth {
   reason?: string
   /** Wall-clock milliseconds the check took. Always present when a probe ran. */
   latencyMs?: number
+  /** Outbox-specific lag measured in seconds. */
+  lagSeconds?: number
   /** Optional safe metadata for debugging readiness (no secrets). */
   details?: Record<string, string | number | boolean | null>
 }


### PR DESCRIPTION
Closes #552

---

Closes #555

---

---

## Description

This pull request adds an **outbox publisher health probe** to the readiness health check endpoint so the service accurately reports its operational status.

Previously, the `/api/health` endpoint could report a healthy state even when the outbox publisher had stopped processing queued events, making it difficult for operators to detect stalled message delivery. This change introduces a health check that monitors the oldest unpublished outbox event and marks the service as unhealthy whenever the outbox lag exceeds the configured threshold (60 seconds).

The implementation also includes a regression test to ensure this behavior is preserved and updates the relevant documentation to describe the new readiness semantics.

**User-visible impact:** Operators and monitoring systems can now detect stalled outbox processing through the health endpoint instead of relying on delayed webhook deliveries or manual investigation.

**Previous mitigation:** Users had to monitor webhook queues or inspect database records to determine whether the outbox publisher was falling behind.

**Fixes / Closes:** #555

---

## Type of Change

* [x] **Bug Fix** (non-breaking change which fixes an issue)
* [ ] **New Feature** (non-breaking change which adds functionality)
* [ ] **Breaking Change** (fix or feature that would cause existing functionality to not work as expected)
* [ ] **Refactoring / Performance** (clean-up or performance optimization without behavioral changes)
* [ ] **Documentation / CI** (changes to docs, workflows, config files)

---

## Verification & Test Plan

### Automated Tests

```bash
npm run lint
npx tsc --noEmit
npm test
npm run security:scan
npm run sbom:check
```

### Manual Verification

1. Verify `/api/health` returns **200 OK** when the oldest unpublished outbox event is 60 seconds old or less.
2. Verify `/api/health` returns **503 Service Unavailable** when the oldest unpublished outbox event exceeds 60 seconds and includes the outbox publisher status in the response.

---

## Sub-System Checklist

### 1. Smart Contracts (`BettaPay-Contract`)

* [ ] Code compiles without warnings (`cargo build --release --target wasm32-unknown-unknown`)
* [ ] Cargo test suite passes locally (`cargo test`)
* [ ] Emits events for state changes
* [ ] Implemented proper authorization controls (`auth.require_auth()`)

### 2. Backend Services (`Credence-Backend`)

* [x] API routes and health checks updated
* [x] Regression test added/updated
* [x] Documentation updated
* [x] Lint, type-check, and tests pass locally

### 3. Frontend Dashboard

* [ ] No frontend changes required

---

## Checklist

* [x] My code follows the style guidelines of this project (run formatters/linters)
* [x] I have performed a self-review of my own code
* [x] I have commented my code where appropriate
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
