### PR TITLE
fix: enforce least-privilege scope on API keys

### DIFF
--- a/src/middleware/__tests__/apiKey.test.ts
+++ b/src/middleware/__tests__/apiKey.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import express from 'express'
+import { requireApiKey, requireScope } from '../apiKey.js'
+import { generateApiKey, _resetStore, ApiKeyScope } from '../../services/apiKeys.js'
+
+async function req(app: express.Express, token?: string) {
+  return new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        server.close()
+        reject(new Error('No address'))
+        return
+      }
+      const url = `http://127.0.0.1:${addr.port}/test`
+      fetch(url, { method: 'GET', headers: { Authorization: `Bearer ${token ?? ''}` } })
+        .then(async (res) => {
+          const body = await res.json().catch(() => null)
+          server.close()
+          resolve({ status: res.status, body })
+        })
+        .catch((err) => {
+          server.close()
+          reject(err)
+        })
+    })
+  })
+}
+
+beforeEach(() => {
+  _resetStore()
+})
+
+describe('requireScope middleware', () => {
+  it('rejects a key that lacks the required scope (403 Forbidden)', async () => {
+    const created = generateApiKey('user-1', 'read')
+    const app = express()
+    app.get('/test', requireApiKey(), requireScope(ApiKeyScope.ATTESTATIONS_WRITE), (_req, res) => {
+      res.json({ ok: true })
+    })
+
+    const { status, body } = await req(app, created.key)
+    expect(status).toBe(403)
+    expect(body.code).toBe('FORBIDDEN')
+    expect(body.error).toContain('Insufficient scope')
+  })
+
+  it('accepts a key that has the required granular scope', async () => {
+    const created = generateApiKey('user-1', ApiKeyScope.ATTESTATIONS_WRITE)
+    const app = express()
+    app.get('/test', requireApiKey(), requireScope(ApiKeyScope.ATTESTATIONS_WRITE), (_req, res) => {
+      res.json({ ok: true })
+    })
+
+    const { status } = await req(app, created.key)
+    expect(status).toBe(200)
+  })
+
+  it('accepts a full/enterprise key for any granular scope', async () => {
+    const created = generateApiKey('user-1', 'full')
+    const app = express()
+    app.get('/test', requireApiKey(), requireScope(ApiKeyScope.ATTESTATIONS_WRITE), (_req, res) => {
+      res.json({ ok: true })
+    })
+
+    const { status } = await req(app, created.key)
+    expect(status).toBe(200)
+  })
+
+  it('rejects request with 401 when requireScope is used without requireApiKey', () => {
+    const app = express()
+    const handler = requireScope(ApiKeyScope.TRUST_READ)
+    const req = { apiKeyRecord: undefined } as any
+    const res = {} as any
+    expect(() => handler(req, res, () => {})).toThrow('API key required')
+  })
+
+  it('returns typed error FORBIDDEN for insufficient scope', async () => {
+    const created = generateApiKey('user-1', [ApiKeyScope.TRUST_READ])
+    const app = express()
+    app.get('/test', requireApiKey(), requireScope(ApiKeyScope.PAYOUTS_WRITE), (_req, res) => {
+      res.json({ ok: true })
+    })
+
+    const { status, body } = await req(app, created.key)
+    expect(status).toBe(403)
+    expect(body.code).toBe('FORBIDDEN')
+  })
+})

--- a/src/middleware/apiKey.ts
+++ b/src/middleware/apiKey.ts
@@ -22,6 +22,24 @@ import { validateApiKey, type KeyScope, type StoredApiKey, ApiKeyScope } from '.
 
 export type RateTier = 'standard' | 'premium'
 
+// ── Realms (scope-group definitions) ─────────────────────────────────────────
+
+/**
+ * A "realm" is a named set of granular scopes that a legacy scope can expand to.
+ * An ENTERPRISE / 'full' key is implicitly granted every scope (no realm needed).
+ */
+const REALMS: Record<string, ReadonlySet<string>> = {
+  public: new Set([
+    ApiKeyScope.TRUST_READ,
+    ApiKeyScope.ATTESTATIONS_READ,
+    ApiKeyScope.BOND_READ,
+  ]),
+}
+
+/** Legacy scope values that imply broader access. */
+const LEGACY_FULL = new Set(['full', 'enterprise'])
+const LEGACY_READ = new Set(['read', 'public'])
+
 // Augment Express Request to carry the validated key record (set by requireApiKey)
 declare module 'express-serve-static-core' {
   interface Request {
@@ -65,6 +83,32 @@ function extractRawKey(req: Request): string | null {
 }
 
 /**
+ * Check whether a set of granted scopes satisfies the required scope.
+ *
+ * Rules (in order):
+ * 1. Direct match → allow.
+ * 2. Granted scopes contain 'full' or 'enterprise' → allow (superset of all).
+ * 3. If granted scopes contain 'read' or 'public' and the required scope is in
+ *    the public realm → allow.
+ * 4. Otherwise → deny.
+ */
+export function scopeSatisfies(grantedScopes: string[], requiredScope: string): boolean {
+  // Exact match
+  if (grantedScopes.includes(requiredScope)) return true
+
+  // Full/enterprise superset
+  if (grantedScopes.some((s) => LEGACY_FULL.has(s))) return true
+
+  // Public/read realm expansion
+  if (grantedScopes.some((s) => LEGACY_READ.has(s))) {
+    const realm = REALMS['public']
+    if (realm?.has(requiredScope)) return true
+  }
+
+  return false
+}
+
+/**
  * Express middleware that validates an API key from the request.
  *
  * Accepts keys via:
@@ -103,13 +147,18 @@ export function requireApiKey() {
  * Express middleware that checks if the validated API key has the required scope.
  * Must be used after `requireApiKey` middleware.
  *
+ * Supports:
+ * - Granular scope matching (e.g. `trust:read`)
+ * - Legacy 'full' / 'enterprise' → superset of all scopes
+ * - Legacy 'read' / 'public' → realm-based expansion
+ *
  * @param requiredScope  The scope required to access this endpoint
  *
  * @example
  * router.get('/bonds', requireApiKey(), requireScope(ApiKeyScope.BOND_READ), handler)
  * router.post('/attestations', requireApiKey(), requireScope(ApiKeyScope.ATTESTATION_WRITE), handler)
  */
-export function requireScope(requiredScope: KeyScope) {
+export function requireScope(requiredScope: string) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const apiKey = req.apiKeyRecord
 
@@ -117,8 +166,10 @@ export function requireScope(requiredScope: KeyScope) {
       throw new UnauthorizedError('API key required')
     }
 
-    if (!apiKey.scopes.includes(requiredScope)) {
-      throw new ForbiddenError('Insufficient scope')
+    if (!scopeSatisfies(apiKey.scopes, requiredScope)) {
+      throw new ForbiddenError(
+        `Insufficient scope: '${requiredScope}' is required, granted: [${apiKey.scopes.join(', ')}]`,
+      )
     }
 
     next()

--- a/src/services/apiKeys.ts
+++ b/src/services/apiKeys.ts
@@ -2,7 +2,28 @@ import { randomBytes, createHash } from 'crypto'
 import { ApiKeysRepository } from '../db/repositories/apiKeysRepository.js'
 import { pool } from '../db/pool.js'
 
-export type KeyScope = 'read' | 'full' | string   // extended to accept granular scope strings
+// ── Scope constants ──────────────────────────────────────────────────────────
+
+export const ApiKeyScope = {
+  TRUST_READ: 'trust:read',
+  ATTESTATIONS_READ: 'attestations:read',
+  ATTESTATIONS_WRITE: 'attestations:write',
+  PAYOUTS_WRITE: 'payouts:write',
+  REPORTS_GENERATE: 'reports:generate',
+  EXPORTS_READ: 'exports:read',
+  WEBHOOKS_ADMIN: 'webhooks:admin',
+  OUTBOX_REINJECT: 'outbox:reinject',
+  ADMIN_READ: 'admin:read',
+  ADMIN_WRITE: 'admin:write',
+  FLAGS_READ: 'flags:read',
+  FLAGS_WRITE: 'flags:write',
+  BOND_READ: 'bond:read',
+  BOND_WRITE: 'bond:write',
+} as const
+
+export type ApiKeyScope = (typeof ApiKeyScope)[keyof typeof ApiKeyScope]
+
+export type KeyScope = 'read' | 'full' | string
 export type SubscriptionTier = 'free' | 'pro' | 'enterprise'
 
 export interface StoredApiKey {
@@ -15,7 +36,7 @@ export interface StoredApiKey {
    * Granted scopes for this key.
    *
    * Legacy keys carry a single-element array with 'read' or 'full'.
-   * Granular keys carry one or more scope strings from ApiScope.
+   * Granular keys carry one or more scope strings from ApiKeyScope.
    *
    * The `scope` field (singular) is kept for backward compatibility and
    * reflects the primary / most-privileged scope in the array.
@@ -67,18 +88,18 @@ function extractPrefix(rawKey: string): string {
  * @param scopes   Optional explicit list of granted scopes. When provided, overrides `scope`.
  * @returns        Key metadata including the raw key (shown once only)
  */
-export async function generateApiKey(
+export function generateApiKey(
   ownerId: string,
-  scopes: KeyScope[] = [],
+  scope: KeyScope | KeyScope[] = 'read',
   tier: SubscriptionTier = 'free',
   scopes?: string[],
 ): CreateApiKeyResult {
-  const random = randomBytes(32).toString('hex') // 64 hex chars
-  const rawKey = `cr_${random}` // 67 chars total
+  const random = randomBytes(32).toString('hex')
+  const rawKey = `cr_${random}`
   const prefix = extractPrefix(rawKey)
   const id = randomBytes(8).toString('hex')
 
-  const grantedScopes = scopes ?? [scope]
+  const grantedScopes: string[] = scopes ?? (Array.isArray(scope) ? scope : [scope])
   const primaryScope = grantedScopes[0] as KeyScope
 
   const stored: StoredApiKey = {
@@ -94,7 +115,7 @@ export async function generateApiKey(
     active: true,
   }
 
-  store.set(id, stored)
+  inMemoryStore.set(id, stored)
   return {
     id,
     key: rawKey,
@@ -158,7 +179,7 @@ export async function revokeApiKey(id: string): Promise<boolean> {
  * scopes, tier, and owner. Returns null if the key doesn't exist or is already revoked.
  */
 export function rotateApiKey(id: string): CreateApiKeyResult | null {
-  const existing = store.get(id)
+  const existing = inMemoryStore.get(id)
   if (!existing || !existing.active) return null
 
   existing.active = false
@@ -171,7 +192,7 @@ export function rotateApiKey(id: string): CreateApiKeyResult | null {
  * @returns Key metadata (minus `hashedKey`), or null if not found.
  */
 export function findApiKeyById(id: string): Omit<StoredApiKey, 'hashedKey'> | null {
-  const key = store.get(id)
+  const key = inMemoryStore.get(id)
   if (!key) return null
   const { hashedKey: _h, ...rest } = key
   return rest


### PR DESCRIPTION
## Add scoped API keys with least-privilege enforcement & Reject zero-amount operations at the entrypoint
 
Closes #566 
Closes #575 

### What changed
- Fix duplicate  param in  (renamed to )
- Fix store references from  to
- Add missing  export with granular scope constants
- Add  for legacy scope expansion (full/enterprise, read/public)
-  now throws typed  with scope detail
- Add negative test: scoped key denied on out-of-scope endpoint returns 403