### PR TITLE
Add explicit Zod schemas with strict validation to admin request bodies

### DIFF
--- a/src/routes/admin/admin.test.ts
+++ b/src/routes/admin/admin.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import express, { Request, Response, NextFunction } from 'express'
+import request from 'supertest'
+import { createAdminRouter } from './index.js'
+
+// ---- Mock middleware ----
+vi.mock('../../middleware/auth.ts', () => ({
+  requireUserAuth: (req: Request, _res: Response, next: NextFunction) => {
+    (req as any).user = { id: 'admin-1', email: 'admin@test.com' }
+    next()
+  },
+  requireAdminRole: (_req: Request, _res: Response, next: NextFunction) => next(),
+}))
+
+// ---- Mock AdminService ----
+const mockAdminService = {
+  listUsers: vi.fn(),
+  assignRole: vi.fn(),
+  revokeApiKey: vi.fn(),
+  getAuditLogs: vi.fn(),
+  exportAuditLogs: vi.fn(),
+  logExportCompletion: vi.fn(),
+}
+
+vi.mock('../../services/admin/index.js', () => ({
+  AdminService: vi.fn().mockImplementation(() => mockAdminService),
+}))
+
+// ---- Mock impersonation service ----
+const mockImpersonationService = {
+  issueToken: vi.fn(),
+  revokeToken: vi.fn(),
+}
+
+vi.mock('../../services/impersonation/index.js', () => ({
+  impersonationService: mockImpersonationService,
+}))
+
+// ---- Mock pagination ----
+vi.mock('../../lib/pagination.ts', () => ({
+  parsePaginationParams: vi.fn().mockReturnValue({ page: 1, limit: 10, offset: 0 }),
+  buildPaginationMeta: vi.fn().mockReturnValue({ totalPages: 1 }),
+}))
+
+// ---- Mock ReplayService ----
+vi.mock('../../services/replayService.js', () => ({
+  ReplayService: vi.fn().mockImplementation(() => ({
+    listFailedEvents: vi.fn().mockResolvedValue({ events: [], total: 0 }),
+    replayEvent: vi.fn().mockResolvedValue({ success: true }),
+  })),
+}))
+
+// ---- Mock repositories ----
+vi.mock('../../db/repositories/failedInboundEventsRepository.js', () => ({
+  FailedInboundEventsRepository: vi.fn().mockImplementation(() => ({})),
+}))
+
+vi.mock('../../db/repositories/identityRepository.js', () => ({
+  IdentityRepository: vi.fn().mockImplementation(() => ({})),
+}))
+
+vi.mock('../../db/repositories/bondsRepository.js', () => ({
+  BondsRepository: vi.fn().mockImplementation(() => ({})),
+}))
+
+vi.mock('../../services/replayHandlers.js', () => ({
+  registerAllReplayHandlers: vi.fn(),
+}))
+
+function setup() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/admin', createAdminRouter())
+  return app
+}
+
+describe('Admin Router - Strict Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('POST /api/admin/roles/assign', () => {
+    it('should reject unknown fields in assign role request', async () => {
+      mockAdminService.assignRole.mockResolvedValue({
+        user: { id: 'u1' },
+        message: 'assigned',
+      })
+
+      const res = await request(setup())
+        .post('/api/admin/roles/assign')
+        .send({ userId: 'u1', role: 'admin', maliciousField: 'attack' })
+
+      expect(res.status).toBe(400)
+      expect(res.body.code).toBe('validation_failed')
+    })
+
+    it('should accept valid assign role request', async () => {
+      mockAdminService.assignRole.mockResolvedValue({
+        user: { id: 'u1' },
+        message: 'assigned',
+      })
+
+      const res = await request(setup())
+        .post('/api/admin/roles/assign')
+        .send({ userId: 'u1', role: 'admin' })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('POST /api/admin/keys/revoke', () => {
+    it('should reject unknown fields in revoke API key request', async () => {
+      mockAdminService.revokeApiKey.mockResolvedValue({
+        message: 'revoked',
+      })
+
+      const res = await request(setup())
+        .post('/api/admin/keys/revoke')
+        .send({ userId: 'u1', apiKey: 'key123', maliciousField: 'attack' })
+
+      expect(res.status).toBe(400)
+      expect(res.body.code).toBe('validation_failed')
+    })
+
+    it('should accept valid revoke API key request', async () => {
+      mockAdminService.revokeApiKey.mockResolvedValue({
+        message: 'revoked',
+      })
+
+      const res = await request(setup())
+        .post('/api/admin/keys/revoke')
+        .send({ userId: 'u1', apiKey: 'key123' })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('POST /api/admin/impersonate', () => {
+    it('should reject unknown fields in impersonate request', async () => {
+      mockImpersonationService.issueToken.mockReturnValue({
+        tokenId: 'token123',
+        targetUserId: 'u1',
+        targetUserEmail: 'user@test.com',
+        expiresAt: '2024-01-01T00:00:00Z',
+        ttlSeconds: 900,
+      })
+
+      const res = await request(setup())
+        .post('/api/admin/impersonate')
+        .send({ targetUserId: 'u1', reason: 'debug', maliciousField: 'attack' })
+
+      expect(res.status).toBe(400)
+      expect(res.body.code).toBe('validation_failed')
+    })
+
+    it('should accept valid impersonate request', async () => {
+      mockImpersonationService.issueToken.mockReturnValue({
+        tokenId: 'token123',
+        targetUserId: 'u1',
+        targetUserEmail: 'user@test.com',
+        expiresAt: '2024-01-01T00:00:00Z',
+        ttlSeconds: 900,
+      })
+
+      const res = await request(setup())
+        .post('/api/admin/impersonate')
+        .send({ targetUserId: 'u1', reason: 'debug' })
+
+      expect(res.status).toBe(201)
+    })
+  })
+})

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express'
+import { Router, Request, Response, NextFunction } from 'express'
 import { AuthenticatedRequest, requireUserAuth, requireAdminRole, UserRole } from '../../middleware/auth.js'
 import {
   buildPaginationMeta,
@@ -7,6 +7,15 @@ import {
 import { AdminService } from '../../services/admin/index.js'
 import { auditLogService } from '../../services/audit/index.js'
 import { AppError, ErrorCode, ValidationError } from '../../lib/errors.js'
+import { validate } from '../../middleware/validate.js'
+import {
+  assignRoleBodySchema,
+  revokeApiKeyBodySchema,
+  issueImpersonationTokenBodySchema,
+  type AssignRoleBody,
+  type RevokeApiKeyBody,
+  type IssueImpersonationTokenBody,
+} from '../../schemas/index.js'
 import type { AssignRoleRequest, RevokeApiKeyRequest } from '../../services/admin/types.js'
 import type { IssueImpersonationTokenRequest } from '../../services/impersonation/types.js'
 import { ReplayService } from '../../services/replayService.js'
@@ -15,6 +24,7 @@ import { registerAllReplayHandlers } from '../../services/replayHandlers.js'
 import { IdentityRepository } from '../../db/repositories/identityRepository.js'
 import { BondsRepository } from '../../db/repositories/bondsRepository.js'
 import { pool } from '../../db/pool.js'
+import { impersonationService } from '../../services/impersonation/index.js'
 
 /**
  * Create the admin router with role and user management endpoints
@@ -37,7 +47,7 @@ export function createAdminRouter(): Router {
   /**
    * GET /api/admin/users
    */
-  router.get('/users', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.get('/users', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next: NextFunction) => {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
@@ -75,95 +85,90 @@ export function createAdminRouter(): Router {
   /**
    * POST /api/admin/roles/assign
    */
-  router.post('/roles/assign', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
-    try {
-      const authReq = req as AuthenticatedRequest
-      const user = authReq.user!
-      const assignRequest = req.body as AssignRoleRequest
+  router.post(
+    '/roles/assign',
+    requireUserAuth,
+    requireAdminRole,
+    validate({ body: assignRoleBodySchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthenticatedRequest
+        const user = authReq.user!
+        const assignRequest = req.validated!.body as AssignRoleBody
 
-      // Validate request body
-      if (!assignRequest.userId || !assignRequest.role) {
-        throw new ValidationError('Missing required fields: userId, role')
+        const result = await adminService.assignRole(user.id, user.email, assignRequest as AssignRoleRequest)
+
+        res.status(200).json({
+          success: true,
+          message: result.message,
+          data: result.user,
+        })
+      } catch (error) {
+        next(error)
       }
-
-      const result = await adminService.assignRole(user.id, user.email, assignRequest)
-
-      res.status(200).json({
-        success: true,
-        message: result.message,
-        data: result.user,
-      })
-    } catch (error) {
-      next(error)
-    }
-  })
+    },
+  )
 
   /**
    * POST /api/admin/keys/revoke
    */
-  router.post('/keys/revoke', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
-    try {
-      const authReq = req as AuthenticatedRequest
-      const user = authReq.user!
-      const revokeRequest = req.body as RevokeApiKeyRequest
+  router.post(
+    '/keys/revoke',
+    requireUserAuth,
+    requireAdminRole,
+    validate({ body: revokeApiKeyBodySchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthenticatedRequest
+        const user = authReq.user!
+        const revokeRequest = req.validated!.body as RevokeApiKeyBody
 
-      // Validate request body
-      if (!revokeRequest.userId || !revokeRequest.apiKey) {
-        throw new ValidationError('Missing required fields: userId, apiKey')
+        const result = await adminService.revokeApiKey(user.id, user.email, revokeRequest as RevokeApiKeyRequest)
+
+        res.status(200).json({
+          success: true,
+          message: result.message,
+        })
+      } catch (error) {
+        next(error)
       }
-
-      const result = await adminService.revokeApiKey(user.id, user.email, revokeRequest)
-
-      res.status(200).json({
-        success: true,
-        message: result.message,
-      })
-    } catch (error) {
-      next(error)
-    }
-  })
+    },
+  )
 
   /**
    * POST /api/admin/impersonate
    *
    * Issue a short-lived impersonation token for support/debug purposes.
    */
-  router.post('/impersonate', requireUserAuth, requireAdminRole, (req: Request, res: Response) => {
-    try {
-      const authReq = req as AuthenticatedRequest
-      const user = authReq.user!
-      const body = req.body as Partial<IssueImpersonationTokenRequest>
+  router.post(
+    '/impersonate',
+    requireUserAuth,
+    requireAdminRole,
+    validate({ body: issueImpersonationTokenBodySchema }),
+    (req: Request, res: Response) => {
+      try {
+        const authReq = req as AuthenticatedRequest
+        const user = authReq.user!
+        const body = req.validated!.body as IssueImpersonationTokenBody
 
-      if (!body.targetUserId) {
-        res.status(400).json({ error: 'InvalidRequest', message: 'targetUserId is required' })
-        return
-      }
-      if (!body.reason) {
-        res.status(400).json({ error: 'InvalidRequest', message: 'reason is required' })
-        return
-      }
+        const issued = impersonationService.issueToken(
+          user.id,
+          user.email,
+          body as IssueImpersonationTokenRequest,
+          req.ip,
+        )
 
-      const issued = impersonationService.issueToken(
-        user.id,
-        user.email,
-        {
-          targetUserId: body.targetUserId,
-          reason: body.reason,
-          ttlSeconds: body.ttlSeconds,
-        },
-        req.ip,
-      )
-
-      res.status(201).json({ success: true, data: issued })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error'
-      if (/User not found/i.test(message)) {
-        res.status(404).json({ error: 'NotFound', message })
-        return
+        res.status(201).json({ success: true, data: issued })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        if (/User not found/i.test(message)) {
+          res.status(404).json({ error: 'NotFound', message })
+          return
+        }
+        res.status(400).json({ error: 'BadRequest', message })
       }
-      res.status(400).json({ error: 'BadRequest', message })
-    }
-  })
+    },
+  )
 
   /**
    * POST /api/admin/impersonate/:tokenId/revoke
@@ -196,7 +201,7 @@ export function createAdminRouter(): Router {
   /**
    * GET /api/admin/audit-logs
    */
-  router.get('/audit-logs', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.get('/audit-logs', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next: NextFunction) => {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
@@ -290,7 +295,7 @@ export function createAdminRouter(): Router {
    * 
    * List failed inbound events for review
    */
-  router.get('/events/failed', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.get('/events/failed', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next: NextFunction) => {
     try {
       const filters: any = {}
       if (req.query.status) filters.status = req.query.status
@@ -306,7 +311,7 @@ export function createAdminRouter(): Router {
         data: result
       })
     } catch (error: any) {
-      res.status(500).json({ error: 'InternalError', message: error.message })
+      next(error)
     }
   })
 
@@ -315,7 +320,7 @@ export function createAdminRouter(): Router {
    * 
    * Replay a specific failed event
    */
-  router.post('/events/replay/:id', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.post('/events/replay/:id', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next: NextFunction) => {
     try {
       const authReq = req as AuthenticatedRequest
       const admin = authReq.user!
@@ -330,7 +335,7 @@ export function createAdminRouter(): Router {
 
       res.status(200).json(result)
     } catch (error: any) {
-      res.status(400).json({ error: 'ReplayFailed', message: error.message })
+      next(error)
     }
   })
 

--- a/src/routes/admin/member.ts
+++ b/src/routes/admin/member.ts
@@ -14,7 +14,7 @@
  *  POST   /api/admin/orgs/:orgId/members/:memberId/restore  Restore a deleted member
  */
 
-import { Router, Request, Response } from 'express'
+import { Router, Request, Response, NextFunction } from 'express'
 import {
   AuthenticatedRequest,
   requireUserAuth,
@@ -25,6 +25,13 @@ import {
   buildPaginationMeta,
   PaginationValidationError,
 } from '../../lib/pagination.js'
+import { validate } from '../../middleware/validate.js'
+import {
+  inviteMemberBodySchema,
+  updateMemberRoleBodySchema,
+  type InviteMemberBody,
+  type UpdateMemberRoleBody,
+} from '../../schemas/index.js'
 import { pool } from '../../db/pool.js'
 import { auditLogService } from '../../services/audit/index.js'
 import type { MemberRole } from '../../services/members/types.js'
@@ -58,7 +65,7 @@ export function createMembersRouter(): Router {
    *   -H "Authorization: Bearer admin-key-12345"
    * ```
    */
-  router.get('/', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.get('/', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next: NextFunction) => {
     try {
       const authReq = req as AuthenticatedRequest
       const { orgId } = req.params
@@ -97,10 +104,7 @@ export function createMembersRouter(): Router {
         },
       })
     } catch (err) {
-      res.status(500).json({
-        error: 'InternalError',
-        message: err instanceof Error ? err.message : 'Unknown error',
-      })
+      next(err)
     }
   })
 
@@ -123,48 +127,34 @@ export function createMembersRouter(): Router {
    *   -d '{"userId":"user-99","email":"alice@example.com","role":"member"}'
    * ```
    */
-  router.post('/', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
-    try {
-      const authReq = req as AuthenticatedRequest
-      const { orgId } = req.params
-      const { userId, email, role } = req.body as {
-        userId?: string
-        email?: string
-        role?: string
-      }
+  router.post(
+    '/',
+    requireUserAuth,
+    requireAdminRole,
+    validate({ body: inviteMemberBodySchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthenticatedRequest
+        const { orgId } = req.params
+        const { userId, email, role } = req.validated!.body as InviteMemberBody
 
-      if (!userId || !email) {
-        res.status(400).json({
-          error: 'InvalidRequest',
-          message: 'Missing required fields: userId, email',
+        const result = await memberService.inviteMember(
+          authReq.user!.id,
+          authReq.user!.email,
+          { orgId, userId, email, role: role ?? 'member' },
+        )
+
+        res.status(201).json({ success: true, data: result.member, message: result.message })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        const isConflict = message.includes('already active')
+        res.status(isConflict ? 409 : 400).json({
+          error: isConflict ? 'Conflict' : 'BadRequest',
+          message,
         })
-        return
       }
-
-      if (role && !VALID_MEMBER_ROLES.includes(role as MemberRole)) {
-        res.status(400).json({
-          error: 'InvalidRequest',
-          message: `Invalid role. Must be one of: ${VALID_MEMBER_ROLES.join(', ')}`,
-        })
-        return
-      }
-
-      const result = await memberService.inviteMember(
-        authReq.user!.id,
-        authReq.user!.email,
-        { orgId, userId, email, role: (role as MemberRole) ?? 'member' },
-      )
-
-      res.status(201).json({ success: true, data: result.member, message: result.message })
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      const isConflict = message.includes('already active')
-      res.status(isConflict ? 409 : 400).json({
-        error: isConflict ? 'Conflict' : 'BadRequest',
-        message,
-      })
-    }
-  })
+    },
+  )
 
   // ── PATCH /api/orgs/:orgId/members/:memberId ────────────────────────
   /**
@@ -172,36 +162,34 @@ export function createMembersRouter(): Router {
    *
    * @body {string} role - New role: 'owner' | 'admin' | 'member'
    */
-  router.patch('/:memberId', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
-    try {
-      const authReq = req as AuthenticatedRequest
-      const { memberId } = req.params
-      const { role } = req.body as { role?: string }
+  router.patch(
+    '/:memberId',
+    requireUserAuth,
+    requireAdminRole,
+    validate({ body: updateMemberRoleBodySchema }),
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const authReq = req as AuthenticatedRequest
+        const { memberId } = req.params
+        const { role } = req.validated!.body as UpdateMemberRoleBody
 
-      if (!role || !VALID_MEMBER_ROLES.includes(role as MemberRole)) {
-        res.status(400).json({
-          error: 'InvalidRequest',
-          message: `Invalid or missing role. Must be one of: ${VALID_MEMBER_ROLES.join(', ')}`,
+        const result = await memberService.updateMemberRole(
+          authReq.user!.id,
+          authReq.user!.email,
+          { memberId, role },
+        )
+
+        res.status(200).json({ success: true, data: result.member, message: result.message })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error'
+        const isNotFound = message.includes('not found')
+        res.status(isNotFound ? 404 : 400).json({
+          error: isNotFound ? 'NotFound' : 'BadRequest',
+          message,
         })
-        return
       }
-
-      const result = await memberService.updateMemberRole(
-        authReq.user!.id,
-        authReq.user!.email,
-        { memberId, role: role as MemberRole },
-      )
-
-      res.status(200).json({ success: true, data: result.member, message: result.message })
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      const isNotFound = message.includes('not found')
-      res.status(isNotFound ? 404 : 400).json({
-        error: isNotFound ? 'NotFound' : 'BadRequest',
-        message,
-      })
-    }
-  })
+    },
+  )
 
   // ── DELETE /api/orgs/:orgId/members/:memberId ───────────────────────
   /**
@@ -211,7 +199,7 @@ export function createMembersRouter(): Router {
    * are set.  The member can be restored via the restore endpoint.
    * After deletion the same user can be re-invited (new row, new membership).
    */
-  router.delete('/:memberId', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.delete('/:memberId', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next: NextFunction) => {
     try {
       const authReq = req as AuthenticatedRequest
       const { memberId } = req.params
@@ -241,7 +229,7 @@ export function createMembersRouter(): Router {
    * (org, user) pair — use the existing membership instead.
    * Returns 404 if the member ID is unknown or the member was never deleted.
    */
-  router.post('/:memberId/restore', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.post('/:memberId/restore', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next: NextFunction) => {
     try {
       const authReq = req as AuthenticatedRequest
       const { memberId } = req.params

--- a/src/routes/admin/members.test.ts
+++ b/src/routes/admin/members.test.ts
@@ -119,6 +119,15 @@ describe('Members Router', () => {
     expect(res.status).toBe(400)
   })
 
+  it('should return 400 for unknown fields in invite request', async () => {
+    const res = await request(setup())
+      .post('/api/admin/orgs/org-1/members')
+      .send({ userId: 'u1', email: 'a@test.com', role: 'admin', maliciousField: 'attack' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe('validation_failed')
+  })
+
   it('should return 409 if member already exists', async () => {
     mockService.inviteMember.mockRejectedValue(
       new Error('already active')
@@ -153,6 +162,15 @@ describe('Members Router', () => {
       .send({ role: 'invalid' })
 
     expect(res.status).toBe(400)
+  })
+
+  it('should return 400 for unknown fields in update role request', async () => {
+    const res = await request(setup())
+      .patch('/api/admin/orgs/org-1/members/m1')
+      .send({ role: 'admin', maliciousField: 'attack' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe('validation_failed')
   })
 
   it('should return 404 if member not found on update', async () => {

--- a/src/schemas/admin.test.ts
+++ b/src/schemas/admin.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import {
+  assignRoleBodySchema,
+  revokeApiKeyBodySchema,
+  issueImpersonationTokenBodySchema,
+  inviteMemberBodySchema,
+  updateMemberRoleBodySchema,
+} from './admin.js'
+
+describe('Admin Schemas - Strict Validation', () => {
+  describe('assignRoleBodySchema', () => {
+    it('should accept valid assign role request', () => {
+      const result = assignRoleBodySchema.safeParse({
+        userId: 'user-123',
+        role: 'admin',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject unknown fields', () => {
+      const result = assignRoleBodySchema.safeParse({
+        userId: 'user-123',
+        role: 'admin',
+        maliciousField: 'attack',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('Unrecognized key')
+      }
+    })
+
+    it('should reject missing required fields', () => {
+      const result = assignRoleBodySchema.safeParse({
+        userId: 'user-123',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('revokeApiKeyBodySchema', () => {
+    it('should accept valid revoke API key request', () => {
+      const result = revokeApiKeyBodySchema.safeParse({
+        userId: 'user-123',
+        apiKey: 'key-123',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject unknown fields', () => {
+      const result = revokeApiKeyBodySchema.safeParse({
+        userId: 'user-123',
+        apiKey: 'key-123',
+        maliciousField: 'attack',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('Unrecognized key')
+      }
+    })
+
+    it('should reject missing required fields', () => {
+      const result = revokeApiKeyBodySchema.safeParse({
+        userId: 'user-123',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('issueImpersonationTokenBodySchema', () => {
+    it('should accept valid impersonate request', () => {
+      const result = issueImpersonationTokenBodySchema.safeParse({
+        targetUserId: 'user-123',
+        reason: 'debug issue',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept valid impersonate request with TTL', () => {
+      const result = issueImpersonationTokenBodySchema.safeParse({
+        targetUserId: 'user-123',
+        reason: 'debug issue',
+        ttlSeconds: 600,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject unknown fields', () => {
+      const result = issueImpersonationTokenBodySchema.safeParse({
+        targetUserId: 'user-123',
+        reason: 'debug issue',
+        maliciousField: 'attack',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('Unrecognized key')
+      }
+    })
+
+    it('should reject TTL exceeding maximum', () => {
+      const result = issueImpersonationTokenBodySchema.safeParse({
+        targetUserId: 'user-123',
+        reason: 'debug issue',
+        ttlSeconds: 4000,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject missing required fields', () => {
+      const result = issueImpersonationTokenBodySchema.safeParse({
+        targetUserId: 'user-123',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('inviteMemberBodySchema', () => {
+    it('should accept valid invite member request', () => {
+      const result = inviteMemberBodySchema.safeParse({
+        userId: 'user-123',
+        email: 'user@example.com',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept valid invite member request with role', () => {
+      const result = inviteMemberBodySchema.safeParse({
+        userId: 'user-123',
+        email: 'user@example.com',
+        role: 'admin',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject unknown fields', () => {
+      const result = inviteMemberBodySchema.safeParse({
+        userId: 'user-123',
+        email: 'user@example.com',
+        maliciousField: 'attack',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('Unrecognized key')
+      }
+    })
+
+    it('should reject invalid email', () => {
+      const result = inviteMemberBodySchema.safeParse({
+        userId: 'user-123',
+        email: 'not-an-email',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject missing required fields', () => {
+      const result = inviteMemberBodySchema.safeParse({
+        userId: 'user-123',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('updateMemberRoleBodySchema', () => {
+    it('should accept valid update member role request', () => {
+      const result = updateMemberRoleBodySchema.safeParse({
+        role: 'admin',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject unknown fields', () => {
+      const result = updateMemberRoleBodySchema.safeParse({
+        role: 'admin',
+        maliciousField: 'attack',
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('Unrecognized key')
+      }
+    })
+
+    it('should reject invalid role', () => {
+      const result = updateMemberRoleBodySchema.safeParse({
+        role: 'invalid-role',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject missing required fields', () => {
+      const result = updateMemberRoleBodySchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src/schemas/admin.ts
+++ b/src/schemas/admin.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+import { UserRole } from '../middleware/auth.js'
+import type { MemberRole } from '../services/members/types.js'
+
+/**
+ * Request body schema for assigning a role to a user
+ * POST /api/admin/roles/assign
+ */
+export const assignRoleBodySchema = z
+  .object({
+    userId: z.string().min(1, 'userId is required'),
+    role: z.nativeEnum(UserRole, {
+      errorMap: () => ({ message: 'role must be a valid UserRole' }),
+    }),
+  })
+  .strict()
+
+/**
+ * Request body schema for revoking an API key
+ * POST /api/admin/keys/revoke
+ */
+export const revokeApiKeyBodySchema = z
+  .object({
+    userId: z.string().min(1, 'userId is required'),
+    apiKey: z.string().min(1, 'apiKey is required'),
+  })
+  .strict()
+
+/**
+ * Request body schema for issuing an impersonation token
+ * POST /api/admin/impersonate
+ */
+export const issueImpersonationTokenBodySchema = z
+  .object({
+    targetUserId: z.string().min(1, 'targetUserId is required'),
+    reason: z.string().min(1, 'reason is required'),
+    ttlSeconds: z
+      .number()
+      .int()
+      .min(1, 'ttlSeconds must be at least 1')
+      .max(3600, 'ttlSeconds must not exceed 3600 (1 hour)')
+      .optional(),
+  })
+  .strict()
+
+/**
+ * Request body schema for inviting a member to an organization
+ * POST /api/admin/orgs/:orgId/members
+ */
+export const inviteMemberBodySchema = z
+  .object({
+    userId: z.string().min(1, 'userId is required'),
+    email: z.string().email('email must be a valid email address'),
+    role: z
+      .enum(['owner', 'admin', 'member'] as const)
+      .optional(),
+  })
+  .strict()
+
+/**
+ * Request body schema for updating a member's role
+ * PATCH /api/admin/orgs/:orgId/members/:memberId
+ */
+export const updateMemberRoleBodySchema = z
+  .object({
+    role: z.enum(['owner', 'admin', 'member'] as const, {
+      errorMap: () => ({ message: 'role must be one of: owner, admin, member' }),
+    }),
+  })
+  .strict()
+
+export type AssignRoleBody = z.infer<typeof assignRoleBodySchema>
+export type RevokeApiKeyBody = z.infer<typeof revokeApiKeyBodySchema>
+export type IssueImpersonationTokenBody = z.infer<typeof issueImpersonationTokenBodySchema>
+export type InviteMemberBody = z.infer<typeof inviteMemberBodySchema>
+export type UpdateMemberRoleBody = z.infer<typeof updateMemberRoleBodySchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -23,3 +23,15 @@ export {
   type AttestationsQuery,
   type CreateAttestationBody,
 } from './attestations.js'
+export {
+  assignRoleBodySchema,
+  revokeApiKeyBodySchema,
+  issueImpersonationTokenBodySchema,
+  inviteMemberBodySchema,
+  updateMemberRoleBodySchema,
+  type AssignRoleBody,
+  type RevokeApiKeyBody,
+  type IssueImpersonationTokenBody,
+  type InviteMemberBody,
+  type UpdateMemberRoleBody,
+} from './admin.js'


### PR DESCRIPTION
This commit addresses a security vulnerability where admin endpoints accepted request bodies with unknown/extra fields without validation. This is a defense-in-depth fix to prevent parameter pollution and potential exploitation.

Threat Model: Attackers could send requests with additional malicious fields beyond what the application expects. Current gap: admin endpoints used TypeScript type assertions but no runtime validation. Mitigation: Added strict Zod schemas that reject unknown fields and surface typed VALIDATION_ERROR responses.

Changes: Created src/schemas/admin.ts with strict Zod schemas for assignRoleBodySchema, revokeApiKeyBodySchema, issueImpersonationTokenBodySchema, inviteMemberBodySchema, updateMemberRoleBodySchema. Updated admin routes to use validate middleware. Added negative tests that verify unknown fields are rejected. Fixed missing NextFunction parameters in error handlers.

Closes #556 
