### PR TITLE
feat(feature-flags): TTL evaluation cache with per-tenant invalidation

### DIFF
--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -21,3 +21,9 @@ export {
   createSlowOperationEvent,
   createSuccessEvent,
 } from './timeoutMetrics.js'
+
+export {
+  featureFlagCacheHits,
+  featureFlagCacheMisses,
+  featureFlagCacheInvalidations,
+} from '../services/featureFlags/index.js'

--- a/src/services/featureFlags/index.test.ts
+++ b/src/services/featureFlags/index.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  FeatureFlagService,
+  FeatureFlagStore,
+  FeatureFlag,
+  FlagOverride,
+  featureFlagCacheHits,
+  featureFlagCacheMisses,
+  featureFlagCacheInvalidations,
+} from './index.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStore(overrides: Partial<FeatureFlagStore> = {}): FeatureFlagStore {
+  return {
+    getFlag: vi.fn(),
+    listFlags: vi.fn(),
+    updateFlag: vi.fn(),
+    listOverrides: vi.fn().mockResolvedValue([]),
+    setOverride: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeFlag(partial: Partial<FeatureFlag> = {}): FeatureFlag {
+  return {
+    key: 'my-flag',
+    enabled: true,
+    tenantId: 'tenant-a',
+    ...partial,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FeatureFlagService', () => {
+  let store: FeatureFlagStore
+  let service: FeatureFlagService
+
+  beforeEach(() => {
+    store = makeStore()
+    service = new FeatureFlagService(store, { ttlMs: 5_000, maxSize: 100 })
+    vi.spyOn(featureFlagCacheHits, 'inc')
+    vi.spyOn(featureFlagCacheMisses, 'inc')
+    vi.spyOn(featureFlagCacheInvalidations, 'inc')
+  })
+
+  // -------------------------------------------------------------------------
+  // isEnabled — cache miss / hit
+  // -------------------------------------------------------------------------
+
+  describe('isEnabled – cache miss then hit', () => {
+    it('fetches from store on first call (cache miss) and returns flag value', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+
+      const result = await service.isEnabled('my-flag', 'tenant-a')
+
+      expect(result).toBe(true)
+      expect(store.getFlag).toHaveBeenCalledOnce()
+      expect(featureFlagCacheMisses.inc).toHaveBeenCalledWith({
+        tenant_id: 'tenant-a',
+        flag_key: 'my-flag',
+      })
+    })
+
+    it('returns cached value on second call (cache hit) without re-querying store', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: false }))
+
+      await service.isEnabled('my-flag', 'tenant-a')
+      const result = await service.isEnabled('my-flag', 'tenant-a')
+
+      expect(result).toBe(false)
+      expect(store.getFlag).toHaveBeenCalledOnce() // only on first call
+      expect(featureFlagCacheHits.inc).toHaveBeenCalledWith({
+        tenant_id: 'tenant-a',
+        flag_key: 'my-flag',
+      })
+    })
+
+    it('returns false when flag does not exist', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(null)
+
+      const result = await service.isEnabled('missing-flag', 'tenant-a')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Tenant isolation
+  // -------------------------------------------------------------------------
+
+  describe('tenant isolation', () => {
+    it('caches separately for different tenants with the same flag key', async () => {
+      vi.mocked(store.getFlag)
+        .mockResolvedValueOnce(makeFlag({ tenantId: 'tenant-a', enabled: true }))
+        .mockResolvedValueOnce(makeFlag({ tenantId: 'tenant-b', enabled: false }))
+
+      const a = await service.isEnabled('my-flag', 'tenant-a')
+      const b = await service.isEnabled('my-flag', 'tenant-b')
+
+      expect(a).toBe(true)
+      expect(b).toBe(false)
+      expect(store.getFlag).toHaveBeenCalledTimes(2)
+    })
+
+    it('invalidating one tenant does not affect another', async () => {
+      vi.mocked(store.getFlag)
+        .mockResolvedValue(makeFlag({ enabled: true }))
+      vi.mocked(store.updateFlag).mockResolvedValue(makeFlag({ enabled: false }))
+
+      await service.isEnabled('my-flag', 'tenant-a')
+      await service.isEnabled('my-flag', 'tenant-b')
+
+      service.bustFlag('my-flag', 'tenant-a')
+
+      // tenant-b still cached → store should not be called again
+      await service.isEnabled('my-flag', 'tenant-b')
+      expect(store.getFlag).toHaveBeenCalledTimes(2) // once per tenant initial fetch
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // TTL expiry
+  // -------------------------------------------------------------------------
+
+  describe('TTL expiry', () => {
+    it('re-fetches from store after TTL expires', async () => {
+      vi.useFakeTimers()
+      const shortTtlService = new FeatureFlagService(store, { ttlMs: 100 })
+
+      vi.mocked(store.getFlag)
+        .mockResolvedValueOnce(makeFlag({ enabled: true }))
+        .mockResolvedValueOnce(makeFlag({ enabled: false }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+
+      await shortTtlService.isEnabled('my-flag', 'tenant-a') // miss, caches true
+
+      vi.advanceTimersByTime(101) // expire
+
+      const result = await shortTtlService.isEnabled('my-flag', 'tenant-a') // miss again
+      expect(result).toBe(false)
+      expect(store.getFlag).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
+    })
+
+    it('serves cached value before TTL boundary', async () => {
+      vi.useFakeTimers()
+      const shortTtlService = new FeatureFlagService(store, { ttlMs: 200 })
+
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+
+      await shortTtlService.isEnabled('my-flag', 'tenant-a')
+
+      vi.advanceTimersByTime(100) // still within TTL
+
+      await shortTtlService.isEnabled('my-flag', 'tenant-a')
+      expect(store.getFlag).toHaveBeenCalledOnce() // still cached
+
+      vi.useRealTimers()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // updateFlag — invalidation
+  // -------------------------------------------------------------------------
+
+  describe('updateFlag – cache invalidation', () => {
+    it('invalidates cached evaluations for the flag/tenant after update', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+      vi.mocked(store.updateFlag).mockResolvedValue(makeFlag({ enabled: false }))
+
+      await service.isEnabled('my-flag', 'tenant-a') // cache entry created
+
+      await service.updateFlag('my-flag', 'tenant-a', { enabled: false })
+
+      // Next isEnabled must go to store (cache was busted)
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: false }))
+      const result = await service.isEnabled('my-flag', 'tenant-a')
+
+      expect(result).toBe(false)
+      expect(store.getFlag).toHaveBeenCalledTimes(2) // first + post-invalidation
+      expect(featureFlagCacheInvalidations.inc).toHaveBeenCalledWith({
+        tenant_id: 'tenant-a',
+        flag_key: 'my-flag',
+      })
+    })
+
+    it('invalidates user-scoped evaluation entries on flag update', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+      vi.mocked(store.updateFlag).mockResolvedValue(makeFlag({ enabled: false }))
+
+      await service.isEnabled('my-flag', 'tenant-a', 'user-1') // user-scoped cache
+
+      await service.updateFlag('my-flag', 'tenant-a', { enabled: false })
+
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: false }))
+
+      const result = await service.isEnabled('my-flag', 'tenant-a', 'user-1')
+      expect(result).toBe(false)
+      expect(store.getFlag).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // setOverride — invalidation
+  // -------------------------------------------------------------------------
+
+  describe('setOverride – cache invalidation', () => {
+    it('invalidates user-scoped entry on override change', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: false }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+
+      const override: FlagOverride = {
+        flagKey: 'my-flag',
+        tenantId: 'tenant-a',
+        userId: 'user-1',
+        enabled: true,
+      }
+      vi.mocked(store.setOverride).mockResolvedValue(override)
+
+      await service.isEnabled('my-flag', 'tenant-a', 'user-1') // cache false
+
+      await service.setOverride('my-flag', 'tenant-a', 'user-1', true)
+
+      // Post-override the cache entry is gone; next call goes to store
+      vi.mocked(store.listOverrides).mockResolvedValue([override])
+      const result = await service.isEnabled('my-flag', 'tenant-a', 'user-1')
+
+      expect(result).toBe(true)
+      expect(featureFlagCacheInvalidations.inc).toHaveBeenCalledWith({
+        tenant_id: 'tenant-a',
+        flag_key: 'my-flag',
+      })
+    })
+
+    it('override added after a cached miss is honoured on next isEnabled call', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: false }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+
+      // First call: no override → false is cached
+      const before = await service.isEnabled('my-flag', 'tenant-a', 'user-42')
+      expect(before).toBe(false)
+
+      const override: FlagOverride = {
+        flagKey: 'my-flag',
+        tenantId: 'tenant-a',
+        userId: 'user-42',
+        enabled: true,
+      }
+      vi.mocked(store.setOverride).mockResolvedValue(override)
+
+      // Add override — must bust the user-42 cache entry
+      await service.setOverride('my-flag', 'tenant-a', 'user-42', true)
+
+      vi.mocked(store.listOverrides).mockResolvedValue([override])
+      const after = await service.isEnabled('my-flag', 'tenant-a', 'user-42')
+      expect(after).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // bustFlag
+  // -------------------------------------------------------------------------
+
+  describe('bustFlag', () => {
+    it('evicts all tenant-scoped entries for a flag key', async () => {
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+
+      // Populate multiple entries: base + two user-scoped
+      await service.isEnabled('my-flag', 'tenant-a')
+      await service.isEnabled('my-flag', 'tenant-a', 'user-1')
+      await service.isEnabled('my-flag', 'tenant-a', 'user-2')
+
+      service.bustFlag('my-flag', 'tenant-a')
+
+      // All three should miss and go to store again
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: false }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+
+      await service.isEnabled('my-flag', 'tenant-a')
+      await service.isEnabled('my-flag', 'tenant-a', 'user-1')
+      await service.isEnabled('my-flag', 'tenant-a', 'user-2')
+
+      // 3 initial misses + 3 post-bust misses = 6 total getFlag calls
+      // (listOverrides is called for user-scoped evaluations)
+      expect(store.getFlag).toHaveBeenCalledTimes(6)
+    })
+
+    it('does not emit invalidation metric when no entries were evicted', async () => {
+      service.bustFlag('nonexistent-flag', 'tenant-a')
+      expect(featureFlagCacheInvalidations.inc).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // User-level overrides
+  // -------------------------------------------------------------------------
+
+  describe('user-level override evaluation', () => {
+    it('uses override value when a matching override exists', async () => {
+      const override: FlagOverride = {
+        flagKey: 'my-flag',
+        tenantId: 'tenant-a',
+        userId: 'user-1',
+        enabled: false,
+      }
+      vi.mocked(store.listOverrides).mockResolvedValue([override])
+
+      const result = await service.isEnabled('my-flag', 'tenant-a', 'user-1')
+      expect(result).toBe(false)
+      expect(store.getFlag).not.toHaveBeenCalled() // override short-circuits
+    })
+
+    it('falls back to flag default when no override matches the user', async () => {
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+
+      const result = await service.isEnabled('my-flag', 'tenant-a', 'user-99')
+      expect(result).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Disabled cache mode
+  // -------------------------------------------------------------------------
+
+  describe('disabled cache', () => {
+    it('always fetches from store when cache is disabled', async () => {
+      const noCache = new FeatureFlagService(store, { disabled: true })
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+
+      await noCache.isEnabled('my-flag', 'tenant-a')
+      await noCache.isEnabled('my-flag', 'tenant-a')
+
+      expect(store.getFlag).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Pass-through admin methods
+  // -------------------------------------------------------------------------
+
+  describe('getFlag / listFlags / listFlagsWithOverrides', () => {
+    it('getFlag delegates directly to the store', async () => {
+      const flag = makeFlag()
+      vi.mocked(store.getFlag).mockResolvedValue(flag)
+
+      const result = await service.getFlag('my-flag', 'tenant-a')
+      expect(result).toEqual(flag)
+      expect(store.getFlag).toHaveBeenCalledWith('my-flag', 'tenant-a')
+    })
+
+    it('listFlags delegates directly to the store', async () => {
+      const flags = [makeFlag()]
+      vi.mocked(store.listFlags).mockResolvedValue(flags)
+
+      const result = await service.listFlags('tenant-a')
+      expect(result).toEqual(flags)
+    })
+
+    it('listFlagsWithOverrides returns flag + overrides together', async () => {
+      const flag = makeFlag()
+      const overrides: FlagOverride[] = [
+        { flagKey: 'my-flag', tenantId: 'tenant-a', userId: 'u1', enabled: false },
+      ]
+      vi.mocked(store.getFlag).mockResolvedValue(flag)
+      vi.mocked(store.listOverrides).mockResolvedValue(overrides)
+
+      const result = await service.listFlagsWithOverrides('my-flag', 'tenant-a')
+      expect(result).toEqual({ flag, overrides })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // maxSize eviction
+  // -------------------------------------------------------------------------
+
+  describe('maxSize eviction', () => {
+    it('evicts oldest entry when cache is full', async () => {
+      const tiny = new FeatureFlagService(store, { ttlMs: 60_000, maxSize: 2 })
+      vi.mocked(store.getFlag).mockResolvedValue(makeFlag({ enabled: true }))
+      vi.mocked(store.listOverrides).mockResolvedValue([])
+
+      // Fill the cache to max
+      await tiny.isEnabled('flag-1', 'tenant-a')
+      await tiny.isEnabled('flag-2', 'tenant-a')
+
+      // Adding a third should evict flag-1
+      await tiny.isEnabled('flag-3', 'tenant-a')
+
+      // flag-1 should be a miss again
+      const callsBefore = vi.mocked(store.getFlag).mock.calls.length
+      await tiny.isEnabled('flag-1', 'tenant-a')
+      expect(vi.mocked(store.getFlag).mock.calls.length).toBe(callsBefore + 1)
+    })
+  })
+})

--- a/src/services/featureFlags/index.ts
+++ b/src/services/featureFlags/index.ts
@@ -1,0 +1,301 @@
+/**
+ * Feature flag evaluation service with in-process TTL cache.
+ *
+ * Cache semantics:
+ * - Keys are tenant-scoped: `${tenantId}:${flagKey}[:${userId}]`
+ * - Never shares entries across tenants (cross-tenant leakage prevention)
+ * - Entries expire after `ttlMs` milliseconds (default 30 s)
+ * - Any flag or override mutation invalidates all affected keys before returning
+ *
+ * Invalidation bus integration:
+ * Call `service.bustFlag(flagKey, tenantId)` from the external invalidation bus
+ * (e.g. src/cache/invalidationBus.ts) to evict all cached evaluations for a
+ * (flagKey, tenantId) pair without requiring a full cache flush.
+ */
+
+import client from 'prom-client'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FeatureFlag {
+  key: string
+  enabled: boolean
+  description?: string
+  tenantId: string
+}
+
+export interface FlagOverride {
+  flagKey: string
+  tenantId: string
+  userId: string
+  enabled: boolean
+}
+
+export interface UpdateFlagInput {
+  enabled?: boolean
+  description?: string
+}
+
+export interface FeatureFlagStore {
+  getFlag(flagKey: string, tenantId: string): Promise<FeatureFlag | null>
+  listFlags(tenantId: string): Promise<FeatureFlag[]>
+  updateFlag(flagKey: string, tenantId: string, input: UpdateFlagInput): Promise<FeatureFlag | null>
+  listOverrides(flagKey: string, tenantId: string): Promise<FlagOverride[]>
+  setOverride(flagKey: string, tenantId: string, userId: string, enabled: boolean): Promise<FlagOverride>
+}
+
+export interface FeatureFlagCacheOptions {
+  /** Entry TTL in milliseconds. Default: 30_000 (30 s). */
+  ttlMs?: number
+  /** Maximum number of cache entries. Oldest entries evicted when exceeded. Default: 1_000. */
+  maxSize?: number
+  /** Set to true to disable caching entirely (useful in tests). Default: false. */
+  disabled?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+export const featureFlagCacheHits = new client.Counter({
+  name: 'feature_flag_cache_hits_total',
+  help: 'Total number of feature flag evaluation cache hits',
+  labelNames: ['tenant_id', 'flag_key'],
+})
+
+export const featureFlagCacheMisses = new client.Counter({
+  name: 'feature_flag_cache_misses_total',
+  help: 'Total number of feature flag evaluation cache misses',
+  labelNames: ['tenant_id', 'flag_key'],
+})
+
+export const featureFlagCacheInvalidations = new client.Counter({
+  name: 'feature_flag_cache_invalidations_total',
+  help: 'Total number of feature flag cache invalidation events',
+  labelNames: ['tenant_id', 'flag_key'],
+})
+
+// ---------------------------------------------------------------------------
+// Internal TTL cache (Map-based, no external dependencies)
+// ---------------------------------------------------------------------------
+
+interface CacheEntry<T> {
+  value: T
+  expiresAt: number
+}
+
+class TtlCache<T> {
+  private readonly store = new Map<string, CacheEntry<T>>()
+  private readonly maxSize: number
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.store.get(key)
+    if (!entry) return undefined
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key)
+      return undefined
+    }
+    return entry.value
+  }
+
+  set(key: string, value: T, ttlMs: number): void {
+    // Evict oldest entry when at capacity
+    if (this.store.size >= this.maxSize && !this.store.has(key)) {
+      const oldest = this.store.keys().next().value
+      if (oldest !== undefined) this.store.delete(oldest)
+    }
+    this.store.set(key, { value, expiresAt: Date.now() + ttlMs })
+  }
+
+  /** Delete all keys that match a prefix. */
+  deleteByPrefix(prefix: string): number {
+    let count = 0
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key)
+        count++
+      }
+    }
+    return count
+  }
+
+  delete(key: string): boolean {
+    return this.store.delete(key)
+  }
+
+  clear(): void {
+    this.store.clear()
+  }
+
+  get size(): number {
+    return this.store.size
+  }
+}
+
+// ---------------------------------------------------------------------------
+// FeatureFlagService
+// ---------------------------------------------------------------------------
+
+export class FeatureFlagService {
+  private readonly cache: TtlCache<boolean>
+  private readonly ttlMs: number
+  private readonly cacheDisabled: boolean
+
+  constructor(
+    private readonly store: FeatureFlagStore,
+    options: FeatureFlagCacheOptions = {},
+  ) {
+    this.ttlMs = options.ttlMs ?? 30_000
+    this.cacheDisabled = options.disabled ?? false
+    this.cache = new TtlCache<boolean>(options.maxSize ?? 1_000)
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Check whether a feature flag is enabled for a given tenant/user context.
+   *
+   * Evaluation order:
+   * 1. User-level override (if userId provided)
+   * 2. Flag default for the tenant
+   *
+   * Results are cached per (tenantId, flagKey, userId?) for `ttlMs` ms.
+   */
+  async isEnabled(flagKey: string, tenantId: string, userId?: string): Promise<boolean> {
+    const cacheKey = this._evalKey(flagKey, tenantId, userId)
+
+    if (!this.cacheDisabled) {
+      const cached = this.cache.get(cacheKey)
+      if (cached !== undefined) {
+        featureFlagCacheHits.inc({ tenant_id: tenantId, flag_key: flagKey })
+        return cached
+      }
+    }
+
+    featureFlagCacheMisses.inc({ tenant_id: tenantId, flag_key: flagKey })
+
+    const result = await this._evaluate(flagKey, tenantId, userId)
+
+    if (!this.cacheDisabled) {
+      this.cache.set(cacheKey, result, this.ttlMs)
+    }
+
+    return result
+  }
+
+  /**
+   * Retrieve a single flag definition for a tenant (uncached — admin read).
+   */
+  async getFlag(flagKey: string, tenantId: string): Promise<FeatureFlag | null> {
+    return this.store.getFlag(flagKey, tenantId)
+  }
+
+  /**
+   * List all flag definitions for a tenant (uncached — admin read).
+   */
+  async listFlags(tenantId: string): Promise<FeatureFlag[]> {
+    return this.store.listFlags(tenantId)
+  }
+
+  /**
+   * Update a flag and invalidate all cached evaluations for that flag/tenant
+   * before returning so callers immediately see the new state.
+   */
+  async updateFlag(
+    flagKey: string,
+    tenantId: string,
+    input: UpdateFlagInput,
+  ): Promise<FeatureFlag | null> {
+    const result = await this.store.updateFlag(flagKey, tenantId, input)
+    this.bustFlag(flagKey, tenantId)
+    return result
+  }
+
+  /**
+   * List all overrides for a flag/tenant combination (uncached — admin read).
+   */
+  async listFlagsWithOverrides(
+    flagKey: string,
+    tenantId: string,
+  ): Promise<{ flag: FeatureFlag | null; overrides: FlagOverride[] }> {
+    const [flag, overrides] = await Promise.all([
+      this.store.getFlag(flagKey, tenantId),
+      this.store.listOverrides(flagKey, tenantId),
+    ])
+    return { flag, overrides }
+  }
+
+  /**
+   * Set a per-user override and invalidate the cached evaluation for that
+   * specific (tenantId, flagKey, userId) triple before returning.
+   */
+  async setOverride(
+    flagKey: string,
+    tenantId: string,
+    userId: string,
+    enabled: boolean,
+  ): Promise<FlagOverride> {
+    const result = await this.store.setOverride(flagKey, tenantId, userId, enabled)
+    // Invalidate the specific user-scoped entry
+    this.cache.delete(this._evalKey(flagKey, tenantId, userId))
+    featureFlagCacheInvalidations.inc({ tenant_id: tenantId, flag_key: flagKey })
+    return result
+  }
+
+  /**
+   * Evict all cached evaluations for a (flagKey, tenantId) pair.
+   *
+   * Called by updateFlag / override mutations and can also be triggered
+   * externally by the invalidation bus (src/cache/invalidationBus.ts).
+   */
+  bustFlag(flagKey: string, tenantId: string): void {
+    const prefix = this._tenantFlagPrefix(flagKey, tenantId)
+    const evicted = this.cache.deleteByPrefix(prefix)
+    if (evicted > 0) {
+      featureFlagCacheInvalidations.inc({ tenant_id: tenantId, flag_key: flagKey })
+    }
+  }
+
+  /** Flush the entire cache (e.g., on graceful shutdown or testing). */
+  clearCache(): void {
+    this.cache.clear()
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private async _evaluate(
+    flagKey: string,
+    tenantId: string,
+    userId?: string,
+  ): Promise<boolean> {
+    if (userId) {
+      const overrides = await this.store.listOverrides(flagKey, tenantId)
+      const override = overrides.find(o => o.userId === userId)
+      if (override !== undefined) return override.enabled
+    }
+    const flag = await this.store.getFlag(flagKey, tenantId)
+    return flag?.enabled ?? false
+  }
+
+  /** Cache key for an isEnabled evaluation. Tenant-scoped. */
+  private _evalKey(flagKey: string, tenantId: string, userId?: string): string {
+    return userId
+      ? `${tenantId}:${flagKey}:${userId}`
+      : `${tenantId}:${flagKey}`
+  }
+
+  /** Prefix shared by all evaluations for a (flagKey, tenantId) pair. */
+  private _tenantFlagPrefix(flagKey: string, tenantId: string): string {
+    return `${tenantId}:${flagKey}`
+  }
+}


### PR DESCRIPTION
## Summary

Closes #639

Adds an in-process TTL evaluation cache to `FeatureFlagService` so that hot-path `isEnabled` calls avoid repeated backing-store reads.

## Changes

### `src/services/featureFlags/index.ts`
- **`TtlCache<T>`** – lightweight `Map`-based cache with per-entry TTL and LRU-style max-size eviction (no new dependencies).
- **`FeatureFlagService`** – wraps a `FeatureFlagStore` with:
  - `isEnabled(flagKey, tenantId, userId?)` – cached; key is `tenantId:flagKey[:userId]` (cross-tenant leakage is impossible by construction)
  - `updateFlag` – calls `store.updateFlag` then `bustFlag` before returning (correctness over speed)
  - `setOverride` – calls `store.setOverride` then evicts the user-scoped cache entry
  - `bustFlag(flagKey, tenantId)` – evicts all entries under the `tenantId:flagKey` prefix; callable from the invalidation bus (`src/cache/invalidationBus.ts`)
  - `clearCache()` – full flush (shutdown / testing)
- **Metrics** (prom-client Counters with `tenant_id` + `flag_key` labels):
  - `feature_flag_cache_hits_total`
  - `feature_flag_cache_misses_total`
  - `feature_flag_cache_invalidations_total`
- **Cache options**: `ttlMs` (default 30 s), `maxSize` (default 1 000), `disabled` flag

### `src/services/featureFlags/index.test.ts`
Vitest suite covering:
- Cache miss → store fetch → cache hit (no second store call)
- TTL expiry (fake timers): re-fetches after TTL, serves from cache before boundary
- Two-tenant isolation: separate entries, busting one tenant doesn't affect the other
- `updateFlag` invalidates base and user-scoped entries
- `setOverride` invalidates the specific user entry; override added after a cached miss is honoured immediately
- `bustFlag` evicts all scoped entries; no metric emitted when nothing was evicted
- User-level override evaluation (override wins over flag default; falls back when absent)
- Disabled cache: every call goes to store
- `maxSize` eviction: oldest entry is dropped when capacity is reached
- Pass-through admin methods: `getFlag`, `listFlags`, `listFlagsWithOverrides`

### `src/observability/index.ts`
Re-exports `featureFlagCacheHits`, `featureFlagCacheMisses`, `featureFlagCacheInvalidations`.

## Testing

```
npm run test -- featureFlags
npm run lint
npm run build
```

## Notes

- `lru-cache` is not in `package.json`; the implementation uses a plain `Map` which satisfies the same requirements with zero new dependencies.
- Invalidation happens **before** the mutating method returns, satisfying the "correctness over speed" requirement.