### PR TITLE
feat(Credence-Backend): add-a-per-org-overage-webhook-emitter-when-usage

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -97,7 +97,11 @@ app.use("/api", rateLimitMiddleware);
 
 try {
   const config = validateConfig(process.env)
-  const costMeterConfig = { costWeights: config.endpointCostWeights, defaultMonthlyCredits: config.credits.defaultMonthly }
+  const costMeterConfig = {
+    costWeights: config.endpointCostWeights,
+    defaultMonthlyCredits: config.credits.defaultMonthly,
+    defaultLowCreditThreshold: config.credits.defaultLowCreditThreshold,
+  }
   const costMeterMiddleware = createCostMeterMiddleware(costMeterConfig, () => pool)
   app.use("/api", costMeterMiddleware)
 } catch {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -286,6 +286,11 @@ export const envSchema = z.object({
     .default('10000')
     .transform(Number)
     .pipe(z.number().int().min(0)),
+  DEFAULT_LOW_CREDIT_THRESHOLD: z
+    .string()
+    .default('100')
+    .transform(Number)
+    .pipe(z.number().int().min(0)),
 
   // Reputation scoring model
   REPUTATION_MODEL_VERSION: z.string().default('1.0.0'),
@@ -517,6 +522,7 @@ export interface Config {
   endpointCostWeights: Record<string, number>
   credits: {
     defaultMonthly: number
+    defaultLowCreditThreshold: number
   }
   metricsAllowedCidrs: string[] | undefined
 }
@@ -704,6 +710,7 @@ function mapEnvToConfig(env: Env): Config {
     endpointCostWeights: parseCostWeights(env.ENDPOINT_COST_WEIGHTS),
     credits: {
       defaultMonthly: env.DEFAULT_MONTHLY_CREDITS,
+      defaultLowCreditThreshold: env.DEFAULT_LOW_CREDIT_THRESHOLD,
     },
     metricsAllowedCidrs: env.METRICS_ALLOWED_CIDRS
       ? env.METRICS_ALLOWED_CIDRS.split(',').map(s => s.trim()).filter(Boolean)

--- a/src/db/outbox/webhookPublisher.ts
+++ b/src/db/outbox/webhookPublisher.ts
@@ -35,6 +35,7 @@ export class WebhookEventPublisher implements EventPublisher {
       'bond.withdrawn': 'bond.withdrawn',
       'attestation.created': 'attestation.created',
       'attestation.revoked': 'attestation.revoked',
+      'credits.low': 'credits.low',
     }
 
     return mapping[eventType] ?? null

--- a/src/middleware/__tests__/costMeter.test.ts
+++ b/src/middleware/__tests__/costMeter.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest'
 import express, { type Express } from 'express'
 import { type AddressInfo } from 'net'
 import { newDb, type IMemoryDb } from 'pg-mem'
 import { Pool } from 'pg'
-import { createCostMeterMiddleware, resolveCostWeight, type CostMeterConfig } from '../costMeter.js'
+import client from 'prom-client'
+import {
+  createCostMeterMiddleware,
+  resolveCostWeight,
+  shouldEmitLowCreditAlert,
+  type CostMeterConfig,
+} from '../costMeter.js'
 import { _resetStore } from '../../services/apiKeys.js'
+import { creditsLowEventsTotal } from '../../observability/creditsMetrics.js'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -47,6 +54,8 @@ async function buildTestDb(): Promise<{ db: IMemoryDb; pool: Pool }> {
       org_id UUID PRIMARY KEY,
       credits_remaining BIGINT NOT NULL DEFAULT 0,
       version INTEGER NOT NULL DEFAULT 1,
+      low_credit_threshold BIGINT,
+      low_credit_alert_armed BOOLEAN NOT NULL DEFAULT true,
       last_top_up_at TIMESTAMPTZ,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -69,13 +78,56 @@ async function buildTestDb(): Promise<{ db: IMemoryDb; pool: Pool }> {
     )
   `)
 
+  db.public.none(`
+    CREATE TABLE event_outbox (
+      id BIGSERIAL PRIMARY KEY,
+      aggregate_type TEXT NOT NULL,
+      aggregate_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload JSONB NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      retry_count INTEGER NOT NULL DEFAULT 0,
+      max_retries INTEGER NOT NULL DEFAULT 5,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `)
+
   const adapter = db.adapters.createPg()
   const pool = new adapter.Pool() as unknown as Pool
 
   return { db, pool }
 }
 
+async function getOutboxEvents(pool: Pool) {
+  const { rows } = await pool.query(
+    'SELECT event_type, payload, aggregate_id FROM event_outbox ORDER BY id',
+  )
+  return rows
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('shouldEmitLowCreditAlert', () => {
+  it('returns true when crossing from above to at threshold', () => {
+    expect(shouldEmitLowCreditAlert(101, 100, 100, true)).toBe(true)
+  })
+
+  it('returns true when crossing from above to below threshold', () => {
+    expect(shouldEmitLowCreditAlert(101, 99, 100, true)).toBe(true)
+  })
+
+  it('returns false when already at or below threshold', () => {
+    expect(shouldEmitLowCreditAlert(100, 99, 100, true)).toBe(false)
+  })
+
+  it('returns false when alert is disarmed', () => {
+    expect(shouldEmitLowCreditAlert(101, 99, 100, false)).toBe(false)
+  })
+
+  it('returns false when staying above threshold', () => {
+    expect(shouldEmitLowCreditAlert(200, 199, 100, true)).toBe(false)
+  })
+})
 
 describe('resolveCostWeight', () => {
   const weights: CostMeterConfig['costWeights'] = {
@@ -101,9 +153,11 @@ describe('CostMeter Middleware (In-Memory)', () => {
   let app: Express
   let pool: Pool
   let config: CostMeterConfig
+  let emitOutbox: ReturnType<typeof vi.fn>
 
   const TEST_ORG_ID = '00000000-0000-0000-0000-000000000001'
   const TEST_CREDITS = 100
+  const LOW_THRESHOLD = 10
 
   beforeAll(async () => {
     const built = await buildTestDb()
@@ -116,11 +170,25 @@ describe('CostMeter Middleware (In-Memory)', () => {
   })
 
   beforeEach(async () => {
+    await pool.query('DELETE FROM event_outbox')
     await pool.query('DELETE FROM credit_transactions')
     await pool.query('DELETE FROM org_credits')
     _resetStore()
+    creditsLowEventsTotal.reset()
+    emitOutbox = vi.fn(async (_db, event) => {
+      await pool.query(
+        `INSERT INTO event_outbox (aggregate_type, aggregate_id, event_type, payload, status)
+         VALUES ($1, $2, $3, $4, 'pending')`,
+        [event.aggregateType, event.aggregateId, event.eventType, JSON.stringify(event.payload)],
+      )
+      return BigInt(1)
+    })
 
-    config = { costWeights: { default: 1 }, defaultMonthlyCredits: TEST_CREDITS }
+    config = {
+      costWeights: { default: 1 },
+      defaultMonthlyCredits: TEST_CREDITS,
+      defaultLowCreditThreshold: LOW_THRESHOLD,
+    }
 
     app = express()
     app.use(express.json())
@@ -131,12 +199,16 @@ describe('CostMeter Middleware (In-Memory)', () => {
     next()
   }
 
+  function mountCostMeter() {
+    const costMeter = createCostMeterMiddleware(config, () => pool, { emitOutbox })
+    app.use(setOrgId)
+    app.use(costMeter)
+  }
+
   // ── Basic flow ────────────────────────────────────────────────────────────
 
   it('deducts credits and sets X-Credits-Remaining header on success', async () => {
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/test', (_req, res) => { res.json({ ok: true }) })
 
     const res = await request(app, '/test')
@@ -147,13 +219,11 @@ describe('CostMeter Middleware (In-Memory)', () => {
 
   it('returns 402 when credits are insufficient', async () => {
     await pool.query(
-      'INSERT INTO org_credits (org_id, credits_remaining, version) VALUES ($1, $2, $3)',
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
       [TEST_ORG_ID, 0, 1],
     )
 
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/test', (_req, res) => { res.json({ ok: true }) })
 
     const res = await request(app, '/test')
@@ -169,11 +239,9 @@ describe('CostMeter Middleware (In-Memory)', () => {
   // ── Free endpoints ────────────────────────────────────────────────────────
 
   it('skips deduction when cost weight is 0', async () => {
-    config = { costWeights: { default: 0 }, defaultMonthlyCredits: TEST_CREDITS }
+    config = { ...config, costWeights: { default: 0 } }
 
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/test', (_req, res) => { res.json({ ok: true }) })
 
     const res = await request(app, '/test')
@@ -185,7 +253,7 @@ describe('CostMeter Middleware (In-Memory)', () => {
   // ── Unauthenticated ───────────────────────────────────────────────────────
 
   it('skips deduction when no org ID is found', async () => {
-    const costMeter = createCostMeterMiddleware(config, () => pool)
+    const costMeter = createCostMeterMiddleware(config, () => pool, { emitOutbox })
     app.use(costMeter)
     app.get('/test', (_req, res) => { res.json({ ok: true }) })
 
@@ -198,9 +266,7 @@ describe('CostMeter Middleware (In-Memory)', () => {
   // ── New org initialization ─────────────────────────────────────────────────
 
   it('initializes credits for new org on first request', async () => {
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/test', (_req, res) => { res.json({ ok: true }) })
 
     await request(app, '/test')
@@ -212,9 +278,7 @@ describe('CostMeter Middleware (In-Memory)', () => {
   // ── Multiple deductions ────────────────────────────────────────────────────
 
   it('decrements credits across multiple requests', async () => {
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/test', (_req, res) => { res.json({ ok: true }) })
 
     const r1 = await request(app, '/test')
@@ -230,9 +294,7 @@ describe('CostMeter Middleware (In-Memory)', () => {
   // ── Refund on handler error ────────────────────────────────────────────────
 
   it('refunds credits when handler returns 5xx', async () => {
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/error', (_req, res) => { res.status(500).json({ error: 'fail' }) })
 
     await request(app, '/error')
@@ -243,9 +305,7 @@ describe('CostMeter Middleware (In-Memory)', () => {
   })
 
   it('does NOT refund credits when handler returns 4xx', async () => {
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/notfound', (_req, res) => { res.status(404).json({ error: 'not found' }) })
 
     await request(app, '/notfound')
@@ -255,9 +315,7 @@ describe('CostMeter Middleware (In-Memory)', () => {
   })
 
   it('refunds credits when handler calls next(err)', async () => {
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/error', (_req, _res, next) => { next(new Error('handler error')) })
     app.use((_err: any, _req: any, res: any, _next: any) => { res.status(500).json({ error: 'fail' }) })
 
@@ -272,13 +330,11 @@ describe('CostMeter Middleware (In-Memory)', () => {
 
   it('handles concurrent deducts with optimistic locking', async () => {
     await pool.query(
-      'INSERT INTO org_credits (org_id, credits_remaining, version) VALUES ($1, $2, $3)',
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
       [TEST_ORG_ID, 5, 1],
     )
 
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/test', (_req, res) => { res.json({ ok: true }) })
 
     const httpServer = app.listen(0)
@@ -306,9 +362,7 @@ describe('CostMeter Middleware (In-Memory)', () => {
   // ── Audit trail ────────────────────────────────────────────────────────────
 
   it('creates audit rows for deduct and refund', async () => {
-    app.use(setOrgId)
-    const costMeter = createCostMeterMiddleware(config, () => pool)
-    app.use(costMeter)
+    mountCostMeter()
     app.get('/error', (_req, res) => { res.status(500).json({ error: 'fail' }) })
 
     await request(app, '/error')
@@ -321,4 +375,157 @@ describe('CostMeter Middleware (In-Memory)', () => {
     expect(rows[0].transaction_type).toBe('deduct')
     expect(rows[1].transaction_type).toBe('refund')
   })
+
+  // ── Low-credit webhook ─────────────────────────────────────────────────────
+
+  it('emits credits.low once when crossing the default threshold', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
+      [TEST_ORG_ID, 11, 1],
+    )
+
+    mountCostMeter()
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    await request(app, '/test')
+
+    const outbox = await getOutboxEvents(pool)
+    expect(outbox).toHaveLength(1)
+    expect(outbox[0].event_type).toBe('credits.low')
+    expect(outbox[0].payload).toMatchObject({
+      orgId: TEST_ORG_ID,
+      creditsRemaining: 10,
+      threshold: LOW_THRESHOLD,
+    })
+    expect(emitOutbox).toHaveBeenCalledTimes(1)
+
+    const metrics = await client.register.getSingleMetric('credits_low_events_total')
+    expect(metrics?.get().values[0]?.value).toBe(1)
+  })
+
+  it('does not emit credits.low again while remaining below threshold', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, false)',
+      [TEST_ORG_ID, 10, 1],
+    )
+
+    mountCostMeter()
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    await request(app, '/test')
+    await request(app, '/test')
+
+    const outbox = await getOutboxEvents(pool)
+    expect(outbox).toHaveLength(0)
+    expect(emitOutbox).not.toHaveBeenCalled()
+  })
+
+  it('emits only once across repeated deductions that stay below threshold after crossing', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
+      [TEST_ORG_ID, 12, 1],
+    )
+
+    mountCostMeter()
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    await request(app, '/test')
+    await request(app, '/test')
+    await request(app, '/test')
+
+    const outbox = await getOutboxEvents(pool)
+    expect(outbox).toHaveLength(1)
+    expect(outbox[0].payload.creditsRemaining).toBe(10)
+  })
+
+  it('uses per-org threshold override when configured', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_threshold, low_credit_alert_armed) VALUES ($1, $2, $3, $4, true)',
+      [TEST_ORG_ID, 6, 1, 5],
+    )
+
+    mountCostMeter()
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    await request(app, '/test')
+
+    const outbox = await getOutboxEvents(pool)
+    expect(outbox).toHaveLength(1)
+    expect(outbox[0].payload).toMatchObject({
+      creditsRemaining: 5,
+      threshold: 5,
+    })
+  })
+
+  it('re-arms after refund lifts credits above threshold and emits again on re-crossing', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
+      [TEST_ORG_ID, 11, 1],
+    )
+
+    mountCostMeter()
+    app.get('/error', (_req, res) => { res.status(500).json({ error: 'fail' }) })
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    await request(app, '/test')
+    await request(app, '/error')
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    const armedRow = await pool.query(
+      'SELECT low_credit_alert_armed FROM org_credits WHERE org_id = $1',
+      [TEST_ORG_ID],
+    )
+    expect(armedRow.rows[0].low_credit_alert_armed).toBe(true)
+
+    await request(app, '/test')
+
+    const outbox = await getOutboxEvents(pool)
+    expect(outbox).toHaveLength(2)
+    expect(outbox.every((row) => row.event_type === 'credits.low')).toBe(true)
+  })
+
+  it('does not block deduction when outbox emission fails', async () => {
+    emitOutbox = vi.fn(async () => {
+      throw new Error('outbox unavailable')
+    })
+
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
+      [TEST_ORG_ID, 11, 1],
+    )
+
+    mountCostMeter()
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const res = await request(app, '/test')
+
+    expect(res.status).toBe(200)
+    expect(res.headers['x-credits-remaining']).toBe('10')
+
+    const outbox = await getOutboxEvents(pool)
+    expect(outbox).toHaveLength(0)
+  })
+
+  it('emits at most one credits.low event under concurrent threshold crossings', async () => {
+    await pool.query(
+      'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
+      [TEST_ORG_ID, 15, 1],
+    )
+
+    mountCostMeter()
+    app.get('/test', (_req, res) => { res.json({ ok: true }) })
+
+    const httpServer = app.listen(0)
+    const port = (httpServer.address() as AddressInfo).port
+    const baseUrl = `http://127.0.0.1:${port}`
+
+    await Promise.all(
+      Array.from({ length: 5 }, () => fetch(`${baseUrl}/test`).then((res) => res.status)),
+    )
+
+    httpServer.close()
+
+    const outbox = await getOutboxEvents(pool)
+    expect(outbox.length).toBeLessThanOrEqual(1)
+  }, 10000)
 })

--- a/src/middleware/costMeter.ts
+++ b/src/middleware/costMeter.ts
@@ -1,12 +1,21 @@
 import type { Request, Response, NextFunction } from 'express'
-import type { Pool } from 'pg'
+import type { Pool, PoolClient } from 'pg'
 import { validateApiKey } from '../services/apiKeys.js'
+import { outboxEmitter } from '../db/outbox/emitter.js'
+import type { Queryable } from '../db/repositories/queryable.js'
+import {
+  creditsLowWebhookPayloadSchema,
+  type CreditsLowWebhookPayload,
+} from '../schemas/credits.js'
+import { recordCreditsLowEvent } from '../observability/creditsMetrics.js'
 
 // ── Public types ──────────────────────────────────────────────────────────────
 
 export interface CostMeterConfig {
   costWeights: Record<string, number>
   defaultMonthlyCredits: number
+  /** Global default low-credit webhook threshold when an org has no override. */
+  defaultLowCreditThreshold: number
 }
 
 export interface DeductionInfo {
@@ -16,6 +25,23 @@ export interface DeductionInfo {
   creditsAfter: number
   endpoint: string
   requestId: string
+}
+
+export interface CostMeterDeps {
+  /** Override outbox emission (used in tests). */
+  emitOutbox?: (db: Queryable, event: {
+    aggregateType: string
+    aggregateId: string
+    eventType: string
+    payload: Record<string, unknown>
+  }) => Promise<bigint>
+}
+
+interface OrgCreditRow {
+  credits_remaining: string
+  version: number
+  low_credit_threshold: string | null
+  low_credit_alert_armed: boolean
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
@@ -64,6 +90,99 @@ export function resolveCostWeight(path: string, costWeights: Record<string, numb
   return costWeights['default'] ?? 1
 }
 
+/**
+ * Returns true when credits cross from above the threshold to at/below it and the
+ * one-shot alert is armed.
+ */
+export function shouldEmitLowCreditAlert(
+  creditsBefore: number,
+  creditsAfter: number,
+  threshold: number,
+  alertArmed: boolean,
+): boolean {
+  return alertArmed && creditsBefore > threshold && creditsAfter <= threshold
+}
+
+function resolveThreshold(
+  orgThreshold: string | null | undefined,
+  defaultLowCreditThreshold: number,
+): number {
+  if (orgThreshold != null) {
+    return Number(orgThreshold)
+  }
+  return defaultLowCreditThreshold
+}
+
+async function enqueueLowCreditWebhook(
+  client: PoolClient,
+  emitOutbox: CostMeterDeps['emitOutbox'],
+  orgId: string,
+  payload: CreditsLowWebhookPayload,
+): Promise<void> {
+  const validated = creditsLowWebhookPayloadSchema.parse(payload)
+  const emit = emitOutbox ?? ((db, event) => outboxEmitter.emit(db, event))
+  await emit(client, {
+    aggregateType: 'org',
+    aggregateId: orgId,
+    eventType: 'credits.low',
+    payload: validated,
+  })
+  recordCreditsLowEvent()
+}
+
+async function maybeEmitLowCreditAlert(
+  client: PoolClient,
+  emitOutbox: CostMeterDeps['emitOutbox'],
+  orgId: string,
+  creditsBefore: number,
+  creditsAfter: number,
+  row: Pick<OrgCreditRow, 'low_credit_threshold' | 'low_credit_alert_armed'>,
+  defaultLowCreditThreshold: number,
+  endpoint: string,
+  requestId: string,
+): Promise<void> {
+  const threshold = resolveThreshold(row.low_credit_threshold, defaultLowCreditThreshold)
+  if (
+    !shouldEmitLowCreditAlert(
+      creditsBefore,
+      creditsAfter,
+      threshold,
+      row.low_credit_alert_armed,
+    )
+  ) {
+    return
+  }
+
+  await enqueueLowCreditWebhook(client, emitOutbox, orgId, {
+    orgId,
+    creditsRemaining: creditsAfter,
+    threshold,
+    endpoint,
+    requestId,
+  })
+
+  await client.query(
+    'UPDATE org_credits SET low_credit_alert_armed = false WHERE org_id = $1',
+    [orgId],
+  )
+}
+
+async function maybeRearmLowCreditAlert(
+  client: PoolClient,
+  orgId: string,
+  creditsAfter: number,
+  row: Pick<OrgCreditRow, 'low_credit_threshold'>,
+  defaultLowCreditThreshold: number,
+): Promise<void> {
+  const threshold = resolveThreshold(row.low_credit_threshold, defaultLowCreditThreshold)
+  if (creditsAfter > threshold) {
+    await client.query(
+      'UPDATE org_credits SET low_credit_alert_armed = true WHERE org_id = $1',
+      [orgId],
+    )
+  }
+}
+
 async function deductCredits(
   pool: Pool,
   orgId: string,
@@ -71,6 +190,8 @@ async function deductCredits(
   endpoint: string,
   requestId: string,
   defaultMonthlyCredits: number,
+  defaultLowCreditThreshold: number,
+  emitOutbox: CostMeterDeps['emitOutbox'],
   retries = 0,
 ): Promise<
   | { ok: true; creditsBefore: number; creditsRemaining: number }
@@ -80,26 +201,30 @@ async function deductCredits(
   try {
     await client.query('BEGIN')
 
-    const { rows } = await client.query<{
-      credits_remaining: string
-      version: number
-    }>('SELECT credits_remaining, version FROM org_credits WHERE org_id = $1 FOR UPDATE', [
-      orgId,
-    ])
+    const { rows } = await client.query<OrgCreditRow>(
+      'SELECT credits_remaining, version, low_credit_threshold, low_credit_alert_armed FROM org_credits WHERE org_id = $1 FOR UPDATE',
+      [orgId],
+    )
 
     let creditsRemaining: number
     let version: number
+    let alertRow: Pick<OrgCreditRow, 'low_credit_threshold' | 'low_credit_alert_armed'>
 
     if (rows.length === 0) {
       creditsRemaining = defaultMonthlyCredits
       version = 1
+      alertRow = { low_credit_threshold: null, low_credit_alert_armed: true }
       await client.query(
-        'INSERT INTO org_credits (org_id, credits_remaining, version) VALUES ($1, $2, $3)',
+        'INSERT INTO org_credits (org_id, credits_remaining, version, low_credit_alert_armed) VALUES ($1, $2, $3, true)',
         [orgId, creditsRemaining, version],
       )
     } else {
       creditsRemaining = Number(rows[0].credits_remaining)
       version = rows[0].version
+      alertRow = {
+        low_credit_threshold: rows[0].low_credit_threshold,
+        low_credit_alert_armed: rows[0].low_credit_alert_armed ?? true,
+      }
     }
 
     if (creditsRemaining < costWeight) {
@@ -111,6 +236,7 @@ async function deductCredits(
       }
     }
 
+    const creditsBefore = creditsRemaining
     const newCreditsRemaining = creditsRemaining - costWeight
     const newVersion = version + 1
 
@@ -122,7 +248,17 @@ async function deductCredits(
     if (updateResult.rowCount === 0) {
       await client.query('ROLLBACK')
       if (retries < MAX_RETRIES) {
-        return deductCredits(pool, orgId, costWeight, endpoint, requestId, defaultMonthlyCredits, retries + 1)
+        return deductCredits(
+          pool,
+          orgId,
+          costWeight,
+          endpoint,
+          requestId,
+          defaultMonthlyCredits,
+          defaultLowCreditThreshold,
+          emitOutbox,
+          retries + 1,
+        )
       }
       return { ok: false, creditsRemaining: 0, creditsDeficit: costWeight }
     }
@@ -130,14 +266,30 @@ async function deductCredits(
     await client.query(
       `INSERT INTO credit_transactions (org_id, transaction_type, amount, credits_remaining_before, credits_remaining_after, endpoint, cost_weight, request_id)
        VALUES ($1, 'deduct', $2, $3, $4, $5, $6, $7)`,
-      [orgId, costWeight, creditsRemaining, newCreditsRemaining, endpoint, costWeight, requestId],
+      [orgId, costWeight, creditsBefore, newCreditsRemaining, endpoint, costWeight, requestId],
     )
+
+    try {
+      await maybeEmitLowCreditAlert(
+        client,
+        emitOutbox,
+        orgId,
+        creditsBefore,
+        newCreditsRemaining,
+        alertRow,
+        defaultLowCreditThreshold,
+        endpoint,
+        requestId,
+      )
+    } catch (err) {
+      console.error('[costMeter] Failed to enqueue credits.low webhook:', err)
+    }
 
     await client.query('COMMIT')
 
     return {
       ok: true,
-      creditsBefore: creditsRemaining,
+      creditsBefore,
       creditsRemaining: newCreditsRemaining,
     }
   } catch (err) {
@@ -151,17 +303,16 @@ async function deductCredits(
 async function refundCredits(
   pool: Pool,
   deduction: DeductionInfo,
+  defaultLowCreditThreshold: number,
 ): Promise<void> {
   const client = await pool.connect()
   try {
     await client.query('BEGIN')
 
-    const { rows } = await client.query<{
-      credits_remaining: string
-      version: number
-    }>('SELECT credits_remaining, version FROM org_credits WHERE org_id = $1 FOR UPDATE', [
-      deduction.orgId,
-    ])
+    const { rows } = await client.query<OrgCreditRow>(
+      'SELECT credits_remaining, version, low_credit_threshold, low_credit_alert_armed FROM org_credits WHERE org_id = $1 FOR UPDATE',
+      [deduction.orgId],
+    )
 
     if (rows.length === 0) {
       await client.query('ROLLBACK')
@@ -181,7 +332,23 @@ async function refundCredits(
     await client.query(
       `INSERT INTO credit_transactions (org_id, transaction_type, amount, credits_remaining_before, credits_remaining_after, endpoint, cost_weight, request_id)
        VALUES ($1, 'refund', $2, $3, $4, $5, $6, $7)`,
-      [deduction.orgId, deduction.costWeight, currentCredits, refundedCredits, deduction.endpoint, deduction.costWeight, deduction.requestId],
+      [
+        deduction.orgId,
+        deduction.costWeight,
+        currentCredits,
+        refundedCredits,
+        deduction.endpoint,
+        deduction.costWeight,
+        deduction.requestId,
+      ],
+    )
+
+    await maybeRearmLowCreditAlert(
+      client,
+      deduction.orgId,
+      refundedCredits,
+      rows[0],
+      defaultLowCreditThreshold,
     )
 
     await client.query('COMMIT')
@@ -198,6 +365,7 @@ async function refundCredits(
 export function createCostMeterMiddleware(
   config: CostMeterConfig,
   getPool: () => Pool,
+  deps: CostMeterDeps = {},
 ) {
   return (req: Request, res: Response, next: NextFunction): void => {
     const orgId = extractOrgId(req)
@@ -217,7 +385,16 @@ export function createCostMeterMiddleware(
 
     const pool = getPool()
 
-    deductCredits(pool, orgId, costWeight, req.path, requestId, config.defaultMonthlyCredits)
+    deductCredits(
+      pool,
+      orgId,
+      costWeight,
+      req.path,
+      requestId,
+      config.defaultMonthlyCredits,
+      config.defaultLowCreditThreshold,
+      deps.emitOutbox,
+    )
       .then((result) => {
         if (!result.ok) {
           res.status(402).json({
@@ -244,7 +421,7 @@ export function createCostMeterMiddleware(
 
         res.once('finish', () => {
           if (res.statusCode >= 500) {
-            refundCredits(pool, deduction)
+            refundCredits(pool, deduction, config.defaultLowCreditThreshold)
           }
         })
 

--- a/src/migrations/024_org_credits_low_watermark.ts
+++ b/src/migrations/024_org_credits_low_watermark.ts
@@ -1,0 +1,22 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('org_credits', {
+    low_credit_threshold: {
+      type: 'bigint',
+      notNull: false,
+      comment: 'Per-org low-credit webhook threshold; null uses the global default',
+    },
+    low_credit_alert_armed: {
+      type: 'boolean',
+      notNull: true,
+      default: true,
+      comment: 'When false, credits.low webhook is suppressed until credits recover above threshold',
+    },
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('org_credits', 'low_credit_alert_armed')
+  pgm.dropColumn('org_credits', 'low_credit_threshold')
+}

--- a/src/observability/creditsMetrics.ts
+++ b/src/observability/creditsMetrics.ts
@@ -1,0 +1,14 @@
+import client from 'prom-client'
+
+/**
+ * Counter for credits.low webhook events enqueued via the outbox.
+ */
+export const creditsLowEventsTotal = new client.Counter({
+  name: 'credits_low_events_total',
+  help: 'Total number of credits.low webhook events emitted when org credits cross the low-water threshold',
+  registers: [client.register],
+})
+
+export function recordCreditsLowEvent(): void {
+  creditsLowEventsTotal.inc()
+}

--- a/src/schemas/credits.test.ts
+++ b/src/schemas/credits.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { creditsLowWebhookPayloadSchema } from './credits.js'
+
+describe('creditsLowWebhookPayloadSchema', () => {
+  it('accepts a valid payload', () => {
+    const result = creditsLowWebhookPayloadSchema.parse({
+      orgId: '00000000-0000-0000-0000-000000000001',
+      creditsRemaining: 50,
+      threshold: 100,
+      endpoint: '/test',
+      requestId: 'req-1',
+    })
+
+    expect(result.creditsRemaining).toBe(50)
+    expect(result.threshold).toBe(100)
+  })
+
+  it('rejects invalid orgId', () => {
+    expect(() =>
+      creditsLowWebhookPayloadSchema.parse({
+        orgId: 'not-a-uuid',
+        creditsRemaining: 50,
+        threshold: 100,
+      }),
+    ).toThrow()
+  })
+
+  it('rejects negative creditsRemaining', () => {
+    expect(() =>
+      creditsLowWebhookPayloadSchema.parse({
+        orgId: '00000000-0000-0000-0000-000000000001',
+        creditsRemaining: -1,
+        threshold: 100,
+      }),
+    ).toThrow()
+  })
+})

--- a/src/schemas/credits.ts
+++ b/src/schemas/credits.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+/**
+ * Payload emitted when an org's remaining credits cross the configured low-water threshold.
+ */
+export const creditsLowWebhookPayloadSchema = z.object({
+  orgId: z.string().uuid(),
+  creditsRemaining: z.number().int().nonnegative(),
+  threshold: z.number().int().nonnegative(),
+  endpoint: z.string().optional(),
+  requestId: z.string().optional(),
+})
+
+export type CreditsLowWebhookPayload = z.infer<typeof creditsLowWebhookPayloadSchema>

--- a/src/services/webhooks/types.ts
+++ b/src/services/webhooks/types.ts
@@ -1,7 +1,7 @@
 /**
  * Webhook event types for bond lifecycle.
  */
-export type WebhookEventType = 'bond.created' | 'bond.slashed' | 'bond.withdrawn' | 'attestation.added' | 'attestation.revoked' | 'score.updated'
+export type WebhookEventType = 'bond.created' | 'bond.slashed' | 'bond.withdrawn' | 'attestation.added' | 'attestation.revoked' | 'score.updated' | 'credits.low'
 
 /**
  * Structured payload data for a webhook event.


### PR DESCRIPTION
Closes #635

## Summary
- Add a per-org overage webhook emitter when usage credits cross a configurable threshold in middleware/costMeter.ts

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths