### PR TITLE
Add property tests for the billing fee engine's decimal money arithmetic in services/billing/feeEngine.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -615,6 +614,137 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@cyclonedx/cyclonedx-npm": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-npm/-/cyclonedx-npm-5.0.0.tgz",
+      "integrity": "sha512-pEz/pqYJHQ0ZvY5xFJa+GQ5AjNL7JOEJCXCHymvKo2N1VnzKE1ROpkumduJt8a0DukQjQfBGRXouGQ9xqJtJaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://owasp.org/donate/?reponame=www-project-cyclonedx&title=OWASP+CycloneDX"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cyclonedx/cyclonedx-library": "^10.0.0",
+        "commander": "^14.0.0",
+        "normalize-package-data": "^7.0.0 || ^8.0.0",
+        "packageurl-js": "^2.0.1",
+        "spdx-expression-parse": "^3.0.1 || ^4.0.0",
+        "xmlbuilder2": "^3.0.2 || ^4.0.3"
+      },
+      "bin": {
+        "cyclonedx-npm": "bin/cyclonedx-npm-cli.js"
+      },
+      "engines": {
+        "node": ">=20.18.0",
+        "npm": ">=9"
+      },
+      "optionalDependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "ajv-formats-draft2019": "^1.6.1",
+        "libxmljs2": "^0.35||^0.37"
+      }
+    },
+    "node_modules/@cyclonedx/cyclonedx-npm/node_modules/@cyclonedx/cyclonedx-library": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-10.1.0.tgz",
+      "integrity": "sha512-4yq0KTQIA32UHJwFMDeY5xj2asp3Mk5lzx4JRVXLOb0YE8w1KeR61c1m/gJ4sjMXpiiEDfaITVQu8BLUuy7t3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://owasp.org/donate/?reponame=www-project-cyclonedx&title=OWASP+CycloneDX"
+        }
+      ],
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "ajv-formats-draft2019": "^1.6.1",
+        "libxmljs2": "^0.35||^0.37",
+        "packageurl-js": "*",
+        "spdx-expression-parse": "*",
+        "xmlbuilder2": "^3.0.2||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        },
+        "ajv-formats-draft2019": {
+          "optional": true
+        },
+        "libxmljs2": {
+          "optional": true
+        },
+        "packageurl-js": {
+          "optional": true
+        },
+        "spdx-expression-parse": {
+          "optional": true
+        },
+        "xmlbuilder2": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cyclonedx/cyclonedx-npm/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@cyclonedx/cyclonedx-npm/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1991,7 +2121,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2269,7 +2398,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2957,7 +3085,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3151,7 +3278,6 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -3676,7 +3802,6 @@
       "integrity": "sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3702,7 +3827,6 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -3893,7 +4017,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4690,7 +4813,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5858,7 +5980,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7382,7 +7503,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -9588,7 +9708,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -11759,7 +11878,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -11867,7 +11985,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12111,7 +12228,6 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12190,7 +12306,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -12696,7 +12811,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/services/billing/feeEngine.property.test.ts
+++ b/src/services/billing/feeEngine.property.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from 'vitest'
+import fc from 'fast-check'
+import { calculateFee, applyFees } from './feeEngine.js'
+import { getCurrencyScale } from './types.js'
+import {
+  RoundingMode,
+  divideDecimals,
+  multiplyDecimals,
+  compareDecimals,
+  addDecimals,
+  roundToScale,
+} from '../../lib/decimalMath.js'
+
+// Set a fixed seed for reproducibility across CI/CD and local environments.
+const SEED = 42
+fc.configureGlobal({ seed: SEED })
+
+describe('Billing Fee Engine Property Tests', () => {
+  // ---------------------------------------------------------------------------
+  // Generators
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generates a valid non-negative decimal string:
+   * - Integer part: up to 999,999,999 to cover large numbers.
+   * - Fractional part: 0 to 8 digits, using an array of random digits to cover
+   *   leading zeros, trailing zeros, and mid-range decimals.
+   */
+  const decimalStringArb = fc
+    .tuple(
+      fc.integer({ min: 0, max: 999_999_999 }),
+      fc.array(fc.integer({ min: 0, max: 9 }), { minLength: 0, maxLength: 8 }),
+    )
+    .map(([intPart, fracDigits]) => {
+      if (fracDigits.length === 0) {
+        return intPart.toString()
+      }
+      return `${intPart}.${fracDigits.join('')}`
+    })
+
+  /**
+   * Generates a valid rate percentage decimal string:
+   * - Range: 0 to 1000 (representing 0% to 1000% fee rate).
+   * - Fractional digits: 0 to 6 digits to cover high-precision fee rates.
+   */
+  const rateStringArb = fc
+    .tuple(
+      fc.integer({ min: 0, max: 1000 }),
+      fc.array(fc.integer({ min: 0, max: 9 }), { minLength: 0, maxLength: 6 }),
+    )
+    .map(([intPart, fracDigits]) => {
+      if (fracDigits.length === 0) {
+        return intPart.toString()
+      }
+      return `${intPart}.${fracDigits.join('')}`
+    })
+
+  /**
+   * Generates a currency code spanning various target scales:
+   * - JPY, KRW (scale 0)
+   * - USD, EUR, XYZ (scale 2, where XYZ tests the fallback default scale)
+   * - KWD, BHD, OMR, JOD (scale 3)
+   */
+  const currencyArb = fc.constantFrom(
+    'USD',
+    'EUR',
+    'JPY',
+    'KRW',
+    'KWD',
+    'BHD',
+    'OMR',
+    'JOD',
+    'XYZ',
+  )
+
+  /**
+   * Generates all supported rounding modes.
+   */
+  const roundingModeArb = fc.constantFrom(
+    RoundingMode.HALF_UP,
+    RoundingMode.HALF_DOWN,
+    RoundingMode.HALF_EVEN,
+    RoundingMode.DOWN,
+    RoundingMode.UP,
+  )
+
+  /**
+   * Generates invalid decimal strings to check robustness:
+   * - Negative numbers.
+   * - Alphabetical and special character inputs.
+   * - Malformed decimal notation (multiple periods, space, etc.).
+   */
+  const invalidDecimalStringArb = fc.oneof(
+    // Negative numbers
+    decimalStringArb.filter((s) => s !== '0' && !s.startsWith('0.')).map((s) => `-${s}`),
+    // Alphabetical / Garbage strings
+    fc.string({ minLength: 1 }).filter((s) => !/^\s*\d+(\.\d*)?\s*$/.test(s)),
+    // Malformed decimals
+    fc.constantFrom('.', '..', '1..5', '1.2.3', '1a', 'a1', '1.0a', '-0'),
+  )
+
+  // ---------------------------------------------------------------------------
+  // Proxy Helper for testing addMoneyStrings via calculateFee
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Proxy function to add two decimal strings using the private addMoneyStrings helper.
+   * To adhere to testing constraints, we proxy through the public calculateFee surface:
+   * By setting base = aNorm and ratePercent = (bNorm / aNorm) * 100 computed with
+   * 50 decimal places of precision, computeRawFee computes the fee as exactly bNorm,
+   * and calculateFee returns totalAmount = addMoneyStrings(aNorm, bNorm, scale).
+   */
+  function testAdd(a: string, b: string, currency: string): string {
+    const scale = getCurrencyScale(currency)
+    const aNorm = roundToScale(a, scale, RoundingMode.DOWN)
+    const bNorm = roundToScale(b, scale, RoundingMode.DOWN)
+
+    const aBig = BigInt(aNorm.replace('.', ''))
+    const bBig = BigInt(bNorm.replace('.', ''))
+
+    if (aBig === 0n) {
+      return bNorm
+    }
+    if (bBig === 0n) {
+      return aNorm
+    }
+
+    const ratePercent = divideDecimals(
+      multiplyDecimals(bNorm, '100'),
+      aNorm,
+      50,
+      RoundingMode.HALF_UP,
+    )
+
+    const result = calculateFee({
+      base: { amount: aNorm, currency },
+      ratePercent,
+    })
+
+    return result.totalAmount.amount
+  }
+
+  // ---------------------------------------------------------------------------
+  // Property Invariant Tests
+  // ---------------------------------------------------------------------------
+
+  /**
+   * TSDoc: Invariant - applyFees (fee + net == gross)
+   *
+   * For every generated non-negative decimal amount, list of rates, currency,
+   * and rounding mode:
+   * The sum of baseAmount (net) and feeAmount (fee) must equal totalAmount (gross).
+   */
+  it('should satisfy fee + net == gross for applyFees', () => {
+    fc.assert(
+      fc.property(
+        decimalStringArb,
+        fc.array(rateStringArb, { minLength: 0, maxLength: 5 }),
+        currencyArb,
+        roundingModeArb,
+        (amount, rates, currency, roundingMode) => {
+          const base = { amount, currency }
+          const result = applyFees(base, rates, roundingMode)
+
+          const sum = addDecimals(result.baseAmount.amount, result.feeAmount.amount)
+          expect(compareDecimals(sum, result.totalAmount.amount)).toBe(0)
+        },
+      ),
+      { numRuns: 1000 },
+    )
+  })
+
+  /**
+   * TSDoc: Invariant - addMoneyStrings Commutativity
+   *
+   * For any generated non-negative decimal values a and b under a fixed currency scale,
+   * addMoneyStrings(a, b) must equal addMoneyStrings(b, a).
+   */
+  it('should satisfy commutativity of addition (add(a, b) == add(b, a))', () => {
+    fc.assert(
+      fc.property(
+        decimalStringArb,
+        decimalStringArb,
+        currencyArb,
+        (a, b, currency) => {
+          const sum1 = testAdd(a, b, currency)
+          const sum2 = testAdd(b, a, currency)
+          expect(sum1).toBe(sum2)
+        },
+      ),
+      { numRuns: 1000 },
+    )
+  })
+
+  /**
+   * TSDoc: Invariant - addMoneyStrings Associativity
+   *
+   * For any generated non-negative decimal values a, b, and c under a fixed currency scale,
+   * addMoneyStrings(addMoneyStrings(a, b), c) must equal addMoneyStrings(a, addMoneyStrings(b, c)).
+   */
+  it('should satisfy associativity of addition (add(add(a, b), c) == add(a, add(b, c)))', () => {
+    fc.assert(
+      fc.property(
+        decimalStringArb,
+        decimalStringArb,
+        decimalStringArb,
+        currencyArb,
+        (a, b, c, currency) => {
+          const sum1 = testAdd(testAdd(a, b, currency), c, currency)
+          const sum2 = testAdd(a, testAdd(b, c, currency), currency)
+          expect(sum1).toBe(sum2)
+        },
+      ),
+      { numRuns: 500 },
+    )
+  })
+
+  /**
+   * TSDoc: Invariant - calculateFee Monotonicity
+   *
+   * For any fixed rate, calculateFee must be monotonic non-decreasing in the amount.
+   * If amount1 <= amount2, then feeAmount(amount1) <= feeAmount(amount2).
+   */
+  it('should be monotonic non-decreasing in the amount for a fixed rate', () => {
+    fc.assert(
+      fc.property(
+        decimalStringArb, // amount1
+        decimalStringArb, // delta (non-negative)
+        rateStringArb,    // rate
+        currencyArb,
+        roundingModeArb,
+        (amount1, delta, rate, currency, roundingMode) => {
+          const scale = getCurrencyScale(currency)
+          const normAmount1 = roundToScale(amount1, scale, RoundingMode.DOWN)
+          const normDelta = roundToScale(delta, scale, RoundingMode.DOWN)
+          const normAmount2 = addDecimals(normAmount1, normDelta)
+
+          const fee1 = calculateFee({ base: { amount: normAmount1, currency }, ratePercent: rate }, roundingMode)
+          const fee2 = calculateFee({ base: { amount: normAmount2, currency }, ratePercent: rate }, roundingMode)
+
+          const cmp = compareDecimals(fee1.feeAmount.amount, fee2.feeAmount.amount)
+          expect(cmp).toBeLessThanOrEqual(0)
+        },
+      ),
+      { numRuns: 1000 },
+    )
+  })
+
+  /**
+   * TSDoc: Invariant - parseNonNegativeDecimal Error Handling
+   *
+   * parseNonNegativeDecimal must reject negative, NaN, and malformed strings.
+   * Verified by ensuring calculateFee throws when such values are passed as ratePercent.
+   */
+  it('should reject negative, NaN, and malformed ratePercent strings', () => {
+    fc.assert(
+      fc.property(
+        invalidDecimalStringArb,
+        currencyArb,
+        (invalidRate, currency) => {
+          expect(() =>
+            calculateFee({
+              base: { amount: '100.00', currency },
+              ratePercent: invalidRate,
+            }),
+          ).toThrow()
+        },
+      ),
+      { numRuns: 500 },
+    )
+  })
+
+  /**
+   * TSDoc: Invariant - parseNonNegativeDecimal Round-Trip
+   *
+   * parseNonNegativeDecimal must parse valid non-negative decimal strings correctly.
+   * Verified by ensuring a base-100 fee calculation round-trips the normalized ratePercent.
+   */
+  it('should round-trip valid non-negative decimal strings', () => {
+    fc.assert(
+      fc.property(
+        decimalStringArb,
+        currencyArb,
+        (rate, currency) => {
+          const scale = getCurrencyScale(currency)
+          const rateNorm = roundToScale(rate, scale, RoundingMode.DOWN)
+
+          const baseAmount = scale === 0 ? '100' : `100.${'0'.repeat(scale)}`
+
+          const result = calculateFee(
+            {
+              base: { amount: baseAmount, currency },
+              ratePercent: rateNorm,
+            },
+            RoundingMode.DOWN,
+          )
+
+          expect(result.feeAmount.amount).toBe(rateNorm)
+        },
+      ),
+      { numRuns: 1000 },
+    )
+  })
+
+  /**
+   * TSDoc: Invariant - Precision Preservation
+   *
+   * No result ever loses precision relative to the configured scale.
+   * If the exact intermediate product `base * rate / 100` is exactly representable
+   * within the target scale, the computed fee must equal the exact value.
+   */
+  it('should not lose precision if the result is exactly representable at the configured scale', () => {
+    fc.assert(
+      fc.property(
+        decimalStringArb,
+        rateStringArb,
+        currencyArb,
+        (amount, rate, currency) => {
+          const scale = getCurrencyScale(currency)
+          const baseAmountNorm = roundToScale(amount, scale, RoundingMode.DOWN)
+
+          const exactFee = divideDecimals(
+            multiplyDecimals(baseAmountNorm, rate),
+            '100',
+            scale + 10,
+            RoundingMode.DOWN,
+          )
+
+          const parts = exactFee.split('.')
+          const fracDigits = parts[1] || ''
+          const extraFrac = fracDigits.slice(scale)
+          const hasExtraPrecision = /[1-9]/.test(extraFrac)
+
+          if (!hasExtraPrecision) {
+            const result = calculateFee(
+              { base: { amount: baseAmountNorm, currency }, ratePercent: rate },
+              RoundingMode.HALF_UP,
+            )
+            const expectedFee = roundToScale(exactFee, scale, RoundingMode.DOWN)
+            expect(result.feeAmount.amount).toBe(expectedFee)
+          }
+        },
+      ),
+      { numRuns: 1000 },
+    )
+  })
+})


### PR DESCRIPTION
##closes #630 

## Description

This PR introduces robust, deterministic property-based testing using `fast-check` to assert the algebraic invariants of the billing fee engine (`src/services/billing/feeEngine.ts`). By replacing simple example-based testing with randomized inputs spanning edge cases, we ensure mathematical correctness and prevent IEEE-754 precision drift or carry bugs in our financial logic.

### Invariants Asserted

1. **`applyFees` Invariant (`fee + net == gross`)**: Asserts that `baseAmount.amount + feeAmount.amount === totalAmount.amount` across all inputs.
2. **`addMoneyStrings` Algebraic Properties** (tested via public proxy `calculateFee` and `decimalMath` helpers):
   - **Commutativity**: `add(a, b) == add(b, a)`
   - **Associativity**: `add(add(a, b), c) == add(a, add(b, c))`
3. **Monotonicity**: Asserts that `calculateFee` is monotonic non-decreasing in the amount for any fixed rate.
4. **Parsing & Error Handling**:
   - Asserts that `parseNonNegativeDecimal` rejects negative numbers, NaN values, and malformed structures.
   - Asserts that valid decimal strings successfully round-trip under clean base-100 calculations.
5. **No Loss of Precision**: Asserts that if the exact intermediate product `base * rate / 100` is exactly representable within the target currency's configured scale, the returned fee matches it exactly.

---

## Verification Results

### Automated Test Runs
Tests were verified using `vitest`:
```bash
npx vitest run src/services/billing/feeEngine.property.test.ts src/services/billing/feeEngine.test.ts


Verifies fee+net==gross, add commutativity/associativity, and monotonicity across generated decimal inputs in services/billing/feeEngine.ts.