### PR TITLE
security(currency): require admin context and audit every whitelist m…

### DIFF
--- a/src/services/currency/whitelist.test.ts
+++ b/src/services/currency/whitelist.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import fc from 'fast-check'
+import { auditLogService } from '../audit/index.js'
 
 import {
   CurrencyWhitelist,
@@ -57,6 +58,16 @@ describe('normalize_currency_code', () => {
 })
 
 describe('CurrencyWhitelist', () => {
+  let auditSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    auditSpy = vi.spyOn(auditLogService, 'logAction').mockResolvedValue(undefined as any)
+  })
+
+  afterEach(() => {
+    auditSpy.mockRestore()
+  })
+
   it('starts empty by default and supports populated lookup behavior', () => {
     const empty = new CurrencyWhitelist()
     const populated = new CurrencyWhitelist([' usd ', 'eur'])
@@ -79,6 +90,17 @@ describe('CurrencyWhitelist', () => {
     expect(result.description).toBe('add_currency(USD): added')
     expect(whitelist.is_allowed_currency('USD')).toBe(true)
     expect(whitelist.is_allowed_currency('EUR')).toBe(false)
+    
+    expect(auditSpy).toHaveBeenCalledWith(expect.objectContaining({
+      actorId: adminCtx.userId,
+      action: 'WHITELIST_MUTATION',
+      details: expect.objectContaining({
+        operation: 'add',
+        assetCode: 'USD',
+        after: 'USD',
+        idempotent: false,
+      })
+    }))
   })
 
   it('keeps adding an existing entry idempotent', () => {
@@ -96,10 +118,27 @@ describe('CurrencyWhitelist', () => {
     expect(whitelist.remove_currency(' usd ', adminCtx).description).toBe(
       'remove_currency(USD): removed',
     )
-    expect(whitelist.remove_currency('gbp', adminCtx).description).toContain(
+    expect(whitelist.remove_currency(' gbP ', adminCtx).description).toContain(
       'not present',
     )
     expect(snapshotValues(whitelist)).toEqual(['EUR'])
+
+    expect(auditSpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'WHITELIST_MUTATION',
+      details: expect.objectContaining({
+        operation: 'remove',
+        assetCode: 'USD',
+        idempotent: false,
+      })
+    }))
+    
+    expect(auditSpy).toHaveBeenCalledWith(expect.objectContaining({
+      details: expect.objectContaining({
+        operation: 'remove',
+        assetCode: 'GBP',
+        idempotent: true,
+      })
+    }))
   })
 
   it('clears currencies idempotently', () => {
@@ -110,6 +149,13 @@ describe('CurrencyWhitelist', () => {
     )
     expect(whitelist.size).toBe(0)
     expect(whitelist.clear_currencies(adminCtx).currencies.size).toBe(0)
+
+    expect(auditSpy).toHaveBeenCalledWith(expect.objectContaining({
+      details: expect.objectContaining({
+        operation: 'clear',
+        idempotent: false,
+      })
+    }))
   })
 
   it('rejects malformed codes for constructor, reads, and mutations', () => {

--- a/src/services/currency/whitelist.ts
+++ b/src/services/currency/whitelist.ts
@@ -12,6 +12,7 @@
  */
 
 import { ForbiddenError, UnauthorizedError } from '../../lib/errors.js'
+import { auditLogService } from '../audit/index.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -164,7 +165,27 @@ export class CurrencyWhitelist {
     assertAdmin(ctx)
     const normalised = normalize_currency_code(currency)
     const wasPresent = this._set.has(normalised)
-    this._set.add(normalised)
+    
+    if (!wasPresent) {
+      this._set.add(normalised)
+    }
+
+    void auditLogService.logAction({
+      tenantId: 'system',
+      actorId: ctx.userId,
+      actorEmail: 'unknown',
+      action: 'WHITELIST_MUTATION',
+      resourceType: 'currency_whitelist',
+      resourceId: 'global',
+      details: {
+        operation: 'add',
+        assetCode: normalised,
+        before: wasPresent ? normalised : null,
+        after: normalised,
+        idempotent: wasPresent,
+      },
+    })
+
     return {
       currencies: this.snapshot(),
       description: wasPresent
@@ -189,7 +210,27 @@ export class CurrencyWhitelist {
     assertAdmin(ctx)
     const normalised = normalize_currency_code(currency)
     const wasPresent = this._set.has(normalised)
-    this._set.delete(normalised)
+    
+    if (wasPresent) {
+      this._set.delete(normalised)
+    }
+
+    void auditLogService.logAction({
+      tenantId: 'system',
+      actorId: ctx.userId,
+      actorEmail: 'unknown',
+      action: 'WHITELIST_MUTATION',
+      resourceType: 'currency_whitelist',
+      resourceId: 'global',
+      details: {
+        operation: 'remove',
+        assetCode: normalised,
+        before: wasPresent ? normalised : null,
+        after: null,
+        idempotent: !wasPresent,
+      },
+    })
+
     return {
       currencies: this.snapshot(),
       description: wasPresent
@@ -214,10 +255,27 @@ export class CurrencyWhitelist {
   set_currencies(currencies: string[], ctx: AdminContext): WhitelistMutationResult {
     assertAdmin(ctx)
     const normalisedCurrencies = currencies.map((c) => normalize_currency_code(c))
+    const beforeCodes = [...this._set]
     this._set.clear()
     for (const c of normalisedCurrencies) {
       this._set.add(c)
     }
+
+    void auditLogService.logAction({
+      tenantId: 'system',
+      actorId: ctx.userId,
+      actorEmail: 'unknown',
+      action: 'WHITELIST_MUTATION',
+      resourceType: 'currency_whitelist',
+      resourceId: 'global',
+      details: {
+        operation: 'set',
+        assetCode: null,
+        before: beforeCodes,
+        after: [...this._set],
+      },
+    })
+
     return {
       currencies: this.snapshot(),
       description: `set_currencies([${[...this._set].join(', ')}]): whitelist replaced`,
@@ -236,7 +294,25 @@ export class CurrencyWhitelist {
    */
   clear_currencies(ctx: AdminContext): WhitelistMutationResult {
     assertAdmin(ctx)
+    const beforeCodes = [...this._set]
     this._set.clear()
+
+    void auditLogService.logAction({
+      tenantId: 'system',
+      actorId: ctx.userId,
+      actorEmail: 'unknown',
+      action: 'WHITELIST_MUTATION',
+      resourceType: 'currency_whitelist',
+      resourceId: 'global',
+      details: {
+        operation: 'clear',
+        assetCode: null,
+        before: beforeCodes,
+        after: [],
+        idempotent: beforeCodes.length === 0,
+      },
+    })
+
     return {
       currencies: this.snapshot(),
       description: 'clear_currencies(): whitelist cleared',


### PR DESCRIPTION
…utation

Gates add/remove/set/clear in services/currency/whitelist.ts and writes tamper-evident audit entries.

Closes #637