### PR TITLE
Fix/631 websocket eviction

### DIFF
--- a/ASSIGNMENT_384_COMPLETION.md
+++ b/ASSIGNMENT_384_COMPLETION.md
@@ -2,7 +2,7 @@
 
 ## Status: ✅ COMPLETE
 
-**Alert Routing Matrix: Severity-Aware Paging Tiers in AlertManager Config**
+**Alert Routing Matrix: Severity-Aware Paging Tiers in AlertManager Cogonfig**
 
 ---
 

--- a/src/__tests__/wsScoreStream.test.ts
+++ b/src/__tests__/wsScoreStream.test.ts
@@ -27,6 +27,7 @@ import {
   type WsMessage,
 } from "../routes/ws.js";
 import { InMemoryApiKeyRepository } from "../repositories/apiKeyRepository.js";
+import { wsEvictedSlowConsumersTotal } from "../observability/customMetrics.js";
 
 describe("TrustScoreNotifier", () => {
   beforeEach(() => {
@@ -615,9 +616,10 @@ describe("WebSocket Auth & Upgrade", () => {
       ws.once("message", (raw) =>
         resolve(JSON.parse(raw.toString()) as WsMessage),
       );
-      ws.once("error", () => resolve("error"));
+      ws.once("error", (e) => resolve("error: " + e.message));
       ws.once("close", () => resolve("close"));
     });
+    console.log("MSG IS:", msg);
     expect((msg as WsMessage).type).toBe("subscribe_success");
     // ctx.close() drains the server-side connection; no explicit ws.close() needed.
   });
@@ -752,6 +754,47 @@ describe("WebSocket Backpressure", () => {
 
       slowClient.close();
       fastClient.close();
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  it("should evict slow consumers when bufferedAmount exceeds highWaterMark", async () => {
+    const ctx = await createTestServer({
+      backpressureThreshold: 300,
+      highWaterMark: 200,
+    });
+    try {
+      const client = await connectAndSubscribe(ctx.baseUrl, "0xevict", ctx.apiKey);
+
+      const [serverWs] = ctx.wss.clients;
+
+      // Force bufferedAmount above highWaterMark
+      Object.defineProperty(serverWs, "bufferedAmount", {
+        get: () => 250,
+        configurable: true,
+      });
+
+      // Get current metric value
+      const metricBefore = (await wsEvictedSlowConsumersTotal.get()).values[0]?.value || 0;
+
+      const closePromise = new Promise<{ code: number; reason: string }>((resolve) => {
+        client.once("close", (code, reason) => {
+          resolve({ code, reason: reason.toString() });
+        });
+      });
+
+      // Trigger a message send which will cause eviction
+      trustScoreNotifier.publish("0xevict", 42);
+
+      const { code, reason } = await closePromise;
+      expect(code).toBe(1013);
+      expect(reason).toBe("slow_consumer");
+
+      // Verify the metric was incremented
+      const metricAfter = (await wsEvictedSlowConsumersTotal.get()).values[0]?.value || 0;
+      expect(metricAfter).toBe(metricBefore + 1);
+
     } finally {
       await ctx.close();
     }

--- a/src/listeners/webhookIntegrationOutbox.ts
+++ b/src/listeners/webhookIntegrationOutbox.ts
@@ -1,11 +1,9 @@
 import type { Queryable } from '../db/repositories/queryable.js'
 import type { IdentityState } from './types.js'
 import type { WebhookEventType } from '../services/webhooks/index.js'
-import { detectEventType } from './webhookDetection.js'
 import { outboxEmitter } from '../db/outbox/emitter.js'
-import { detectEventType } from './webhookEventDetection.js'
 
-export { detectEventType } from './webhookEventDetection.js'
+import { detectEventType } from './webhookEventDetection.js'
 
 /**
  * Emit webhook event to outbox for identity state change.

--- a/src/observability/customMetrics.ts
+++ b/src/observability/customMetrics.ts
@@ -45,6 +45,15 @@ export const dbTxnSavepoints = new client.Histogram({
 });
 
 /**
+ * Counter for WebSocket slow consumers that were evicted.
+ */
+export const wsEvictedSlowConsumersTotal = new client.Counter({
+  name: 'ws_evicted_slow_consumers_total',
+  help: 'Total number of WebSocket connections evicted due to slow consumption (exceeding backpressure high-water mark)',
+  registers: [client.register],
+});
+
+/**
  * Register the custom metrics with an external registry if needed.
  * The caller can pass its own Registry; otherwise the default global one is used.
  */
@@ -55,5 +64,6 @@ export function registerSyntheticMetrics(registry?: client.Registry): void {
   reg.registerMetric(webhookPayloadBytes);
   reg.registerMetric(dbTxnDurationSeconds);
   reg.registerMetric(dbTxnSavepoints);
+  reg.registerMetric(wsEvictedSlowConsumersTotal);
 }
 

--- a/src/routes/admin/member.ts
+++ b/src/routes/admin/member.ts
@@ -139,21 +139,6 @@ export function createMembersRouter(): Router {
         const { orgId } = req.params
         const { userId, email, role } = req.validated!.body as InviteMemberBody
 
-        const result = await memberService.inviteMember(
-          authReq.user!.id,
-          authReq.user!.email,
-          { orgId, userId, email, role: role ?? 'member' },
-        )
-
-        res.status(201).json({ success: true, data: result.member, message: result.message })
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        const isConflict = message.includes('already active')
-        res.status(isConflict ? 409 : 400).json({
-          error: isConflict ? 'Conflict' : 'BadRequest',
-          message,
-        })
-      }
 
       if (role && !VALID_MEMBER_ROLES.includes(role as MemberRole)) {
         res.status(400).json({
@@ -198,21 +183,6 @@ export function createMembersRouter(): Router {
         const { memberId } = req.params
         const { role } = req.validated!.body as UpdateMemberRoleBody
 
-        const result = await memberService.updateMemberRole(
-          authReq.user!.id,
-          authReq.user!.email,
-          { memberId, role },
-        )
-
-        res.status(200).json({ success: true, data: result.member, message: result.message })
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        const isNotFound = message.includes('not found')
-        res.status(isNotFound ? 404 : 400).json({
-          error: isNotFound ? 'NotFound' : 'BadRequest',
-          message,
-        })
-      }
 
       const result = await memberService.updateMemberRole(
         authReq.user!.tenantId,

--- a/src/routes/ws.ts
+++ b/src/routes/ws.ts
@@ -23,6 +23,7 @@ import {
 } from "../repositories/apiKeyRepository.js";
 import type { Pool } from "pg";
 import { URL } from "url";
+import { wsEvictedSlowConsumersTotal } from "../observability/customMetrics.js";
 
 export interface WsSubscriptionConfig {
   /**
@@ -42,6 +43,12 @@ export interface WsSubscriptionConfig {
    * @default 5000
    */
   shutdownGracePeriodMs?: number;
+
+  /**
+   * High water mark for buffer size. If exceeded, connection will be closed.
+   * @default 0 (disabled)
+   */
+  highWaterMark?: number;
 }
 
 export interface WsMessage {
@@ -73,6 +80,7 @@ export function createWsSubscriptionServer(
   const rateLimitPerSec = config.rateLimitPerSec ?? 100;
   const backpressureThreshold = config.backpressureThreshold ?? 1024 * 1024;
   const shutdownGracePeriodMs = config.shutdownGracePeriodMs ?? 5000;
+  const highWaterMark = config.highWaterMark ?? 0;
 
   // Use injected repo for testing, otherwise fall back to the default
   // (in-memory) implementation. A PostgreSQL-backed adapter can be injected
@@ -118,7 +126,7 @@ export function createWsSubscriptionServer(
       let tenantId: string;
       let apiKeyId: string;
       try {
-        const keyRecord = repo.validate(apiKey);
+        const keyRecord = await repo.validate(apiKey);
         if (!keyRecord || !keyRecord.active) {
           socket.destroy();
           return;
@@ -251,6 +259,14 @@ export function createWsSubscriptionServer(
    */
   function sendMessage(ws: WebSocket, message: WsMessage): void {
     try {
+      if (highWaterMark > 0 && ws.bufferedAmount > highWaterMark) {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.close(1013, "slow_consumer");
+          wsEvictedSlowConsumersTotal.inc();
+        }
+        return;
+      }
+
       ws.send(JSON.stringify(message));
     } catch (error) {
       // Ignore send errors - connection may be closing


### PR DESCRIPTION
#Closes #631


    ## Description
    This PR hardens the WebSocket subscription server by
  introducing a slow-consumer eviction mechanism. This
  prevents memory exhaustion and degraded performance
  caused by clients that consume messages too slowly.

    ## Changes Included
    - **High Watermark Configuration:** Added
  `highWaterMark` to the WebSocket subscription
  configuration and connection setup.
    - **Client Eviction:** Implemented client eviction
  (using status code `1013 Try Again Later` /
  `slow_consumer`) when the buffer exceeds the
  `highWaterMark` during `sendMessage`.
    - **API Key Validation Fix:** Fixed a missing `await`
  on API-key repository validation, which was previously
  causing test timeouts and disconnects during the upgrade
  process.
    - **Metrics Tracking:** Added a new Prometheus metric
  `wsEvictedSlowConsumersTotal` to monitor and track the
  number of slow consumer evictions.
    - **Syntax Fixes:** Fixed pre-existing unhandled syntax
  errors in `member.ts` and `webhookIntegrationOutbox.ts`
  caused by code duplication.