### PR TITLE
Feat/graceful shutdown handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,17 @@ Extend with additional Horizon event ingestion when implementing the full archit
 - Integration notes: `docs/stellar-integration.md`
 - Tests: `src/clients/soroban.test.ts`
 
+## Graceful Shutdown
+
+On `SIGTERM` or `SIGINT`, the Credence Backend API executes an ordered graceful shutdown sequence:
+1. Stops accepting new HTTP connections and allows in-flight requests to drain (`server.close()`).
+2. Closes WebSocket subscription server connections gracefully.
+3. Stops event consumers and background schedulers.
+4. Closes database connection pools (primary, worker, replica) cleanly (`pool.end()`).
+5. Disconnects from Redis connection.
+
+The grace period is configurable via `SHUTDOWN_GRACE_PERIOD_MS` (default: 30,000 ms). For more details, see **[docs/graceful-shutdown.md](docs/graceful-shutdown.md)**.
+
 ## Security
 
 For security policies, reporting, and architecture documentation:

--- a/docs/graceful-shutdown.md
+++ b/docs/graceful-shutdown.md
@@ -123,6 +123,10 @@ The test suite covers:
 - Double-signal triggers immediate force-exit
 - SIGTERM arriving before HTTP server is ready
 
+## Signal Handling in Production
+
+In the production entrypoint (`src/index.ts`), the process listens for `SIGTERM` and `SIGINT` signals, routing them directly to the `GracefulShutdownManager.shutdown()` method. This ensures that the application executes the full, ordered cleanup process (draining in-flight requests, stopping schedulers, closing database pools, disconnecting Redis, etc.) before exiting.
+
 ## Operational runbook
 
 ### Rolling deploy (Kubernetes)

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,29 +1,30 @@
-# feat(trust): ETag + conditional GET for trust score reads
+# feat(shutdown): drain in-flight requests, close DB pools, and exit cleanly on SIGTERM
 
 ## Description
 
-This PR adds ETag support and conditional GET handling (`If-None-Match`) to the `GET /api/trust/:address` endpoint. This allows clients to avoid transferring the full trust score body when it hasn't changed, reducing bandwidth and database load.
+This PR fixes a bug where `SIGTERM` and `SIGINT` signals bypassed the configured `GracefulShutdownManager` in production (due to duplicate signal handlers in `src/index.ts` that immediately called `process.exit(0)` when the HTTP server closed, bypassing the closing of DB pools, Redis connections, and background schedulers).
+
+With this fix, signals are correctly routed to the `GracefulShutdownManager`, which performs a clean, ordered graceful shutdown sequence before exiting.
+
+Closes #<this-issue>
 
 ## Changes
 
--   **`src/routes/trust.ts`**:
-    -   Added a `generateEtag` helper using SHA-256 to create deterministic ETags from the `TrustScore` object.
-    -   Updated the `GET /:address` route handler to compute the ETag and set `ETag` and `Cache-Control` headers.
-    -   Added logic to check for `If-None-Match` and return `304 Not Modified` if the ETag matches.
--   **`src/__tests__/trust.test.ts`**:
-    -   Added unit tests to verify:
-        -   First request returns `200 OK` + `ETag`.
-        -   Subsequent request with matching `If-None-Match` returns `304 Not Modified`.
-        -   Request with changed data returns `200 OK` + new `ETag`.
+- **`src/index.ts`**: Removed duplicate local `shutdown` handler and its signal registrations to ensure `GracefulShutdownManager` manages the shutdown process.
+- **`src/__tests__/gracefulShutdown.test.ts`**: Added a new sequence verification test to ensure that the server closing/draining, database pools closing, and process exiting occur in the correct order.
+- **`README.md`**: Documented the graceful shutdown behavior.
+- **`docs/graceful-shutdown.md`**: Updated signal handling architecture notes.
 
-## Testing
+## Commits
 
--   Ran `vitest src/__tests__/trust.test.ts` and all tests passed.
--   Verified ETag logic by mocking the reputation service.
+1. `fix(shutdown): remove redundant signal handlers in index.ts`
+2. `test(shutdown): add test to verify shutdown sequence order`
+3. `docs(shutdown): document production graceful shutdown and signal handling`
 
 ## Checklist
 
--   [x] ETag implemented and deterministic.
--   [x] `If-None-Match` honored, returns 304.
--   [x] `Cache-Control` headers set.
--   [x] Tests updated/added with ≥95% coverage for the new logic.
+- [x] The change matches the summary above.
+- [x] No regression in the existing test suite.
+- [x] The change is documented where it is observable (README, docs/).
+- [x] Lint, type-check, and tests all pass locally.
+- [x] PR description references this issue with `Closes #<this-issue>`.

--- a/src/__tests__/gracefulShutdown.test.ts
+++ b/src/__tests__/gracefulShutdown.test.ts
@@ -80,6 +80,59 @@ describe('GracefulShutdownManager', () => {
     expect(forceExit).toHaveBeenCalledWith(1)
     vi.useRealTimers()
   })
+
+  it('drains in-flight requests on SIGTERM, then closes the DB pool and Redis, then exits', async () => {
+    const sequence: string[] = []
+    const close = vi.fn((callback: (err?: Error | null) => void) => {
+      sequence.push('server_close_start')
+      callback()
+      sequence.push('server_close_end')
+    })
+    const fakeServer = { close } as unknown as import('http').Server
+    
+    const dbPoolEnd = vi.fn(async () => {
+      sequence.push('db_pool_close')
+    })
+    const dbPool = { end: dbPoolEnd }
+    
+    const redisDisconnect = vi.fn(async () => {
+      sequence.push('redis_close')
+    })
+    const redis = { disconnect: redisDisconnect }
+    
+    const forceExit = vi.fn((code: number) => {
+      sequence.push(`exit_${code}`)
+    })
+
+    const manager = new GracefulShutdownManager({
+      server: fakeServer,
+      dbPools: [dbPool],
+      redis,
+      gracePeriodMs: 1000,
+      forceExit,
+      logger: vi.fn(),
+    })
+
+    await manager.shutdown('SIGTERM')
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(dbPoolEnd).toHaveBeenCalledOnce()
+    expect(redisDisconnect).toHaveBeenCalledOnce()
+    expect(forceExit).toHaveBeenCalledWith(0)
+    
+    // Assert the exact sequence: server closes first, then DB/Redis close, then exit
+    expect(sequence[0]).toBe('server_close_start')
+    expect(sequence[1]).toBe('server_close_end')
+    
+    const dbIndex = sequence.indexOf('db_pool_close')
+    const redisIndex = sequence.indexOf('redis_close')
+    const exitIndex = sequence.indexOf('exit_0')
+    
+    expect(dbIndex).toBeGreaterThan(1)
+    expect(redisIndex).toBeGreaterThan(1)
+    expect(exitIndex).toBeGreaterThan(dbIndex)
+    expect(exitIndex).toBeGreaterThan(redisIndex)
+  })
 })
 
 describe('Health router readiness during shutdown', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,25 +116,6 @@ if (process.env.NODE_ENV !== "test") {
 
     installShutdownHandlers();
 
-    // Graceful shutdown
-    const shutdown = async (signal: string): Promise<void> => {
-      logger.info(`Received ${signal}, shutting down gracefully...`)
-      
-      // Close HTTP server
-      server.close(() => {
-        logger.info('HTTP server closed')
-        process.exit(0)
-      })
-      
-      // Force shutdown after 10 seconds
-      setTimeout(() => {
-        logger.error('Forced shutdown after timeout')
-        process.exit(1)
-      }, 10000)
-    }
-
-    process.on('SIGTERM', () => void shutdown('SIGTERM'))
-    process.on('SIGINT', () => void shutdown('SIGINT'))
 
     if (process.env.DATABASE_URL) {
       const thresholdSeconds = Number(


### PR DESCRIPTION
Here is a comprehensive summary of what was implemented:

### 1. The Core Issue
In production (`process.env.NODE_ENV !== "test"`), the application registered duplicate signal handlers for `SIGTERM` and `SIGINT` inside [src/index.ts](file:///c:/Users/USER/Desktop/Credence-Backend/src/index.ts). 

While the system initialized the `GracefulShutdownManager` and called `installShutdownHandlers()`, it immediately followed with an inline `shutdown` handler registered via `process.on(...)`. This overriding handler immediately called `server.close(() => process.exit(0))` upon receiving a signal. As a result, the process would exit as soon as the HTTP server closed, bypassing the remaining phases of the `GracefulShutdownManager` sequence (which was responsible for closing database pools, stopping WebSockets, pausing background schedulers, stopping the outbox publisher, and disconnecting from Redis).

### 2. The Solution (Code Changes)
- **Signal Handler Cleanup**: Removed the local `shutdown` function and its duplicate `process.on('SIGTERM')` and `process.on('SIGINT')` registrations in [src/index.ts](file:///c:/Users/USER/Desktop/Credence-Backend/src/index.ts). This leaves `installShutdownHandlers()` as the single production registration point.
- **Unified Shutdown Sequence**: Signals are now routed exclusively to `GracefulShutdownManager.shutdown()`. This executes the following clean, ordered sequence before exiting:
  1. **`server_close`**: Express HTTP server stops accepting new connections, allowing in-flight HTTP requests to complete.
  2. **`ws_drain`**: Open WebSocket clients are closed gracefully (code 1000) with a 5-second hard termination fallback.
  3. **`listener_stop`**: Event consumers are paused at their current offsets.
  4. **`scheduler_drain`**: Schedulers are stopped and current running jobs are allowed to finish.
  5. **`outbox_stop`**: Outbox publisher is safely shut down.
  6. **`invalidation_bus_stop`**: Cross-replica cache invalidation listener connection is closed.
  7. **`pool_close`**: All three database connection pools (`pool`, `workerPool`, `replicaPool`) are cleanly closed via `pool.end()`.
  8. **`redis_close`**: Redis client is cleanly disconnected via `disconnect()`.
  9. **Exit**: The process exits with code `0` (or `1` if any phase throws an error or the grace period expires).

### 3. Unit Test Integration
We added a sequence verification test in [src/__tests__/gracefulShutdown.test.ts](file:///c:/Users/USER/Desktop/Credence-Backend/src/__tests__/gracefulShutdown.test.ts) to guarantee order execution:
- Mocks were introduced to track call execution order for `server.close()`, `pool.end()`, `redis.disconnect()`, and `process.exit()`.
- The test asserts that the HTTP server close finishes first (draining in-flight requests) before database pool termination begins, and that `process.exit(0)` is only triggered after all resources are closed.

### 4. Documentation Updates
- **[README.md](file:///c:/Users/USER/Desktop/Credence-Backend/README.md)**: Added a new `## Graceful Shutdown` section documenting how the backend handles SIGTERM/SIGINT signals, and linking to the primary documentation.
- **[docs/graceful-shutdown.md](file:///c:/Users/USER/Desktop/Credence-Backend/docs/graceful-shutdown.md)**: Updated the architecture guide with a new `## Signal Handling in Production` section detailing the entrypoint signal hooks.
- **[pr-description.md](file:///c:/Users/USER/Desktop/Credence-Backend/pr-description.md)**: Updated with the PR description and a `Closes #<this-issue>` tag.

closes #562 
