### PR TITLE
Add Postgres advisory lock–based worker leadership lease for outbox loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,16 @@ OUTBOX_PUBLISHED_RETENTION_DAYS=7
 OUTBOX_FAILED_RETENTION_DAYS=30
 OUTBOX_CLEANUP_INTERVAL_MS=3600000
 
+# ── Outbox Worker Leadership Lease ───────────────────────────────────────────
+# When enabled, a Postgres advisory lock ensures only one outbox publisher
+# instance runs at a time.  Other instances stay in standby and take over
+# automatically if the leader's connection dies.
+OUTBOX_LEADER_LEASE_ENABLED=false
+# How often (ms) a standby instance retries acquiring the lock.  Default: 5000.
+OUTBOX_LEADER_LEASE_RETRY_MS=5000
+# How often (ms) the leader verifies its connection is alive.  Default: 10000.
+OUTBOX_LEADER_LEASE_HEARTBEAT_MS=10000
+
 # ── Report Storage ────────────────────────────────────────────────────────────
 # Signing secret for HMAC-signed report artifact download URLs.
 # Must be non-empty; recommended length ≥ 32 characters.

--- a/docs/outbox-scaling.md
+++ b/docs/outbox-scaling.md
@@ -82,3 +82,57 @@ Split the outbox load into 8 disjoint slices.
 
 1.  **Publisher Death**: If an instance dies mid-lease, its claimed events will remain locked in the `processing` state until the lease expires (`lease_expires_at < NOW()`). Any running instance assigned to the same `shardId` will automatically reclaim the expired events in subsequent polling cycles.
 2.  **Dynamic Re-sharding**: If the number of publisher instances ($N$) changes during runtime (e.g. from 2 to 4), the hash-modulo slices shift. Any currently processing leases will complete normally under their assigned consumer IDs. Once expired or released, the new slice distribution will apply, ensuring seamless scaling transitions.
+
+---
+
+## Worker Leadership Lease (Advisory Locks)
+
+When running multiple replicas behind a load balancer, you may want **only one** instance to run the outbox loop at a time, while the others remain in standby. This avoids duplicate processing and simplifies operational reasoning.
+
+The worker leadership lease uses **Postgres session-level advisory locks** (`pg_advisory_lock` / `pg_advisory_try_lock`) to elect a single leader.
+
+### How It Works
+
+```
+Instance A                    Instance B                    Postgres
+    │                             │                             │
+    ├── pg_advisory_lock(5381) ──┼────────────────────────────▶│
+    │◀── true (leader) ──────────┼─────────────────────────────┤
+    │   starts outbox loop       │                             │
+    │                            ├── pg_advisory_lock(5381) ──▶│
+    │                            │◀── blocks (standby) ────────┤
+    │   [connection dies]        │                             │
+    │                            │◀── lock released (session) ─┤
+    │                            │   now acquires lock         │
+    │                            │   starts outbox loop        │
+```
+
+1. On start, each instance checks out a dedicated connection and calls `pg_advisory_lock(5381)`.
+2. The first instance to acquire the lock becomes **leader** and starts the outbox publisher loop.
+3. Other instances block on the same lock key and stay in **standby** mode.
+4. If the leader's Postgres connection dies (crash, network partition, DB restart), the session is destroyed and the lock is automatically released.
+5. A standby instance's blocked `pg_advisory_lock` call returns, it becomes the new leader, and starts the outbox loop.
+6. A heartbeat timer on the leader verifies the connection is alive; if it fails, the instance reverts to standby and re-enters the acquisition race.
+
+### Configuration
+
+| Environment Variable | Default | Description |
+|----------------------|---------|-------------|
+| `OUTBOX_LEADER_LEASE_ENABLED` | `false` | Enable leader election via advisory locks |
+| `OUTBOX_LEADER_LEASE_RETRY_MS` | `5000` | Standby retry interval (ms) |
+| `OUTBOX_LEADER_LEASE_HEARTBEAT_MS` | `10000` | Leader heartbeat interval (ms) |
+
+### Enabling
+
+Set `OUTBOX_LEADER_LEASE_ENABLED=true` in your environment. No database migrations are required — advisory locks are a built-in Postgres feature that uses no tables.
+
+### Observability
+
+Two Prometheus counters are emitted:
+
+- `outbox_leader_acquired_total` — incremented each time this instance acquires leadership.
+- `outbox_leader_lost_total` — incremented each time this instance loses leadership.
+
+### Combining with Sharding
+
+The leadership lease is independent of sharding. If you enable both, only the leader instance runs a publisher, and it processes events from all shards. If you need horizontal scaling with leadership, consider a **leader-per-shard** pattern where each shard assignment gets its own advisory lock key.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -163,6 +163,22 @@ export const envSchema = z.object({
     .transform(Number)
     .pipe(z.number().int().min(60000)),
 
+  // Outbox worker leadership lease (advisory-lock based)
+  OUTBOX_LEADER_LEASE_ENABLED: z
+    .string()
+    .default('false')
+    .transform((val) => val === 'true'),
+  OUTBOX_LEADER_LEASE_RETRY_MS: z
+    .string()
+    .default('5000')
+    .transform(Number)
+    .pipe(z.number().int().min(1000).max(60000)),
+  OUTBOX_LEADER_LEASE_HEARTBEAT_MS: z
+    .string()
+    .default('10000')
+    .transform(Number)
+    .pipe(z.number().int().min(1000).max(60000)),
+
   // Request snapshots retention
   REQUEST_SNAPSHOT_RETENTION_DAYS: z
     .string()
@@ -450,6 +466,11 @@ export interface Config {
     publishedRetentionDays: number
     failedRetentionDays: number
     cleanupIntervalMs: number
+    leaderLease: {
+      enabled: boolean
+      retryIntervalMs: number
+      heartbeatIntervalMs: number
+    }
   }
   requestSnapshots: {
     retentionDays: number
@@ -643,6 +664,11 @@ function mapEnvToConfig(env: Env): Config {
       publishedRetentionDays: env.OUTBOX_PUBLISHED_RETENTION_DAYS,
       failedRetentionDays: env.OUTBOX_FAILED_RETENTION_DAYS,
       cleanupIntervalMs: env.OUTBOX_CLEANUP_INTERVAL_MS,
+      leaderLease: {
+        enabled: env.OUTBOX_LEADER_LEASE_ENABLED,
+        retryIntervalMs: env.OUTBOX_LEADER_LEASE_RETRY_MS,
+        heartbeatIntervalMs: env.OUTBOX_LEADER_LEASE_HEARTBEAT_MS,
+      },
     },
     requestSnapshots: {
       retentionDays: env.REQUEST_SNAPSHOT_RETENTION_DAYS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,13 @@ if (process.env.NODE_ENV !== "test") {
     // Start Outbox Publisher job if enabled
     if (config.outbox.enabled) {
       try {
-        outboxJob = new OutboxJob(pool);
+        outboxJob = new OutboxJob(pool, {
+          leaderLease: {
+            enabled: config.outbox.leaderLease.enabled,
+            retryIntervalMs: config.outbox.leaderLease.retryIntervalMs,
+            heartbeatIntervalMs: config.outbox.leaderLease.heartbeatIntervalMs,
+          },
+        });
         await outboxJob.start();
         logger.info("[Main] Outbox Publisher started");
       } catch (error) {

--- a/src/jobs/outbox.ts
+++ b/src/jobs/outbox.ts
@@ -5,6 +5,11 @@ import { PostgresWebhookRepository } from '../db/repositories/webhookRepository.
 import { PostgresDlqStore } from '../services/webhooks/postgresDlqStore.js'
 import { auditLogService } from '../services/audit/index.js'
 import { WebhookService } from '../services/webhooks/service.js'
+import { WorkerLeaseManager } from './workerLeaseManager.js'
+import {
+  incrementOutboxLeaderAcquired,
+  incrementOutboxLeaderLost,
+} from '../observability/index.js'
 import type { Pool } from 'pg'
 
 export interface OutboxJobOptions {
@@ -16,14 +21,24 @@ export interface OutboxJobOptions {
   consumerId?: string
   leaseSeconds?: number
   heartbeatIntervalMs?: number
+  leaderLease?: {
+    enabled?: boolean
+    retryIntervalMs?: number
+    heartbeatIntervalMs?: number
+  }
 }
 
 /**
  * Background job that runs the OutboxPublisher.
  * Manages lifecycle (start/stop) and holds dependencies.
+ *
+ * When `leaderLease.enabled` is true, the job uses a Postgres advisory lock
+ * to ensure only one instance runs the outbox loop at a time.
  */
 export class OutboxJob {
   private publisher: OutboxPublisher | null = null
+  private leaseManager: WorkerLeaseManager | null = null
+  private started = false
 
   constructor(
     private readonly pool: Pool,
@@ -32,15 +47,76 @@ export class OutboxJob {
 
   /**
    * Start the outbox publisher.
+   *
+   * When the leader lease is enabled the publisher is only started after
+   * this instance acquires advisory-lock leadership.  If leadership is
+   * lost the publisher is stopped and the instance re-enters standby mode.
    */
   async start(): Promise<void> {
-    // Create dependencies
+    if (this.started) return
+    this.started = true
+
+    if (this.options.leaderLease?.enabled) {
+      this.leaseManager = new WorkerLeaseManager({
+        pool: this.pool,
+        retryIntervalMs: this.options.leaderLease.retryIntervalMs,
+        heartbeatIntervalMs: this.options.leaderLease.heartbeatIntervalMs,
+      })
+
+      this.leaseManager.on({
+        onStateChange: async (state) => {
+          if (state === 'leader') {
+            incrementOutboxLeaderAcquired()
+            await this.startPublisher()
+          } else {
+            await this.stopPublisher()
+          }
+        },
+        onReleased: () => {
+          incrementOutboxLeaderLost()
+        },
+      })
+
+      await this.leaseManager.start()
+      return
+    }
+
+    // No leader lease — start publisher immediately (backwards-compatible)
+    await this.startPublisher()
+  }
+
+  /**
+   * Stop the outbox publisher gracefully.
+   */
+  async stop(): Promise<void> {
+    if (!this.started) return
+    this.started = false
+
+    await this.stopPublisher()
+
+    if (this.leaseManager) {
+      await this.leaseManager.stop()
+      this.leaseManager = null
+    }
+  }
+
+  /** Whether the outbox loop is currently active (leader holds the lock). */
+  isRunning(): boolean {
+    return this.publisher !== null
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  private async startPublisher(): Promise<void> {
+    if (this.publisher) return
+
     const webhookStore = new PostgresWebhookRepository(this.pool)
     const dlqStore = new PostgresDlqStore(this.pool)
     const webhookService = new WebhookService(webhookStore, undefined, dlqStore, auditLogService)
     const eventPublisher = new WebhookEventPublisher(webhookService)
 
-    // Build configuration
     const config: OutboxPublisherConfig = {
       pollIntervalMs: this.options.pollIntervalMs ?? 1000,
       batchSize: this.options.batchSize ?? 100,
@@ -58,10 +134,9 @@ export class OutboxJob {
     await this.publisher.start()
   }
 
-  /**
-   * Stop the outbox publisher gracefully.
-   */
-  async stop(): Promise<void> {
-    await this.publisher?.stop()
+  private async stopPublisher(): Promise<void> {
+    if (!this.publisher) return
+    await this.publisher.stop()
+    this.publisher = null
   }
 }

--- a/src/jobs/workerLeaseManager.test.ts
+++ b/src/jobs/workerLeaseManager.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { WorkerLeaseManager, OUTBOX_LEADER_LOCK_KEY } from './workerLeaseManager.js'
+
+function createMockClient() {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: [{ pg_advisory_lock: true }] }),
+    release: vi.fn(),
+  }
+}
+
+function createMockPool(client?: ReturnType<typeof createMockClient>) {
+  const c = client ?? createMockClient()
+  return {
+    connect: vi.fn().mockResolvedValue(c),
+  }
+}
+
+describe('WorkerLeaseManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('exports a stable lock key constant', () => {
+    expect(OUTBOX_LEADER_LOCK_KEY).toBe(53_81)
+  })
+
+  it('starts in standby state', () => {
+    const pool = createMockPool()
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    expect(mgr.currentState).toBe('standby')
+  })
+
+  it('acquires leadership on start and fires onStateChange', async () => {
+    const client = createMockClient()
+    const pool = createMockPool(client)
+    const onStateChange = vi.fn()
+
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    mgr.on({ onStateChange })
+
+    await mgr.start()
+    await mgr.stop()
+
+    expect(onStateChange).toHaveBeenCalledWith('leader')
+    expect(mgr.currentState).toBe('standby')
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_lock'),
+      [OUTBOX_LEADER_LOCK_KEY],
+    )
+  })
+
+  it('fires onAcquired when leadership is obtained', async () => {
+    const pool = createMockPool()
+    const onAcquired = vi.fn()
+
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    mgr.on({ onAcquired })
+
+    await mgr.start()
+    await mgr.stop()
+
+    expect(onAcquired).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the advisory lock on stop', async () => {
+    const client = createMockClient()
+    const pool = createMockPool(client)
+    const onReleased = vi.fn()
+
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    mgr.on({ onReleased })
+    await mgr.start()
+
+    await mgr.stop()
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_unlock'),
+      [OUTBOX_LEADER_LOCK_KEY],
+    )
+    expect(client.release).toHaveBeenCalled()
+    expect(onReleased).toHaveBeenCalledTimes(1)
+    expect(mgr.currentState).toBe('standby')
+  })
+
+  it('does not start twice', async () => {
+    const pool = createMockPool()
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    await mgr.start()
+    await mgr.start()
+
+    expect(pool.connect).toHaveBeenCalledTimes(1)
+    await mgr.stop()
+  })
+
+  it('does nothing on stop if not started', async () => {
+    const pool = createMockPool()
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    await mgr.stop()
+
+    expect(pool.connect).not.toHaveBeenCalled()
+  })
+
+  it('retries on connection failure', async () => {
+    const client = createMockClient()
+    const pool = {
+      connect: vi.fn()
+        .mockRejectedValueOnce(new Error('connection refused'))
+        .mockResolvedValue(client),
+    }
+    const onError = vi.fn()
+
+    const mgr = new WorkerLeaseManager({
+      pool: pool as any,
+      retryIntervalMs: 1000,
+    })
+    mgr.on({ onError })
+
+    await mgr.start()
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'connection refused' }))
+    expect(mgr.currentState).toBe('standby')
+
+    // After retry timer fires
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(mgr.currentState).toBe('leader')
+
+    await mgr.stop()
+  })
+
+  it('retries on query failure', async () => {
+    const client = createMockClient()
+    client.query
+      .mockRejectedValueOnce(new Error('query failed'))
+      .mockResolvedValueOnce({ rows: [{ pg_advisory_lock: true }] })
+
+    const pool = {
+      connect: vi.fn().mockResolvedValue(client),
+    }
+    const onError = vi.fn()
+
+    const mgr = new WorkerLeaseManager({
+      pool: pool as any,
+      retryIntervalMs: 1000,
+    })
+    mgr.on({ onError })
+
+    await mgr.start()
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'query failed' }))
+    expect(mgr.currentState).toBe('standby')
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(mgr.currentState).toBe('leader')
+
+    await mgr.stop()
+  })
+
+  it('heartbeat detects connection loss and reverts to standby', async () => {
+    const client = createMockClient()
+    client.query
+      .mockResolvedValueOnce({ rows: [{ pg_advisory_lock: true }] }) // acquire
+      .mockRejectedValueOnce(new Error('connection lost')) // heartbeat SELECT 1
+
+    const client2 = createMockClient()
+    const pool = {
+      connect: vi.fn()
+        .mockResolvedValueOnce(client)
+        .mockResolvedValueOnce(client2),
+    }
+
+    const onStateChange = vi.fn()
+    const onReleased = vi.fn()
+
+    const mgr = new WorkerLeaseManager({
+      pool: pool as any,
+      heartbeatIntervalMs: 5000,
+      retryIntervalMs: 1000,
+    })
+    mgr.on({ onStateChange, onReleased })
+
+    await mgr.start()
+    expect(onStateChange).toHaveBeenCalledWith('leader')
+
+    // Heartbeat fires
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(onReleased).toHaveBeenCalled()
+    expect(mgr.currentState).toBe('standby')
+
+    // Retry fires and acquires
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(onStateChange).toHaveBeenLastCalledWith('leader')
+
+    await mgr.stop()
+  })
+
+  it('stop clears all timers', async () => {
+    const pool = createMockPool()
+    const mgr = new WorkerLeaseManager({
+      pool: pool as any,
+      heartbeatIntervalMs: 5000,
+    })
+
+    await mgr.start()
+    await mgr.stop()
+
+    // Advance past where timers would fire — no errors
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(mgr.currentState).toBe('standby')
+  })
+
+  it('uses custom lock key', async () => {
+    const client = createMockClient()
+    const pool = createMockPool(client)
+
+    const mgr = new WorkerLeaseManager({ pool: pool as any, lockKey: 9999 })
+    await mgr.start()
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.stringContaining('pg_advisory_lock'),
+      [9999],
+    )
+
+    await mgr.stop()
+  })
+
+  it('releaseLock is safe to call when client is null', async () => {
+    const pool = createMockPool()
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+
+    // stop without start should not throw
+    await mgr.stop()
+    expect(pool.connect).not.toHaveBeenCalled()
+  })
+
+  it('isRunning() reflects publisher state via onStateChange', async () => {
+    const pool = createMockPool()
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+
+    expect(mgr.currentState).toBe('standby')
+
+    await mgr.start()
+    expect(mgr.currentState).toBe('leader')
+
+    await mgr.stop()
+    expect(mgr.currentState).toBe('standby')
+  })
+
+  it('on() replaces previously registered handlers for the same key', async () => {
+    const pool = createMockPool()
+    const cb1 = vi.fn()
+    const cb2 = vi.fn()
+
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    mgr.on({ onAcquired: cb1 })
+    mgr.on({ onAcquired: cb2 }) // replaces cb1
+
+    await mgr.start()
+    await mgr.stop()
+
+    expect(cb1).not.toHaveBeenCalled()
+    expect(cb2).toHaveBeenCalledTimes(1)
+  })
+
+  it('on() allows registering different event keys', async () => {
+    const pool = createMockPool()
+    const onAcquired = vi.fn()
+    const onReleased = vi.fn()
+
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    mgr.on({ onAcquired })
+    mgr.on({ onReleased })
+
+    await mgr.start()
+    await mgr.stop()
+
+    expect(onAcquired).toHaveBeenCalledTimes(1)
+    expect(onReleased).toHaveBeenCalledTimes(1)
+  })
+
+  it('state change does not fire when already in target state', async () => {
+    const pool = createMockPool()
+    const onStateChange = vi.fn()
+
+    const mgr = new WorkerLeaseManager({ pool: pool as any })
+    mgr.on({ onStateChange })
+
+    await mgr.start()
+
+    // Only one state change (standby → leader)
+    expect(onStateChange).toHaveBeenCalledTimes(1)
+    expect(onStateChange).toHaveBeenCalledWith('leader')
+
+    await mgr.stop()
+
+    // leader → standby
+    expect(onStateChange).toHaveBeenCalledTimes(2)
+    expect(onStateChange).toHaveBeenLastCalledWith('standby')
+  })
+})

--- a/src/jobs/workerLeaseManager.ts
+++ b/src/jobs/workerLeaseManager.ts
@@ -1,0 +1,244 @@
+import type { Pool, PoolClient } from 'pg'
+import { logger } from '../utils/logger.js'
+
+/**
+ * Advisory lock key used for outbox worker leadership.
+ *
+ * All outbox publisher instances use this same integer so that only one can
+ * hold the lock at a time.  The value is an arbitrary but stable constant
+ * chosen to avoid collision with other advisory-lock users in the system.
+ */
+export const OUTBOX_LEADER_LOCK_KEY = 53_81
+
+export interface WorkerLeaseManagerOptions {
+  /** Postgres connection pool. */
+  pool: Pool
+  /** Advisory lock key.  Default: {@link OUTBOX_LEADER_LOCK_KEY}. */
+  lockKey?: number
+  /** How often (ms) to attempt acquisition when in standby mode.  Default: 5000. */
+  retryIntervalMs?: number
+  /** How often (ms) to heartbeat / verify ownership while leader.  Default: 10000. */
+  heartbeatIntervalMs?: number
+  /** Clock injection for deterministic tests. */
+  now?: () => Date
+  /** Logger override. */
+  log?: (msg: string) => void
+}
+
+export type WorkerLeaseState = 'standby' | 'leader'
+
+export interface WorkerLeaseEvents {
+  onStateChange?: (state: WorkerLeaseState) => void
+  onAcquired?: () => void
+  onReleased?: () => void
+  onError?: (error: Error) => void
+}
+
+/**
+ * Ensures only one outbox publisher instance runs at a time by using a
+ * Postgres session-level advisory lock.
+ *
+ * ### How it works
+ *
+ * 1. On `start()`, the manager checks out a dedicated connection from the
+ *    pool and calls `pg_advisory_lock($1)` on it.
+ * 2. If the lock is acquired, the instance becomes **leader** and its
+ *    `onStateChange('leader')` callback fires.  A heartbeat timer verifies
+ *    the connection is still alive.
+ * 3. If the lock is not immediately available (`pg_advisory_try_lock`
+ *    returns false), the instance stays in **standby** and retries every
+ *    `retryIntervalMs`.
+ * 4. On `stop()`, the manager calls `pg_advisory_unlock($1)` and releases
+ *    the connection back to the pool.
+ * 5. If the dedicated connection drops (DB restart, network partition), the
+ *    advisory lock is automatically released by Postgres.  The heartbeat
+ *    detects the broken connection, releases the client, and re-enters
+ *    standby mode to retry.
+ *
+ * Advisory locks are **session-level** — the lock lives as long as the
+ * underlying Postgres backend session.  This is ideal for long-lived
+ * leader ownership because there is no TTL-based expiry to manage; the
+ * lock is held until the connection is explicitly closed or lost.
+ */
+export class WorkerLeaseManager {
+  private readonly pool: Pool
+  private readonly lockKey: number
+  private readonly retryIntervalMs: number
+  private readonly heartbeatIntervalMs: number
+  private readonly now: () => Date
+  private readonly log: (msg: string) => void
+
+  private client: PoolClient | null = null
+  private running = false
+  private state: WorkerLeaseState = 'standby'
+  private retryTimer: NodeJS.Timeout | null = null
+  private heartbeatTimer: NodeJS.Timeout | null = null
+  private events: WorkerLeaseEvents = {}
+
+  constructor(opts: WorkerLeaseManagerOptions) {
+    this.pool = opts.pool
+    this.lockKey = opts.lockKey ?? OUTBOX_LEADER_LOCK_KEY
+    this.retryIntervalMs = opts.retryIntervalMs ?? 5_000
+    this.heartbeatIntervalMs = opts.heartbeatIntervalMs ?? 10_000
+    this.now = opts.now ?? (() => new Date())
+    this.log = opts.log ?? ((msg) => logger.info(msg))
+  }
+
+  /** Current leadership state. */
+  get currentState(): WorkerLeaseState {
+    return this.state
+  }
+
+  /** Register lifecycle callbacks. */
+  on(events: WorkerLeaseEvents): void {
+    this.events = { ...this.events, ...events }
+  }
+
+  /**
+   * Start the lease manager.  Attempts to acquire the advisory lock
+   * immediately and begins retrying if unsuccessful.
+   */
+  async start(): Promise<void> {
+    if (this.running) return
+    this.running = true
+    this.log(`[WorkerLease] Starting (lockKey=${this.lockKey}, retry=${this.retryIntervalMs}ms)`)
+
+    // Attempt acquisition immediately
+    await this.tryAcquire()
+  }
+
+  /**
+   * Stop the lease manager, release the advisory lock, and clean up timers.
+   */
+  async stop(): Promise<void> {
+    if (!this.running) return
+    this.running = false
+
+    this.clearTimers()
+    await this.releaseLock()
+    this.setState('standby')
+    this.log('[WorkerLease] Stopped')
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  private async tryAcquire(): Promise<void> {
+    if (!this.running) return
+
+    // Ensure we have a dedicated connection
+    if (!this.client) {
+      try {
+        this.client = await this.pool.connect()
+      } catch (err) {
+        this.events.onError?.(err instanceof Error ? err : new Error(String(err)))
+        this.scheduleRetry()
+        return
+      }
+    }
+
+    try {
+      const { rows } = await this.client.query<{ pg_advisory_lock: boolean }>(
+        'SELECT pg_advisory_lock($1) AS pg_advisory_lock',
+        [this.lockKey],
+      )
+
+      const acquired = rows[0]?.pg_advisory_lock === true
+      if (acquired) {
+        this.log(`[WorkerLease] Acquired leadership (lockKey=${this.lockKey})`)
+        this.setState('leader')
+        this.events.onAcquired?.()
+        this.startHeartbeat()
+        return
+      }
+
+      // pg_advisory_lock blocks until acquired, so reaching here is
+      // unexpected with session-level locks.  Log and retry.
+      this.log('[WorkerLease] pg_advisory_lock returned unexpected false — retrying')
+      this.scheduleRetry()
+    } catch (err) {
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)))
+      await this.releaseClient()
+      this.scheduleRetry()
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.clearTimers()
+
+    this.heartbeatTimer = setInterval(() => {
+      this.heartbeat().catch((err) => {
+        this.events.onError?.(err instanceof Error ? err : new Error(String(err)))
+      })
+    }, this.heartbeatIntervalMs)
+  }
+
+  private async heartbeat(): Promise<void> {
+    if (!this.running || this.state !== 'leader' || !this.client) return
+
+    try {
+      // Verify connection is alive — if the backend session dropped, this
+      // will throw and we re-enter standby.
+      await this.client.query('SELECT 1')
+    } catch {
+      this.log('[WorkerLease] Heartbeat failed — connection lost, reverting to standby')
+      await this.releaseClient()
+      this.setState('standby')
+      this.events.onReleased?.()
+      this.scheduleRetry()
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (!this.running) return
+
+    this.clearTimers()
+    this.retryTimer = setTimeout(() => {
+      void this.tryAcquire()
+    }, this.retryIntervalMs)
+  }
+
+  private async releaseLock(): Promise<void> {
+    if (!this.client) return
+
+    try {
+      await this.client.query('SELECT pg_advisory_unlock($1)', [this.lockKey])
+      this.log(`[WorkerLease] Released advisory lock (lockKey=${this.lockKey})`)
+      this.events.onReleased?.()
+    } catch {
+      // Connection may already be dead — nothing to do
+    } finally {
+      await this.releaseClient()
+    }
+  }
+
+  private async releaseClient(): Promise<void> {
+    if (!this.client) return
+    try {
+      this.client.release()
+    } catch {
+      // ignore
+    }
+    this.client = null
+  }
+
+  private clearTimers(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private setState(newState: WorkerLeaseState): void {
+    if (this.state === newState) return
+    const prev = this.state
+    this.state = newState
+    this.events.onStateChange?.(newState)
+    this.log(`[WorkerLease] State: ${prev} → ${newState}`)
+  }
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -37,6 +37,8 @@ export {
   setOutboxPendingGauge,
   incrementOutboxLeaseRenew,
   incrementOutboxQuarantine,
+  incrementOutboxLeaderAcquired,
+  incrementOutboxLeaderLost,
 } from './outboxMetrics.js'
 
 export {

--- a/src/observability/outboxMetrics.ts
+++ b/src/observability/outboxMetrics.ts
@@ -19,6 +19,8 @@ let _failedCounter: any | undefined = undefined
 let _pendingGauge: any | undefined = undefined
 let _leaseRenewCounter: any | undefined = undefined
 let _quarantineCounter: any | undefined = undefined
+let _leaderAcquiredCounter: any | undefined = undefined
+let _leaderLostCounter: any | undefined = undefined
 
 function getMetric(name: string, type: 'Counter' | 'Gauge', help: string, labelNames: string[] = []) {
     const prom = tryLoadPromClient()
@@ -91,6 +93,24 @@ export function incrementOutboxQuarantine(reason: string = 'unknown') {
     }
 }
 
+export function incrementOutboxLeaderAcquired() {
+    if (!_leaderAcquiredCounter) {
+        _leaderAcquiredCounter = getMetric('outbox_leader_acquired_total', 'Counter', 'Total number of times this instance acquired outbox leadership')
+    }
+    if (_leaderAcquiredCounter) {
+        try { _leaderAcquiredCounter.inc(1) } catch {}
+    }
+}
+
+export function incrementOutboxLeaderLost() {
+    if (!_leaderLostCounter) {
+        _leaderLostCounter = getMetric('outbox_leader_lost_total', 'Counter', 'Total number of times this instance lost outbox leadership')
+    }
+    if (_leaderLostCounter) {
+        try { _leaderLostCounter.inc(1) } catch {}
+    }
+}
+
 export function _resetOutboxMetricsCacheForTests(): void {
     const prom = tryLoadPromClient()
     if (prom) {
@@ -103,4 +123,6 @@ export function _resetOutboxMetricsCacheForTests(): void {
     _pendingGauge = undefined
     _leaseRenewCounter = undefined
     _quarantineCounter = undefined
+    _leaderAcquiredCounter = undefined
+    _leaderLostCounter = undefined
 }


### PR DESCRIPTION
Introduces WorkerLeaseManager that uses pg_advisory_lock on a dedicated connection to ensure only one worker instance runs the outbox publish loop at a time. Leaders heartbeat the lock and automatically step down on failure; standbys retry acquisition. Opt-in via OUTBOX_LEADER_LEASE_ENABLED=false (backwards-compatible default). Includes unit tests, Prometheus metrics, env var config, and documentation.

Closes #690