### PR TITLE
feat(db): log slow queries with their EXPLAIN plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ DB_POOL_CONNECTION_TIMEOUT_MS=5000
 DB_STATEMENT_TIMEOUT_MS=30000
 # Maximum connections in the worker pool for background jobs (default: 5)
 DB_WORKER_POOL_MAX=5
+# Minimum query duration (ms) that triggers a slow-query log entry with the
+# query's EXPLAIN plan attached. Set to 0 to disable. (default: 1000)
+SLOW_QUERY_THRESHOLD_MS=1000
 
 # ── Redis ────────────────────────────────────────────────────────────────────
 REDIS_URL=redis://localhost:6379

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -204,6 +204,7 @@ npx eslint src/ --rule 'logger-schema/require-schema-context: warn'
 | `HTTP_ERROR`                         | `message`, `method`, `path`, `statusCode`, `error`, `stack`, `requestId` | Request error           |
 | `AUTH_LOGIN`                         | `message`, `method`, `success`                                    | Login events                 |
 | `AUTH_FAILURE`                       | `message`, `method`, `reason`                                     | Auth failure events          |
+| `DB_SLOW_QUERY`                      | `message`, `query`, `durationMs`, `thresholdMs`, `pool`, `plan`   | Query exceeded slow-query threshold |
 | `GENERIC_INFO` / `GENERIC_ERROR`     | `message` (+ `error`/`stack` for ERROR)                           | Fallback schemas             |
 
 ### Testing Redaction
@@ -338,6 +339,47 @@ const result = await txManager.withTransaction(
 ```
 
 The span is created via the `withSpan` utility and exported by the configured `SpanProcessor` (ConsoleSpanExporter in dev; OTLP in production).
+
+## Slow Query Logging
+
+Every query issued through `pool`, `workerPool`, or `replicaPool` (`src/db/pool.ts`) is timed. Any query taking at least `SLOW_QUERY_THRESHOLD_MS` (default `1000`, i.e. 1 second; `0` disables the check) emits a `db:slow-query` structured log — `LogEventType.DB_SLOW_QUERY` — with the query's plan attached, and increments Prometheus metrics.
+
+| Field         | Type   | Description                                                        |
+|---------------|--------|---------------------------------------------------------------------|
+| `message`     | string | `"Slow query exceeded threshold"`                                   |
+| `query`       | string | The parameterized query text (e.g. `... WHERE id = $1`), truncated to 4000 characters. Bind parameter *values* are never logged. |
+| `durationMs`  | number | Observed query duration, rounded to the nearest millisecond.        |
+| `thresholdMs` | number | The configured `SLOW_QUERY_THRESHOLD_MS` value at the time of the call. |
+| `pool`        | string | Which pool ran the query: `"api"`, `"worker"`, or `"replica"`.      |
+| `plan`        | string | JSON-stringified output of `EXPLAIN (FORMAT JSON) <query>`, run against the same query text and bind parameters. Omitted if EXPLAIN itself fails. |
+
+### Why plain `EXPLAIN`, not `EXPLAIN ANALYZE`
+
+`EXPLAIN ANALYZE` re-executes the statement to gather real timing, which would duplicate side effects for mutating queries (`INSERT`/`UPDATE`/`DELETE`) every time one runs slowly. Plain `EXPLAIN` only plans the query — it never executes it — so it is safe to run unconditionally after any slow query, including writes.
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|--------------|
+| `SLOW_QUERY_THRESHOLD_MS` | `1000` | Minimum query duration (ms) that triggers a slow-query log entry. `0` disables slow-query logging entirely. |
+
+### Metrics
+
+- **`db_slow_queries_total`** (Counter, labeled by `pool`): total number of queries that exceeded the threshold.
+- **`db_slow_query_duration_seconds`** (Histogram, labeled by `pool`): duration distribution of queries that exceeded the threshold.
+
+### Example log line
+
+```json
+{
+  "message": "Slow query exceeded threshold",
+  "query": "SELECT * FROM attestations WHERE subject_id = $1",
+  "durationMs": 1342,
+  "thresholdMs": 1000,
+  "pool": "api",
+  "plan": "[{\"Plan\":{\"Node Type\":\"Seq Scan\",\"Relation Name\":\"attestations\",\"Total Cost\":48123.0}}]"
+}
+```
 
 ## Outbox Publisher Observability (Issue #329)
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -85,6 +85,16 @@ export const envSchema = z.object({
     .default('10000')
     .transform(Number)
     .pipe(z.number().int().min(100).max(60000)),
+  /**
+   * Minimum query duration (ms) that triggers a slow-query log entry with
+   * the query's EXPLAIN plan attached. Set to 0 to disable. Default: 1000
+   * (1 second) — see docs/observability.md#slow-query-logging.
+   */
+  SLOW_QUERY_THRESHOLD_MS: z
+    .string()
+    .default('1000')
+    .transform(Number)
+    .pipe(z.number().int().min(0)),
 
   // Redis
   REDIS_URL: z.string().url({ message: 'REDIS_URL must be a valid URL' }),
@@ -420,6 +430,8 @@ export interface Config {
     workerPool: {
       max: number
     }
+    /** Minimum query duration (ms) that triggers a slow-query log entry. 0 disables. */
+    slowQueryThresholdMs: number
   }
   redis: {
     url: string
@@ -619,6 +631,7 @@ function mapEnvToConfig(env: Env): Config {
       workerPool: {
         max: env.DB_WORKER_POOL_MAX,
       },
+      slowQueryThresholdMs: env.SLOW_QUERY_THRESHOLD_MS,
     },
     redis: {
       url: env.REDIS_URL,

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,6 +1,8 @@
-import { Pool, type PoolClient } from "pg";
+import { Pool, type PoolClient, type QueryResult } from "pg";
 import dotenv from "dotenv";
 import { logger } from "../utils/logger.js";
+import { LogEventType } from "../observability/logSchemas.js";
+import { redact } from "../observability/redaction.js";
 
 dotenv.config();
 
@@ -22,6 +24,13 @@ const IDLE_TIMEOUT = envInt("DB_POOL_IDLE_TIMEOUT_MS", 30_000);
 const CONN_TIMEOUT = envInt("DB_POOL_CONNECTION_TIMEOUT_MS", 5_000);
 const STMT_TIMEOUT = envInt("DB_STATEMENT_TIMEOUT_MS", 30_000);
 const WORKER_MAX = envInt("DB_WORKER_POOL_MAX", 5);
+
+/**
+ * Minimum query duration (ms) that triggers a slow-query log entry with the
+ * query's EXPLAIN plan attached. 0 disables slow-query logging entirely.
+ * See docs/observability.md#slow-query-logging.
+ */
+const SLOW_QUERY_THRESHOLD_MS = envInt("SLOW_QUERY_THRESHOLD_MS", 1_000);
 
 const DB_REPLICA_URL = process.env.DB_REPLICA_URL || DB_URL;
 const MAX_REPLICA_LAG_MS = envInt("MAX_REPLICA_LAG_MS", 1000);
@@ -78,6 +87,149 @@ export const replicaPool = new Pool({
 replicaPool.on("error", (err) => {
   logger.error("[replicaPool] unexpected client error", err);
 });
+
+type PoolName = "api" | "worker" | "replica";
+
+/** Maximum characters of query text kept in a slow-query log line. */
+const MAX_LOGGED_QUERY_LENGTH = 4_000;
+
+function truncateQueryText(text: string): string {
+  return text.length > MAX_LOGGED_QUERY_LENGTH
+    ? `${text.slice(0, MAX_LOGGED_QUERY_LENGTH)}…[truncated]`
+    : text;
+}
+
+function extractQueryText(args: unknown[]): string | undefined {
+  const first = args[0];
+  if (typeof first === "string") return first;
+  if (first && typeof first === "object" && "text" in first) {
+    const text = (first as { text?: unknown }).text;
+    return typeof text === "string" ? text : undefined;
+  }
+  return undefined;
+}
+
+function extractQueryParams(args: unknown[]): unknown[] | undefined {
+  const first = args[0];
+  if (first && typeof first === "object" && "values" in first) {
+    const values = (first as { values?: unknown }).values;
+    return Array.isArray(values) ? values : undefined;
+  }
+  return Array.isArray(args[1]) ? (args[1] as unknown[]) : undefined;
+}
+
+/**
+ * Logs a slow-query event (with EXPLAIN plan) once `durationMs` exceeds
+ * `thresholdMs`. Uses plain `EXPLAIN` — never `EXPLAIN ANALYZE` — because
+ * ANALYZE re-executes the statement, which would duplicate side effects for
+ * mutating queries (INSERT/UPDATE/DELETE). Bind parameter *values* are
+ * never logged, only the parameterized query text and the estimated plan,
+ * so this cannot leak PII/secrets passed as query parameters.
+ */
+async function reportIfSlow(
+  originalQuery: (...args: unknown[]) => Promise<QueryResult>,
+  poolName: PoolName,
+  thresholdMs: number,
+  args: unknown[],
+  startedAt: bigint
+): Promise<void> {
+  const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+  if (durationMs < thresholdMs) return;
+
+  const text = extractQueryText(args);
+  if (!text) return;
+
+  // Imported lazily (rather than at module top level) so that constructing
+  // a Pool never has a side effect on prom-client's global metrics
+  // registry — module-reload-heavy tests (e.g. pool.test.ts) re-evaluate
+  // this file's top level repeatedly, which would otherwise re-register
+  // the same metric name and throw.
+  const { dbSlowQueriesTotal, dbSlowQueryDurationSeconds } = await import("../observability/customMetrics.js");
+  dbSlowQueriesTotal.inc({ pool: poolName });
+  dbSlowQueryDurationSeconds.observe({ pool: poolName }, durationMs / 1000);
+
+  // Best-effort: if EXPLAIN itself fails (e.g. the statement isn't
+  // EXPLAIN-able in isolation), still emit the slow-query log below with
+  // plan omitted rather than losing the timing signal entirely.
+  let plan: string | undefined;
+  try {
+    const params = extractQueryParams(args);
+    const explainResult = await originalQuery(`EXPLAIN (FORMAT JSON) ${text}`, params);
+    const planJson = explainResult.rows[0]?.["QUERY PLAN"];
+    plan = planJson !== undefined ? truncateQueryText(JSON.stringify(planJson)) : undefined;
+  } catch {
+    plan = undefined;
+  }
+
+  logger.warn(
+    redact(
+      {
+        eventType: LogEventType.DB_SLOW_QUERY,
+        message: "Slow query exceeded threshold",
+        query: truncateQueryText(text),
+        durationMs: Math.round(durationMs),
+        thresholdMs,
+        pool: poolName,
+        plan,
+      },
+      { eventType: LogEventType.DB_SLOW_QUERY }
+    )
+  );
+}
+
+/**
+ * Wraps `target.query` so that any call taking at least `thresholdMs`
+ * (default `SLOW_QUERY_THRESHOLD_MS`) is logged together with its EXPLAIN
+ * plan. A `thresholdMs` of 0 disables instrumentation.
+ * @internal Exported for testing only.
+ */
+export function instrumentSlowQueryLogging(
+  target: Pool,
+  poolName: PoolName,
+  thresholdMs: number = SLOW_QUERY_THRESHOLD_MS
+): void {
+  if (thresholdMs <= 0) return;
+
+  const originalQuery = target.query.bind(target) as (...args: unknown[]) => unknown;
+
+  target.query = ((...args: unknown[]) => {
+    // Callback-style calls aren't used anywhere in this codebase; pass them
+    // through unmodified rather than instrumenting a shape we can't time.
+    if (typeof args[args.length - 1] === "function") {
+      return originalQuery(...args);
+    }
+
+    const startedAt = process.hrtime.bigint();
+    const result = originalQuery(...args) as Promise<QueryResult>;
+
+    return result.then(
+      (res) => {
+        void reportIfSlow(
+          originalQuery as (...a: unknown[]) => Promise<QueryResult>,
+          poolName,
+          thresholdMs,
+          args,
+          startedAt
+        );
+        return res;
+      },
+      (err) => {
+        void reportIfSlow(
+          originalQuery as (...a: unknown[]) => Promise<QueryResult>,
+          poolName,
+          thresholdMs,
+          args,
+          startedAt
+        );
+        throw err;
+      }
+    );
+  }) as unknown as Pool["query"];
+}
+
+instrumentSlowQueryLogging(pool, "api");
+instrumentSlowQueryLogging(workerPool, "worker");
+instrumentSlowQueryLogging(replicaPool, "replica");
 
 /**
  * Helper to execute an operation on the replica, falling back to primary

--- a/src/db/slowQueryLogging.test.ts
+++ b/src/db/slowQueryLogging.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Pool, QueryResult } from 'pg'
+import { instrumentSlowQueryLogging } from './pool.js'
+import { logger } from '../utils/logger.js'
+import { dbSlowQueriesTotal, dbSlowQueryDurationSeconds } from '../observability/customMetrics.js'
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('instrumentSlowQueryLogging', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined)
+    dbSlowQueriesTotal.reset()
+    dbSlowQueryDurationSeconds.reset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Negative test: before this change, no code timed queries or emitted a
+  // slow-query log at all, so this assertion fails on main. After the fix,
+  // a query exceeding the threshold is logged together with its plan.
+  it('logs a slow query together with its EXPLAIN plan, without leaking bind values', async () => {
+    const mainResult = { rows: [{ id: 1 }], rowCount: 1 } as unknown as QueryResult
+    const explainPlan = [{ Plan: { 'Node Type': 'Seq Scan', 'Relation Name': 'users' } }]
+
+    const query = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 15))
+        return mainResult
+      })
+      .mockImplementationOnce(async (text: string) => {
+        expect(text).toMatch(/^EXPLAIN \(FORMAT JSON\) SELECT/)
+        return { rows: [{ 'QUERY PLAN': explainPlan }] } as unknown as QueryResult
+      })
+
+    const fakePool = { query } as unknown as Pool
+    instrumentSlowQueryLogging(fakePool, 'api', 5)
+
+    const result = await fakePool.query('SELECT * FROM users WHERE ssn = $1', ['secret-ssn-value'])
+    expect(result).toBe(mainResult)
+
+    await flushMicrotasks()
+
+    expect(query).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+
+    const [payload] = warnSpy.mock.calls[0] as [Record<string, unknown>]
+    expect(payload.message).toBe('Slow query exceeded threshold')
+    expect(payload.query).toBe('SELECT * FROM users WHERE ssn = $1')
+    expect(payload.pool).toBe('api')
+    expect(payload.thresholdMs).toBe(5)
+    expect(payload.plan).toBe(JSON.stringify(explainPlan))
+    expect(payload.durationMs as number).toBeGreaterThanOrEqual(5)
+
+    // Bind parameter values must never be logged, only the placeholder text.
+    expect(JSON.stringify(payload)).not.toContain('secret-ssn-value')
+  })
+
+  it('does not log or call EXPLAIN for a query that completes below the threshold', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 } as unknown as QueryResult)
+    const fakePool = { query } as unknown as Pool
+    instrumentSlowQueryLogging(fakePool, 'api', 10_000)
+
+    await fakePool.query('SELECT 1')
+    await flushMicrotasks()
+
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not wrap query() when thresholdMs is 0 (disabled)', () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] } as unknown as QueryResult)
+    const fakePool = { query } as unknown as Pool
+    const original = fakePool.query
+
+    instrumentSlowQueryLogging(fakePool, 'api', 0)
+
+    expect(fakePool.query).toBe(original)
+  })
+
+  it('still logs (with plan omitted) when EXPLAIN itself fails', async () => {
+    const query = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return { rows: [] } as unknown as QueryResult
+      })
+      .mockRejectedValueOnce(new Error('syntax error at or near "EXPLAIN"'))
+
+    const fakePool = { query } as unknown as Pool
+    instrumentSlowQueryLogging(fakePool, 'api', 5)
+
+    await fakePool.query('SELECT pg_sleep(1)')
+    await flushMicrotasks()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const [payload] = warnSpy.mock.calls[0] as [Record<string, unknown>]
+    expect(payload.plan).toBeUndefined()
+  })
+
+  it('still reports a slow query that ultimately rejects', async () => {
+    const query = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        throw new Error('connection terminated')
+      })
+      .mockResolvedValueOnce({ rows: [{ 'QUERY PLAN': [{}] }] } as unknown as QueryResult)
+
+    const fakePool = { query } as unknown as Pool
+    instrumentSlowQueryLogging(fakePool, 'api', 5)
+
+    await expect(
+      fakePool.query('DELETE FROM sessions WHERE id = $1', ['abc'])
+    ).rejects.toThrow('connection terminated')
+    await flushMicrotasks()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses plain EXPLAIN, never EXPLAIN ANALYZE, so mutating queries are not re-executed', async () => {
+    const query = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return { rows: [], rowCount: 1 } as unknown as QueryResult
+      })
+      .mockImplementationOnce(async (text: string) => {
+        expect(text).not.toContain('ANALYZE')
+        return { rows: [{ 'QUERY PLAN': [{}] }] } as unknown as QueryResult
+      })
+
+    const fakePool = { query } as unknown as Pool
+    instrumentSlowQueryLogging(fakePool, 'api', 5)
+
+    await fakePool.query('DELETE FROM sessions WHERE id = $1', ['abc'])
+    await flushMicrotasks()
+
+    expect(query).toHaveBeenCalledTimes(2)
+  })
+
+  it('increments the slow-query counter and duration histogram', async () => {
+    const query = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return { rows: [] } as unknown as QueryResult
+      })
+      .mockResolvedValueOnce({ rows: [{ 'QUERY PLAN': [{}] }] } as unknown as QueryResult)
+
+    const fakePool = { query } as unknown as Pool
+    instrumentSlowQueryLogging(fakePool, 'worker', 5)
+
+    await fakePool.query('SELECT 1')
+    await flushMicrotasks()
+
+    const counterValue = await dbSlowQueriesTotal.get()
+    const workerSample = counterValue.values.find((v) => v.labels.pool === 'worker')
+    expect(workerSample?.value).toBe(1)
+
+    const histogramValue = await dbSlowQueryDurationSeconds.get()
+    const workerHistogramSample = histogramValue.values.find(
+      (v) => v.labels.pool === 'worker' && v.metricName?.endsWith('_count')
+    )
+    expect(workerHistogramSample?.value).toBe(1)
+  })
+})

--- a/src/observability/customMetrics.ts
+++ b/src/observability/customMetrics.ts
@@ -45,6 +45,27 @@ export const dbTxnSavepoints = new client.Histogram({
 });
 
 /**
+ * Counter for queries whose duration exceeded SLOW_QUERY_THRESHOLD_MS.
+ */
+export const dbSlowQueriesTotal = new client.Counter({
+  name: 'db_slow_queries_total',
+  help: 'Total number of database queries exceeding SLOW_QUERY_THRESHOLD_MS',
+  labelNames: ['pool'],
+  registers: [client.register],
+});
+
+/**
+ * Duration histogram for queries whose duration exceeded SLOW_QUERY_THRESHOLD_MS.
+ */
+export const dbSlowQueryDurationSeconds = new client.Histogram({
+  name: 'db_slow_query_duration_seconds',
+  help: 'Duration of database queries that exceeded SLOW_QUERY_THRESHOLD_MS, in seconds',
+  labelNames: ['pool'],
+  buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10, 30],
+  registers: [client.register],
+});
+
+/**
  * Counter for WebSocket slow consumers that were evicted.
  */
 export const wsEvictedSlowConsumersTotal = new client.Counter({
@@ -65,5 +86,6 @@ export function registerSyntheticMetrics(registry?: client.Registry): void {
   reg.registerMetric(dbTxnDurationSeconds);
   reg.registerMetric(dbTxnSavepoints);
   reg.registerMetric(wsEvictedSlowConsumersTotal);
+  reg.registerMetric(dbSlowQueriesTotal);
+  reg.registerMetric(dbSlowQueryDurationSeconds);
 }
-

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -44,5 +44,7 @@ export {
   syntheticProbeFailureTotal,
   dbTxnDurationSeconds,
   dbTxnSavepoints,
+  dbSlowQueriesTotal,
+  dbSlowQueryDurationSeconds,
   registerSyntheticMetrics,
 } from './customMetrics.js'

--- a/src/observability/logSchemas.ts
+++ b/src/observability/logSchemas.ts
@@ -52,6 +52,9 @@ export enum LogEventType {
   // ── Audit Chain Verifier Events ──
   AUDIT_CHAIN_VERIFICATION = "audit-chain:verification",
 
+  // ── Database Events ──
+  DB_SLOW_QUERY = "db:slow-query",
+
   // ── Generic Fallback Events ──
   GENERIC_INFO = "generic:info",
   GENERIC_ERROR = "generic:error",
@@ -236,6 +239,23 @@ export const LOG_SCHEMAS: Record<LogEventType, Record<string, FieldSchema>> = {
     lastCheckedSeq: { type: "number" },
     firstViolationSeq: { type: "number" },
     checkedAt: { type: "string" },
+  },
+
+  // ── Database ──
+
+  [LogEventType.DB_SLOW_QUERY]: {
+    message: { type: "string" },
+    // Parameterized query text (e.g. "... WHERE id = $1") — bind values are
+    // never included, so this cannot leak PII/secrets passed as query params.
+    query: { type: "string" },
+    durationMs: { type: "number" },
+    thresholdMs: { type: "number" },
+    pool: { type: "string" },
+    // JSON-stringified EXPLAIN (FORMAT JSON) output. Kept as a string
+    // (rather than a nested object/array) because the plan's shape varies
+    // per query and per node type, which the allowlist schema can't
+    // usefully describe field-by-field.
+    plan: { type: "string" },
   },
 
   // ── Generic Fallback ──


### PR DESCRIPTION
Closes #678

## Summary

Any database query that runs at least `SLOW_QUERY_THRESHOLD_MS` (default 1000ms) is now logged together with its EXPLAIN plan, so operators and on-call engineers can see why a query was slow without reproducing it, attaching a debugger, or re-running EXPLAIN by hand after the fact.

## What's implemented

**New files**
- `src/db/slowQueryLogging.test.ts` — test suite (see below).

**Modified files**
- `src/db/pool.ts` — the core change. `instrumentSlowQueryLogging(target, poolName, thresholdMs)` wraps `query()` on the `api`, `worker`, and `replica` pools (`pool`, `workerPool`, `replicaPool`). Every call is timed via `process.hrtime.bigint()`; once a call's duration reaches the threshold, it:
  1. Increments `db_slow_queries_total` / observes `db_slow_query_duration_seconds`, labeled by pool.
  2. Runs plain `EXPLAIN (FORMAT JSON) <query>` against the same query text and bind parameters, using the *original* (un-instrumented) query function so the EXPLAIN call itself isn't re-timed/re-logged.
  3. Emits a `db:slow-query` structured log via `logger.warn()`, passed through the existing `redact()`/schema pipeline.

  A threshold of `0` disables instrumentation entirely (the pool's `query` method is left untouched). Callback-style `query()` calls are passed through unmodified rather than instrumented — no call site in this codebase uses that form, so there was nothing to preserve semantics for, but it keeps the wrapper from mis-timing a shape it can't safely await.

- `src/observability/logSchemas.ts` — adds `LogEventType.DB_SLOW_QUERY` (`db:slow-query`) and its allowlist schema: `message`, `query`, `durationMs`, `thresholdMs`, `pool`, `plan`.
- `src/observability/customMetrics.ts`, `src/observability/index.ts` — adds `db_slow_queries_total` (Counter) and `db_slow_query_duration_seconds` (Histogram), both labeled by `pool`, following the existing `dbTxnDurationSeconds`/`dbTxnSavepoints` pattern.
- `src/config/index.ts` — adds `SLOW_QUERY_THRESHOLD_MS` to the validated Zod env schema and `Config.db`, following the existing `DB_STATEMENT_TIMEOUT_MS` pattern (the pool itself reads the raw env var directly via `envInt()`, matching how the rest of `pool.ts`'s own timeouts are configured; the config-schema entry keeps the value validated/documented alongside the other DB settings for consumers that read `Config` rather than `pool.ts` internals).
- `.env.example` — documents `SLOW_QUERY_THRESHOLD_MS` in the "Database Pool Tuning" section.
- `docs/observability.md` — new "Slow Query Logging" section (fields, config, metrics, example log line) plus a `DB_SLOW_QUERY` row in the "Known Event Types" table.

## Implementation details

**Why plain `EXPLAIN`, never `EXPLAIN ANALYZE`.** `ANALYZE` re-executes the statement to gather real timing. For a mutating query (`INSERT`/`UPDATE`/`DELETE`) that would duplicate the side effect every single time it happens to run slowly — a correctness bug, not just a performance one. Plain `EXPLAIN` only plans the query; it never executes it, so it's safe to run unconditionally after any slow query, including writes.

**Why bind parameter values are never logged.** Only the parameterized query text (`... WHERE id = $1`) and the plan are included in the log; the bind values array is used solely to run the `EXPLAIN` call and is never serialized into the log payload. Since query parameters can carry PII or secrets (emails, tokens, etc.), logging them by default would be a real leak — this keeps the feature safe without needing per-field redaction rules for arbitrary query params.

**Why the plan is JSON-stringified rather than logged as a nested object.** `EXPLAIN (FORMAT JSON)` returns a `[{ Plan: {...} }]` array whose shape varies by query and node type, which the allowlist-schema redaction system (`src/observability/redaction.ts`) can't usefully describe field-by-field. Serializing it to a string keeps it a single scalar field the schema can allow outright, while still fully preserving the plan content for anyone reading the log (and Postgres itself will already have applied the substitution — the plan for a parameterized statement shows `$1`-style placeholders, not literal bind values, so serializing it doesn't reintroduce a leak).

**Why the metrics import is lazy.** `src/db/pool.ts` imports `../observability/customMetrics.js` inside `reportIfSlow()` via a dynamic `import()`, not at module top level. `customMetrics.ts` registers its Prometheus metrics as a side effect of being imported, against `prom-client`'s CJS-singleton default registry. `src/db/pool.test.ts` repeatedly does `vi.resetModules()` + fresh `await import('./pool.js')` per test to exercise different env-var configurations; a top-level import would have re-run `customMetrics.ts`'s metric registration on every one of those resets and thrown `"already registered"` — a real regression this caused during development (see test run history). The `prom-client` registry singleton survives `vi.resetModules()` because it's a CJS/`node_modules` module, unlike the project's own ESM source files. Deferring the import to only run when a slow query actually occurs (never touched by `pool.test.ts`'s existing tests, which don't drive a real query through the instrumented wrapper) sidesteps the whole class of failure without touching any pre-existing metric registration code.

## Threat/impact framing

This isn't a security fix — it's an observability gap. Before this change, diagnosing a slow admin/API query required either enabling Postgres's own `log_min_duration_statement` at the DB level (extra ops overhead, no application context) or manually reproducing and EXPLAIN-ing the query after the fact. Operators, on-call engineers, and anyone debugging a latency regression now get the plan attached to the original slow-query event automatically, in the same structured log stream as everything else.

## Tests added (`src/db/slowQueryLogging.test.ts`)

All tests instrument a fake `{ query: vi.fn() }` pool via `instrumentSlowQueryLogging` (exported `@internal` for testing), so nothing here touches a live database:

- **Logs a slow query together with its EXPLAIN plan, without leaking bind values** — the core negative test: before this change nothing timed queries or emitted this log at all, so this assertion fails on `main`; after the fix, a query exceeding the threshold logs `message`, `query` (placeholder text only), `pool`, `thresholdMs`, `durationMs`, and `plan`, and the serialized payload is asserted to never contain the literal bind value passed to the query.
- **Does not log or call EXPLAIN for a query completing below the threshold** — confirms no noise/overhead for the common case.
- **Does not wrap `query()` when `thresholdMs` is 0** — confirms the disable switch leaves the pool's `query` reference untouched.
- **Still logs (with plan omitted) when EXPLAIN itself fails** — confirms best-effort degradation rather than losing the timing signal.
- **Still reports a slow query that ultimately rejects** — confirms a failing/timing-out query is still worth knowing the plan for.
- **Uses plain EXPLAIN, never EXPLAIN ANALYZE, so mutating queries are not re-executed** — asserts the EXPLAIN call text never contains `ANALYZE`.
- **Increments the slow-query counter and duration histogram** — asserts the Prometheus metrics update correctly, labeled by pool.

## How to test

```bash
npx tsc --noEmit
npx vitest run src/db/slowQueryLogging.test.ts src/db/pool.test.ts
```

Or manually: set `SLOW_QUERY_THRESHOLD_MS=1` (so essentially any query qualifies), start the server, hit any endpoint that runs a DB query, and confirm a `db:slow-query` warn-level log appears with `query`, `durationMs`, `pool`, and `plan` fields. Setting `SLOW_QUERY_THRESHOLD_MS=0` should produce no such logs for any query.

## Verification performed

- `npx tsc --noEmit` — clean.
- `npx vitest run src/db/slowQueryLogging.test.ts src/db/pool.test.ts src/observability src/config` — all pass except 2 pre-existing failures unrelated to this change (`config.test.ts`'s production-CORS-wildcard test and `auditLogsRepository.test.ts`'s pagination test, both reproducible identically on `main` before this branch's changes).
- `npm run security:scan` / `npm run sbom:check` — no new findings; this PR adds no new dependencies.
- Lint (`eslint`) on all touched non-test source files — clean.