### PR TITLE
test: add trace-id propagation test using supertest (#734)

### DIFF
--- a/src/middleware/__tests__/traceIdPropagation.test.ts
+++ b/src/middleware/__tests__/traceIdPropagation.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import express, { type Express, type Request, type Response, type NextFunction } from 'express'
+import request from 'supertest'
+import { requestIdMiddleware } from '../requestId.js'
+import { tracingContext } from '../../utils/logger.js'
+
+/**
+ * Trace-id propagation tests using supertest.
+ *
+ * Assert the x-trace-id header stays consistent through nested calls.
+ * Covers:
+ *  - Happy path: provided x-trace-id propagates to response and inner handlers.
+ *  - Sad path:   missing or empty x-trace-id falls back to auto-generation.
+ */
+describe('Trace ID propagation', () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = express()
+    app.use(requestIdMiddleware)
+  })
+
+  // ── Happy path ──────────────────────────────────────────────────────
+
+  it('returns_same_x_trace_id_when_provided_in_request_header', async () => {
+    const traceId = '00000000-0000-0000-0000-000000000001'
+
+    app.get('/test', (_req: Request, res: Response) => {
+      res.json({ ok: true })
+    })
+
+    const response = await request(app)
+      .get('/test')
+      .set('x-trace-id', traceId)
+
+    expect(response.status).toBe(200)
+    expect(response.headers['x-trace-id']).toBe(traceId)
+  })
+
+  it('keeps_trace_id_consistent_through_nested_middleware_chain', async () => {
+    const traceId = '00000000-0000-0000-0000-000000000002'
+    const capturedTraceIds: (string | undefined)[] = []
+
+    // Middleware layer 1
+    app.use((_req: Request, _res: Response, next: NextFunction) => {
+      capturedTraceIds.push(tracingContext.getStore()?.get('traceId'))
+      next()
+    })
+
+    // Route handler (nested call within the app)
+    app.get('/nested', (req: Request, res: Response) => {
+      capturedTraceIds.push(tracingContext.getStore()?.get('traceId'))
+      // Verify the middleware-attached property matches the context
+      capturedTraceIds.push(req.traceId)
+      res.json({ ok: true })
+    })
+
+    const response = await request(app)
+      .get('/nested')
+      .set('x-trace-id', traceId)
+
+    expect(response.status).toBe(200)
+    // Response header must echo back the same trace-id
+    expect(response.headers['x-trace-id']).toBe(traceId)
+    // Every layer in the chain saw the identical trace-id
+    expect(capturedTraceIds).toHaveLength(3)
+    for (const captured of capturedTraceIds) {
+      expect(captured).toBe(traceId)
+    }
+  })
+
+  it('propagates_trace_id_across_sequential_requests_on_the_same_app', async () => {
+    // Each request may carry a different trace-id; the test verifies that
+    // within a single request/response cycle the trace-id is consistent.
+    const firstTraceId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const secondTraceId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+    app.get('/echo', (req: Request, res: Response) => {
+      const store = tracingContext.getStore()
+      res.json({
+        fromContext: store?.get('traceId'),
+        fromHeader: req.header('x-trace-id'),
+      })
+    })
+
+    const first = await request(app)
+      .get('/echo')
+      .set('x-trace-id', firstTraceId)
+
+    const second = await request(app)
+      .get('/echo')
+      .set('x-trace-id', secondTraceId)
+
+    expect(first.status).toBe(200)
+    expect(first.headers['x-trace-id']).toBe(firstTraceId)
+    expect(first.body.fromContext).toBe(firstTraceId)
+    expect(first.body.fromHeader).toBe(firstTraceId)
+
+    expect(second.status).toBe(200)
+    expect(second.headers['x-trace-id']).toBe(secondTraceId)
+    expect(second.body.fromContext).toBe(secondTraceId)
+    expect(second.body.fromHeader).toBe(secondTraceId)
+  })
+
+  // ── Sad path ────────────────────────────────────────────────────────
+
+  it('generates_new_trace_id_when_header_is_missing', async () => {
+    app.get('/test', (_req: Request, res: Response) => {
+      res.json({ ok: true })
+    })
+
+    const response = await request(app).get('/test')
+
+    expect(response.status).toBe(200)
+    expect(response.headers['x-trace-id']).toBeDefined()
+    const traceId = response.headers['x-trace-id']
+    expect(traceId).toBeTruthy()
+    expect(typeof traceId).toBe('string')
+    // Must be a valid UUID v4
+    expect(traceId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    )
+  })
+
+  it('generates_new_trace_id_when_header_is_empty_string', async () => {
+    app.get('/test', (_req: Request, res: Response) => {
+      res.json({ ok: true })
+    })
+
+    const response = await request(app)
+      .get('/test')
+      .set('x-trace-id', '')
+
+    expect(response.status).toBe(200)
+    const traceId = response.headers['x-trace-id']
+    expect(traceId).toBeTruthy()
+    expect(typeof traceId).toBe('string')
+    // An empty string is falsy, so the middleware must generate a new UUID
+    expect(traceId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    )
+  })
+
+  it('trace_id_is_available_in_tracingContext_for_downstream_handlers', async () => {
+    const traceId = 'deadbeef-dead-beef-dead-beefdeadbeef'
+
+    app.get('/context', (_req: Request, res: Response) => {
+      const store = tracingContext.getStore()
+      res.json({
+        traceId: store?.get('traceId'),
+        requestId: store?.get('requestId'),
+        correlationId: store?.get('correlationId'),
+      })
+    })
+
+    const response = await request(app)
+      .get('/context')
+      .set('x-trace-id', traceId)
+
+    expect(response.status).toBe(200)
+    expect(response.body.traceId).toBe(traceId)
+    // Sanity: other context fields are also populated
+    expect(response.body.requestId).toBeTruthy()
+    expect(response.body.correlationId).toBeTruthy()
+  })
+})

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto'
 import { tracingContext } from '../utils/logger.js'
 
 /**
- * Middleware to handle Request ID, Correlation ID, and context for distributed tracing.
+ * Middleware to handle Request ID, Correlation ID, Trace ID, and context for distributed tracing.
  */
 export const requestIdMiddleware = (
   req: Request,
@@ -16,18 +16,24 @@ export const requestIdMiddleware = (
   // 2. Handle Request ID
   const requestId = (req.header('x-request-id') as string) || randomUUID()
 
-  // 3. Attach IDs to the request object
+  // 3. Handle Trace ID - reuse from incoming header or generate a new one
+  const traceId = (req.header('x-trace-id') as string) || randomUUID()
+
+  // 4. Attach IDs to the request object
   req['correlationId'] = correlationId
   req['requestId'] = requestId
+  req['traceId'] = traceId
 
-  // 4. Return IDs in response headers
+  // 5. Return IDs in response headers
   res.setHeader('x-correlation-id', correlationId)
   res.setHeader('x-request-id', requestId)
+  res.setHeader('x-trace-id', traceId)
 
-  // 5. Wrap the rest of the request in a tracing context
+  // 6. Wrap the rest of the request in a tracing context
   const context = new Map<string, string>()
   context.set('correlationId', correlationId)
   context.set('requestId', requestId)
+  context.set('traceId', traceId)
 
   // Set standardized observability fields
   context.set('route', req.originalUrl || req.path || 'N/A')

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -5,6 +5,7 @@ declare global {
     interface Request {
       requestId: string
       correlationId: string
+      traceId: string
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes #734

Adds a **trace-id propagation test** using supertest. Asserts that the `x-trace-id` header stays consistent through nested middleware calls, as described in #734.

## Background

Test coverage in this area was previously thin: regressions could land without a failing build. This PR locks the contract in place by adding `x-trace-id` header handling to the existing `requestIdMiddleware` and documenting the expected behaviour through executable test cases.

## Changes

### 1. `src/middleware/requestId.ts`
- Added `x-trace-id` header handling alongside existing `x-request-id` and `x-correlation-id`
- Reads `x-trace-id` from incoming request header (or auto-generates a UUID v4 if missing)
- Attaches `traceId` to the request object via `req.traceId`
- Sets `x-trace-id` in the response header
- Stores `traceId` in `tracingContext` (AsyncLocalStorage) for downstream handlers

### 2. `src/types/express.d.ts`
- Added `traceId: string` to the Express `Request` interface augmentation (matching existing `requestId` and `correlationId` declarations)

### 3. `src/middleware/__tests__/traceIdPropagation.test.ts` (new)
- 6 supertest-based tests covering both happy path and sad path:
  - **Happy path:**
    - `returns_same_x_trace_id_when_provided_in_request_header` — header echoes back in response
    - `keeps_trace_id_consistent_through_nested_middleware_chain` — trace-id is identical across middleware layers and the route handler via `tracingContext` and `req.traceId`
    - `propagates_trace_id_across_sequential_requests_on_the_same_app` — different trace-ids per request are isolated correctly
  - **Sad path:**
    - `generates_new_trace_id_when_header_is_missing` — missing header triggers UUID v4 generation
    - `generates_new_trace_id_when_header_is_empty_string` — empty string header triggers UUID v4 generation
    - `trace_id_is_available_in_tracingContext_for_downstream_handlers` — context store contains traceId alongside requestId and correlationId

## How to Test

```bash
# Run the new tests
npx vitest run src/middleware/__tests__/traceIdPropagation.test.ts

# Run all related tests
npx vitest run src/middleware/__tests__/traceIdPropagation.test.ts src/__tests__/requestId.test.ts

# Type-check
npx tsc --noEmit

# Lint
npm run lint
```

## Verification

| Check | Result |
|-------|--------|
| `npx tsc --noEmit` | Zero errors |
| `vitest` (10 tests: 6 new + 4 existing) | All pass |
| `eslint` | No errors |
| Merge conflicts with `upstream/main` | None |

## Acceptance Criteria Checklist

- [x] The change matches the issue summary (trace-id propagation test using supertest)
- [x] The test passes after the fix (middleware now handles `x-trace-id`)
- [x] Tests run on every CI matrix entry (file in `src/**/__tests__/**/*.ts` glob)
- [x] Lint, type-check, and tests all pass locally
- [x] PR description references this issue with `Closes #734`
- [x] Happy path covered (3 tests)
- [x] At least one explicit sad path covered (3 tests)
- [x] Test names are assertive (snake_case, not interrogative)
- [x] Tests are deterministic (no `Date.now()` or `Math.random()`)

## Out of Scope

- Unrelated refactors in adjacent files
- Stylistic-only changes not required by the fix
- gRPC trace-id propagation (can be a follow-up)
- SDK client trace-id propagation (can be a follow-up)

Closes #734
