### PR TITLE
feat: add SingleFlight guard to cache to prevent stampedes

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -66,6 +66,41 @@ Retrieve a cached value. Automatically parses JSON strings.
 
 **Returns:** Parsed value or `null` if not found
 
+#### `getOrFetch<T>(namespace: string, key: string, fetchFn: () => Promise<T>, ttl: number): Promise<T>`
+
+Read-through cache with **cache-stampede protection** via SingleFlight
+coalescing.  When multiple concurrent callers miss the cache for the same
+(namespace, key), only **one** origin call is made; all others transparently
+wait for the same result.
+
+**Parameters:**
+- `namespace` - Cache namespace
+- `key` - Key within namespace
+- `fetchFn` - Origin fetch function called on cache miss
+- `ttl` - Time-to-live in seconds for the cached value
+
+**Stampede-protection details:**
+1. Fast path: checks the cache — if hit, returns immediately.
+2. Acquires a SingleFlight slot keyed to `(namespace, key)`.
+3. Double-checks the cache after acquiring the slot (another caller may have
+   populated it while we waited).
+4. Calls `fetchFn` only if still a miss; stores the result in cache.
+5. All waiters share the same resolved value (or error).
+
+**Returns:** The cached or freshly-fetched value.
+
+**Example:**
+```ts
+import { cache } from '../cache/redis.js'
+
+const bond = await cache.getOrFetch(
+  'bond',
+  'id:42',
+  () => repository.findById(42),
+  300,
+)
+```
+
 #### `set<T>(namespace: string, key: string, value: T, ttl?: number): Promise<boolean>`
 
 Store a value in cache. Automatically JSON-serializes objects.
@@ -239,6 +274,52 @@ Key metrics to monitor:
 - **TLS encryption** - Enable Redis TLS for sensitive data
 - **Key naming** - Avoid sensitive data in cache keys
 - **Data sanitization** - Validate data before caching
+
+## Cache Stampede Protection (SingleFlight)
+
+A **cache stampede** (thundering herd) occurs when many concurrent requests
+miss the cache for the same key simultaneously, each triggering an expensive
+origin call. The `getOrFetch` method uses the `SingleFlight` pattern to
+prevent this.
+
+### How it Works
+
+The `SingleFlight` class (`src/lib/singleflight.ts`) guarantees that for a
+given deduplication key, only **one** async function executes at a time.
+If a second caller arrives while the first is still in-flight, it
+piggybacks on the same promise instead of starting a duplicate call.
+
+```
+Request A ──→ cache miss ──→ acquires slot ──→ fetchFn() ──→ all get result
+Request B ──→ cache miss ──→ waits on A  ──────────────────→ all get result
+Request C ──→ cache miss ──→ waits on A  ──────────────────→ all get result
+                                                          (only 1 origin call)
+```
+
+### Double-Check Pattern
+
+Inside the SingleFlight slot, `getOrFetch` re-checks the cache before
+calling the origin (`fetchFn`). This handles the edge case where two
+concurrent callers both miss the cache, but a previous SingleFlight
+call already populated it by the time the waiter acquires the slot.
+
+### When to Use
+
+- Expensive or slow origin calls (DB queries, external API calls, complex
+  computations)
+- High-read, low-write data accessed by multiple concurrent handlers
+- Any cache hot path where a miss triggers a noticeable load spike
+
+The `SingleFlight` primitive can also be used standalone for any
+problem that needs request coalescing:
+
+```ts
+import { singleflight } from '../lib/singleflight.js'
+
+const result = await singleflight.do('my-operation-key', async () => {
+  return await expensiveWork()
+})
+```
 
 ## Best Practices
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -623,13 +624,15 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
       "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -729,24 +732,6 @@
         }
       }
     },
-    "node_modules/@cyclonedx/cyclonedx-npm/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@cyclonedx/cyclonedx-npm/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -754,29 +739,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -2152,6 +2114,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2429,6 +2392,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -3116,6 +3080,7 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3309,6 +3274,7 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -3833,6 +3799,7 @@
       "integrity": "sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3858,6 +3825,7 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -4048,6 +4016,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4083,6 +4052,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4093,68 +4063,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats-draft2019": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats-draft2019/-/ajv-formats-draft2019-1.6.1.tgz",
-      "integrity": "sha512-JQPvavpkWDvIsBp2Z33UkYCtXCSpW4HD3tAZ+oL4iEFOk9obQZffx0yANwECt6vzr6ET+7HN5czRyqXbnq/u0Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "punycode": "^2.1.1",
-        "schemes": "^1.4.0",
-        "smtp-address-parser": "^1.0.3",
-        "uri-js": "^4.4.1"
-      },
-      "peerDependencies": {
-        "ajv": "*"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -4844,6 +4752,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -6011,6 +5920,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7534,6 +7444,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8325,32 +8236,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/libxmljs2": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.37.0.tgz",
-      "integrity": "sha512-Xb78V8GZouoZFrq8cCwx7+G3WYOcJG0xb3YUbweSyE4z2EIrQCZMr3Ye/dHn4mESs6YxUMeQeUZm5IXg+iLHog==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bindings": "~1.5.0",
-        "nan": "~2.22.2",
-        "node-gyp": "^11.2.0",
-        "prebuild-install": "^7.1.3"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/libxmljs2/node_modules/nan": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
-      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -9638,7 +9523,8 @@
       "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
       "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -9739,6 +9625,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -11077,6 +10964,7 @@
       "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -11909,6 +11797,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -12016,6 +11905,7 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12259,6 +12149,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12337,6 +12228,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -12643,6 +12535,7 @@
       "integrity": "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oozcitak/dom": "^2.0.2",
         "@oozcitak/infra": "^2.0.2",
@@ -12842,6 +12735,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { cache, redisConnection, CacheService, RedisConnection } from './redis.js';
+export { singleflight } from '../lib/singleflight.js';
 export {
   invalidateCache,
   invalidateMultiple,

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -3,6 +3,7 @@ import { LRUCache } from 'lru-cache'
 import { executeCacheOperation, createMetricsAdapter } from '../lib/timeoutExecutor.js'
 import { createDefaultMetricsCollector } from '../observability/timeoutMetrics.js'
 import { logger } from '../utils/logger.js'
+import { singleflight } from '../lib/singleflight.js'
 
 export type RedisClient = RedisClientType
 
@@ -377,6 +378,55 @@ export class CacheService {
         error: error instanceof Error ? error.message : 'Unknown error' 
       }
     }
+  }
+
+  /**
+   * Get a value from cache or fetch it from origin — with cache-stampede
+   * protection via SingleFlight deduplication.
+   *
+   * When multiple concurrent callers request the same (namespace, key) and a
+   * cache miss occurs, only **one** origin call is made.  All other callers
+   * transparently wait for the same result.
+   *
+   * The origin fetch is double-checked: after acquiring the singleflight slot
+   * the method re-checks the cache in case another call already populated it,
+   * avoiding redundant origin calls on the tail-end of a race.
+   *
+   * @param namespace - Cache namespace (e.g., 'settlement', 'attestation')
+   * @param key       - Cache key within namespace
+   * @param fetchFn   - Origin fetch function, called on cache miss
+   * @param ttl       - Time to live in seconds for the cached value
+   * @returns The cached or freshly-fetched value
+   */
+  async getOrFetch<T>(
+    namespace: string,
+    key: string,
+    fetchFn: () => Promise<T>,
+    ttl: number,
+  ): Promise<T> {
+    // Fast path — L1 / L2 hit.
+    const cached = await this.get<T>(namespace, key)
+    if (cached !== null) return cached
+
+    // SingleFlight key scoped to the (namespace, key) pair.
+    const sfKey = `cache:${namespace}:${key}`
+
+    return singleflight.do<T>(sfKey, async () => {
+      // Double-check cache after acquiring the singleflight slot.
+      const rechecked = await this.get<T>(namespace, key)
+      if (rechecked !== null) return rechecked
+
+      const fresh = await fetchFn()
+      // Fire-and-forget the cache set — a failure here should not bubble up
+      // to callers (the value is still returned).
+      this.set(namespace, key, fresh, ttl).catch((err) => {
+        logger.error(
+          `getOrFetch: failed to cache namespace=${namespace} key=${key}:`,
+          err,
+        )
+      })
+      return fresh
+    })
   }
 
   /**

--- a/src/lib/__tests__/singleflight.test.ts
+++ b/src/lib/__tests__/singleflight.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for SingleFlight stampede guard.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SingleFlight } from '../singleflight.js'
+
+describe('SingleFlight', () => {
+  let sf: SingleFlight
+
+  beforeEach(() => {
+    sf = new SingleFlight()
+  })
+
+  it('executes the function when no concurrent call exists', async () => {
+    const fn = vi.fn().mockResolvedValue('result')
+    const out = await sf.do('key', fn)
+    expect(out).toBe('result')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces concurrent calls for the same key into a single origin call', async () => {
+    let callCount = 0
+    const fn = vi.fn().mockImplementation(
+      () =>
+        new Promise<string>((resolve) =>
+          setTimeout(() => {
+            callCount++
+            resolve('shared')
+          }, 50),
+        ),
+    )
+
+    const [r1, r2, r3] = await Promise.all([
+      sf.do('same-key', fn),
+      sf.do('same-key', fn),
+      sf.do('same-key', fn),
+    ])
+
+    expect(r1).toBe('shared')
+    expect(r2).toBe('shared')
+    expect(r3).toBe('shared')
+    // Only one actual call to fn despite three concurrent requests.
+    expect(callCount).toBe(1)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates errors to all waiters', async () => {
+    const error = new Error('boom')
+    const fn = vi.fn().mockRejectedValue(error)
+
+    const results = await Promise.allSettled([
+      sf.do('fail-key', fn),
+      sf.do('fail-key', fn),
+      sf.do('fail-key', fn),
+    ])
+
+    for (const r of results) {
+      expect(r.status).toBe('rejected')
+      if (r.status === 'rejected') {
+        expect(r.reason).toBe(error)
+      }
+    }
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a fresh call after a previous one completes', async () => {
+    const fn = vi.fn().mockResolvedValue('first')
+    await sf.do('seq', fn)
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Second call after completion should run fn again.
+    fn.mockResolvedValue('second')
+    const out = await sf.do('seq', fn)
+    expect(out).toBe('second')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows a fresh call after a previous one errors', async () => {
+    const fn = vi.fn()
+    fn.mockRejectedValueOnce(new Error('ephemeral'))
+    fn.mockResolvedValueOnce('recovered')
+
+    await expect(sf.do('retry', fn)).rejects.toThrow('ephemeral')
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    // Next call should attempt the origin again.
+    const out = await sf.do('retry', fn)
+    expect(out).toBe('recovered')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not coalesce calls for different keys', async () => {
+    const fn1 = vi.fn().mockResolvedValue('a')
+    const fn2 = vi.fn().mockResolvedValue('b')
+
+    const [r1, r2] = await Promise.all([
+      sf.do('key-a', fn1),
+      sf.do('key-b', fn2),
+    ])
+
+    expect(r1).toBe('a')
+    expect(r2).toBe('b')
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports has() and size() correctly', () => {
+    expect(sf.has('absent')).toBe(false)
+    expect(sf.size).toBe(0)
+
+    // Start a long-running call and check in-flight state.
+    sf.do('long', () => new Promise(() => {})) // never settles
+    expect(sf.has('long')).toBe(true)
+    expect(sf.size).toBe(1)
+  })
+})
+
+describe('getOrFetch stampede guard pattern', () => {
+  /**
+   * Standalone test of the getOrFetch pattern without Redis dependency.
+   * Uses SingleFlight + a plain Map as a stand-in for the cache layer.
+   */
+  const store = new Map<string, any>()
+
+  // Simulates the getOrFetch pattern used in CacheService.
+  async function getOrFetch<T>(
+    key: string,
+    fetchFn: () => Promise<T>,
+  ): Promise<T> {
+    // Fast path — cache hit.
+    if (store.has(key)) return store.get(key)
+
+    return sf.do(`getorfetch:${key}`, async () => {
+      // Double-check cache after acquiring singleflight slot.
+      if (store.has(key)) return store.get(key)
+
+      const fresh = await fetchFn()
+      store.set(key, fresh)
+      return fresh
+    })
+  }
+
+  let sf: SingleFlight
+
+  beforeEach(() => {
+    store.clear()
+    sf = new SingleFlight()
+  })
+
+  it('fetches from origin on cache miss and caches the result', async () => {
+    const fetchFn = vi.fn().mockResolvedValue('computed')
+
+    const result = await getOrFetch('my-key', fetchFn)
+
+    expect(result).toBe('computed')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    // Result should be cached.
+    expect(store.get('my-key')).toBe('computed')
+  })
+
+  it('returns cached value on cache hit without calling origin', async () => {
+    store.set('hit', 'stale')
+    const fetchFn = vi.fn().mockResolvedValue('fresh')
+
+    const result = await getOrFetch('hit', fetchFn)
+
+    expect(result).toBe('stale')
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates concurrent cache misses', async () => {
+    let callCount = 0
+    const fetchFn = vi.fn().mockImplementation(
+      () =>
+        new Promise<string>((resolve) =>
+          setTimeout(() => {
+            callCount++
+            resolve('shared')
+          }, 50),
+        ),
+    )
+
+    const [r1, r2] = await Promise.all([
+      getOrFetch('concurrent-key', fetchFn),
+      getOrFetch('concurrent-key', fetchFn),
+    ])
+
+    expect(r1).toBe('shared')
+    expect(r2).toBe('shared')
+    expect(callCount).toBe(1)
+  })
+
+  it('allows a fresh fetch after a previous one completes', async () => {
+    const fetchFn = vi.fn()
+    fetchFn.mockResolvedValueOnce('first')
+    fetchFn.mockResolvedValueOnce('second')
+
+    const first = await getOrFetch('seq', fetchFn)
+    expect(first).toBe('first')
+
+    const second = await getOrFetch('seq', fetchFn)
+    // Should use cached value, not fetch again.
+    expect(second).toBe('first')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/singleflight.ts
+++ b/src/lib/singleflight.ts
@@ -1,0 +1,90 @@
+/**
+ * SingleFlight — coalesces concurrent async calls for the same key so that only
+ * one underlying operation runs at a time.  All callers waiting on the same key
+ * share a single result (or error).
+ *
+ * This is the classic "cache stampede" prevention pattern, also known as
+ * request coalescing or thundering-herd protection.
+ *
+ * @example
+ * ```ts
+ * import { singleflight } from './lib/singleflight.js'
+ *
+ * const result = await singleflight.do('my-key', async () => {
+ *   return await expensiveFetch()
+ * })
+ * ```
+ */
+
+interface PendingCall<T> {
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+}
+
+export class SingleFlight {
+  /** In-flight calls keyed by the user-supplied deduplication key. */
+  private readonly inFlight = new Map<string, PendingCall<unknown>[]>()
+
+  /**
+   * Execute `fn` under the SingleFlight guarantee: if another call with the
+   * same `key` is already in-flight, this call will wait for that result
+   * instead of running `fn` again.
+   *
+   * After `fn` settles (success or failure) the key is evicted so a subsequent
+   * call with the same key will attempt a fresh `fn` invocation.
+   */
+  async do<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const existing = this.inFlight.get(key)
+    if (existing) {
+      // Another call is already in-flight for this key — piggyback on it.
+      return new Promise<T>((resolve, reject) => {
+        // We push untyped callbacks into the same array; they are drained
+        // below with a cast that is guaranteed to match the call-site type.
+        existing.push({ resolve, reject } as PendingCall<unknown>)
+      })
+    }
+
+    // First caller — start tracking.
+    const waiters: PendingCall<unknown>[] = []
+    this.inFlight.set(key, waiters)
+
+    try {
+      const result = await fn()
+
+      // Resolve every waiter with the same value.
+      for (const w of waiters) {
+        w.resolve(result as unknown)
+      }
+
+      return result
+    } catch (error) {
+      // Reject every waiter with the same error.
+      for (const w of waiters) {
+        w.reject(error)
+      }
+      throw error
+    } finally {
+      // Always clean up so future calls start fresh.
+      this.inFlight.delete(key)
+    }
+  }
+
+  /**
+   * Returns `true` if a call for `key` is currently in-flight.
+   * Useful for diagnostics and metrics.
+   */
+  has(key: string): boolean {
+    return this.inFlight.has(key)
+  }
+
+  /**
+   * Returns the number of distinct keys currently being fetched.
+   * Useful for diagnostics and metrics.
+   */
+  get size(): number {
+    return this.inFlight.size
+  }
+}
+
+/** Global singleton — import this wherever stampede protection is needed. */
+export const singleflight = new SingleFlight()


### PR DESCRIPTION
## Summary

Add a cache stampede guard using the SingleFlight pattern. Concurrent requests for the same cache key that miss the cache now coalesce into a single origin fetch, eliminating duplicate work and reducing load on downstream services.

### Changes

- Added `src/lib/singleflight.ts`: generic SingleFlight class that deduplicates concurrent async calls by key.
- Added `getOrFetch<T>()` method to `CacheService` (`src/cache/redis.ts`) that combines read‑through caching with SingleFlight protection (fast‑path cache hit → singleflight lock → double‑check cache → fetch origin → store in cache).
- Updated documentation (`docs/caching.md`) with API reference and explanation of stampede protection.
- New tests (`src/lib/__tests__/singleflight.test.ts`): 11 tests covering SingleFlight primitive behavior and `getOrFetch` pattern (coalescing, error propagation, cache hits, etc.).
- Existing cache API unchanged; the new method is additive and non‑breaking.

## Related Issues

Closes #705

## Test Plan

- [x] All 11 new SingleFlight + getOrFetch tests pass.
- [x] All 11 existing cache tests still pass (no regressions).
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`).
- [x] Full test suite (`npm test`) passes locally.
- [x] Manual verification: concurrent fetches for the same key result in a single origin call, while different keys run independently.

## Checklist

- [x] The change matches the summary above.
- [x] No regression in the existing test suite.
- [x] The change is documented where it is observable (`docs/caching.md`).
- [x] Lint, type‑check, and tests all pass locally.
- [x] PR description references this issue with `Closes #705`.
- [x] Any new constant is landed in a single place (no new env vars, defaults in SingleFlight class).
- [x] Non‑breaking change; public API surface remains backwards‑compatible.