### PR TITLE
feat: add graceful degrade middleware honouring X-Read-Only header

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,11 +557,13 @@ On `SIGTERM` or `SIGINT`, the Credence Backend API executes an ordered graceful 
 
 The grace period is configurable via `SHUTDOWN_GRACE_PERIOD_MS` (default: 30,000 ms). For more details, see **[docs/graceful-shutdown.md](docs/graceful-shutdown.md)**.
 
-## Replay-Safe Handlers & Side-Effects
+## Graceful Degradation
 
-To prevent duplicate side-effects (e.g., duplicate webhooks or notifications) when failed inbound events are replayed or retried, the system implements a context-aware replay-safe handler wrapper and a side-effect execution helper.
+During maintenance or database upgrades, operators can gracefully degrade the service to a read-only state. This is done on a per-request basis by passing the `X-Read-Only` header set to `true` or `1`.
 
-For details on configuration and usage, see **[docs/REPLAY_SAFE_HANDLERS.md](docs/REPLAY_SAFE_HANDLERS.md)**.
+When active, any state-mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) are cleanly rejected with a `503 Service Unavailable` response, while read-only requests (`GET`, `HEAD`, `OPTIONS`) are permitted to proceed.
+
+For more details, see **[docs/graceful-degrade.md](docs/graceful-degrade.md)**.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -565,6 +565,12 @@ When active, any state-mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) are 
 
 For more details, see **[docs/graceful-degrade.md](docs/graceful-degrade.md)**.
 
+## Replay-Safe Handlers & Side-Effects
+
+To prevent duplicate side-effects (e.g., duplicate webhooks or notifications) when failed inbound events are replayed or retried, the system implements a context-aware replay-safe handler wrapper and a side-effect execution helper.
+
+For details on configuration and usage, see **[docs/REPLAY_SAFE_HANDLERS.md](docs/REPLAY_SAFE_HANDLERS.md)**.
+
 ## Security
 
 For security policies, reporting, and architecture documentation:

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,24 @@ X-API-Key: <your-key>
 
 ---
 
+## Graceful Degradation (X-Read-Only Header)
+
+Operators can trigger a graceful degradation mode (read-only mode) on a per-request basis by supplying the `X-Read-Only` header with the value `true` or `1`.
+
+When graceful degradation is active, any write requests (mutations using HTTP methods `POST`, `PUT`, `PATCH`, or `DELETE`) will be cleanly rejected with a `503 Service Unavailable` status and a structured error response:
+
+```json
+{
+  "error": "Writes are temporarily disabled due to maintenance",
+  "code": "service_unavailable",
+  "error_code": "service_unavailable"
+}
+```
+
+Safe read-only methods (`GET`, `HEAD`, `OPTIONS`) continue to function normally.
+
+---
+
 ## Address format
 
 All `:address` path parameters must be Ethereum addresses:

--- a/docs/graceful-degrade.md
+++ b/docs/graceful-degrade.md
@@ -1,0 +1,73 @@
+# Graceful Degradation (Read-Only Mode)
+
+The Credence API supports a graceful degradation mode (read-only mode) that can be triggered dynamically. This is useful for operators (ops) during system maintenance, database migrations, or infrastructure failover drills where write operations must be cleanly rejected without causing raw database or gateway errors.
+
+## How it works
+
+The `gracefulDegradeMiddleware` (implemented in `src/middleware/gracefulDegrade.ts`) intercepts incoming requests.
+
+1. It checks the presence of the `X-Read-Only` header.
+2. If the header is set to `'true'` or `'1'`, the middleware identifies whether the incoming HTTP method is a state-mutating write operation.
+3. Write operations include:
+   - `POST`
+   - `PUT`
+   - `PATCH`
+   - `DELETE`
+4. If the request is a write operation, it is cleanly rejected by throwing a `ServiceUnavailableError`, which translates to an HTTP `503 Service Unavailable` response with a structured JSON error payload.
+5. If the request is a safe, read-only operation (such as `GET`, `HEAD`, or `OPTIONS`), it is allowed to pass through to the router.
+
+## Error Response Format
+
+When a write is rejected, the API returns a standard `503 Service Unavailable` response:
+
+```json
+{
+  "error": "Writes are temporarily disabled due to maintenance",
+  "code": "service_unavailable",
+  "error_code": "service_unavailable"
+}
+```
+
+## Operator Usage (Runbook)
+
+### Load Balancer / Gateway Injection
+
+Operators can enable read-only mode by configuring the ingress proxy, API gateway (e.g. Kong, Envoy, NGINX), or CDN to inject the `X-Read-Only: true` header for all requests routed to the backend during the maintenance window.
+
+For example, in NGINX, this can be done using the `proxy_set_header` directive:
+
+```nginx
+location /api {
+    proxy_set_header X-Read-Only "true";
+    proxy_pass http://backend;
+}
+```
+
+### Manual Testing
+
+You can manually verify that writes are rejected and reads are allowed using `curl`:
+
+**Read Request (GET):**
+```bash
+curl -i -H "X-Read-Only: true" http://localhost:3000/api/health
+# Should return HTTP 200 OK
+```
+
+**Write Request (POST):**
+```bash
+curl -i -H "X-Read-Only: true" -X POST http://localhost:3000/api/trust
+# Should return HTTP 503 Service Unavailable
+```
+
+## Testing
+
+The test suite covers:
+- Verification of GET requests (allowed with/without header)
+- Verification of POST, PUT, PATCH, DELETE requests (blocked with header, allowed without)
+- Handling of different header values (`true`, `1`, `false`, other strings)
+
+To run the middleware tests:
+
+```bash
+npx vitest run src/middleware/__tests__/gracefulDegrade.test.ts
+```

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -17,6 +17,43 @@ components:
       format: null
       minLength: 1
       maxLength: null
+    assignRoleBodySchema:
+      def:
+        type: object
+        shape:
+          userId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          role:
+            def:
+              type: enum
+              entries:
+                SUPER_ADMIN: super-admin
+                ADMIN: admin
+                VERIFIER: verifier
+                USER: user
+            type: enum
+            enum:
+              SUPER_ADMIN: super-admin
+              ADMIN: admin
+              VERIFIER: verifier
+              USER: user
+            options:
+              - super-admin
+              - admin
+              - verifier
+              - user
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
     attestationEventSchema:
       def:
         type: object
@@ -251,6 +288,180 @@ components:
             type: never
           type: never
       type: object
+    auditChainStatusQuerySchema:
+      def:
+        type: object
+        shape: {}
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    auditChainStatusResponseSchema:
+      def:
+        type: object
+        shape:
+          lastVerifiedHeight:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          verifiedAt:
+            def:
+              type: nullable
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - def:
+                        type: string
+                        format: datetime
+                        check: string_format
+                        offset: false
+                        local: false
+                        precision: null
+                        pattern: {}
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                type: string
+                format: datetime
+                minLength: null
+                maxLength: null
+            type: nullable
+          status:
+            def:
+              type: enum
+              entries:
+                valid: valid
+                break_detected: break_detected
+                never_run: never_run
+            type: enum
+            enum:
+              valid: valid
+              break_detected: break_detected
+              never_run: never_run
+            options:
+              - valid
+              - break_detected
+              - never_run
+          firstBreakSeq:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: nullable
+                  innerType:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                        - {}
+                    type: number
+                    minValue: 0
+                    maxValue: 9007199254740991
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                type: nullable
+            type: optional
+          violationCount:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+          rowsChecked:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+      type: object
+    auditChainVerificationStatusSchema:
+      def:
+        type: enum
+        entries:
+          valid: valid
+          break_detected: break_detected
+          never_run: never_run
+      type: enum
+      enum:
+        valid: valid
+        break_detected: break_detected
+        never_run: never_run
+      options:
+        - valid
+        - break_detected
+        - never_run
     bondCreationEventSchema:
       def:
         type: object
@@ -437,7 +648,5648 @@ components:
               - inactive
               - unbonded
       type: object
-    WorkerHealthEntry:
+    createAttestationBodySchema:
+      def:
+        type: object
+        shape:
+          bondId:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  coerce: true
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+          attesterAddress:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - {}
+                    - {}
+                type: string
+                format: null
+                minLength: 1
+                maxLength: null
+            type: optional
+          subject:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          value:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: 2048
+          key:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - {}
+                    - {}
+                type: string
+                format: null
+                minLength: 1
+                maxLength: 128
+            type: optional
+          score:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  coerce: true
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 100
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    createBondBodySchema:
+      def:
+        type: object
+        shape:
+          address:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          bondedAmount:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          bondDuration:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+      type: object
+    createFlagBodySchema:
+      def:
+        type: object
+        shape:
+          key:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+                - {}
+            type: string
+            format: regex
+            minLength: 1
+            maxLength: 128
+          description:
+            def:
+              type: default
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - {}
+                type: string
+                format: null
+                minLength: null
+                maxLength: 512
+              defaultValue: ""
+            type: default
+          defaultEnabled:
+            def:
+              type: default
+              innerType:
+                def:
+                  type: boolean
+                type: boolean
+              defaultValue: false
+            type: default
+          rolloutPercent:
+            def:
+              type: default
+              innerType:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 100
+                isInt: true
+                isFinite: true
+                format: safeint
+              defaultValue: 0
+            type: default
+      type: object
+    createPayoutSchema:
+      def:
+        type: object
+        shape:
+          bondId:
+            def:
+              type: union
+              options:
+                - def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                - def:
+                    type: number
+                    checks: []
+                  type: number
+                  minValue: null
+                  maxValue: null
+                  isInt: false
+                  isFinite: true
+                  format: null
+            type: union
+            options:
+              - def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+              - def:
+                  type: number
+                  checks: []
+                type: number
+                minValue: null
+                maxValue: null
+                isInt: false
+                isFinite: true
+                format: null
+          amount:
+            def:
+              type: string
+              checks:
+                - {}
+                - def:
+                    type: custom
+                    check: custom
+                  type: custom
+            type: string
+            format: regex
+            minLength: null
+            maxLength: null
+          transactionHash:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: 128
+          settledAt:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - def:
+                        type: string
+                        format: datetime
+                        check: string_format
+                        offset: false
+                        local: false
+                        precision: null
+                        pattern: {}
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                type: string
+                format: datetime
+                minLength: null
+                maxLength: null
+            type: optional
+          status:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: enum
+                  entries:
+                    pending: pending
+                    settled: settled
+                    failed: failed
+                type: enum
+                enum:
+                  pending: pending
+                  settled: settled
+                  failed: failed
+                options:
+                  - pending
+                  - settled
+                  - failed
+            type: optional
+      type: object
+    createPolicyBodySchema:
+      def:
+        type: object
+        shape:
+          subject:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          action:
+            def:
+              type: enum
+              entries:
+                org:read: org:read
+                org:update: org:update
+                org:delete: org:delete
+                org:member:invite: org:member:invite
+                org:member:remove: org:member:remove
+                org:member:list: org:member:list
+                org:role:assign: org:role:assign
+                org:apikey:create: org:apikey:create
+                org:apikey:revoke: org:apikey:revoke
+                org:apikey:list: org:apikey:list
+                org:audit:read: org:audit:read
+                org:policy:read: org:policy:read
+                org:policy:write: org:policy:write
+                "*": "*"
+            type: enum
+            enum:
+              org:read: org:read
+              org:update: org:update
+              org:delete: org:delete
+              org:member:invite: org:member:invite
+              org:member:remove: org:member:remove
+              org:member:list: org:member:list
+              org:role:assign: org:role:assign
+              org:apikey:create: org:apikey:create
+              org:apikey:revoke: org:apikey:revoke
+              org:apikey:list: org:apikey:list
+              org:audit:read: org:audit:read
+              org:policy:read: org:policy:read
+              org:policy:write: org:policy:write
+              "*": "*"
+            options:
+              - org:read
+              - org:update
+              - org:delete
+              - org:member:invite
+              - org:member:remove
+              - org:member:list
+              - org:role:assign
+              - org:apikey:create
+              - org:apikey:revoke
+              - org:apikey:list
+              - org:audit:read
+              - org:policy:read
+              - org:policy:write
+              - "*"
+          resource:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          effect:
+            def:
+              type: enum
+              entries:
+                allow: allow
+                deny: deny
+            type: enum
+            enum:
+              allow: allow
+              deny: deny
+            options:
+              - allow
+              - deny
+          conditions:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: record
+                  keyType:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  valueType:
+                    def:
+                      type: union
+                      options:
+                        - def:
+                            type: string
+                          type: string
+                          format: null
+                          minLength: null
+                          maxLength: null
+                        - def:
+                            type: boolean
+                          type: boolean
+                        - def:
+                            type: number
+                            checks: []
+                          type: number
+                          minValue: null
+                          maxValue: null
+                          isInt: false
+                          isFinite: true
+                          format: null
+                    type: union
+                    options:
+                      - def:
+                          type: string
+                        type: string
+                        format: null
+                        minLength: null
+                        maxLength: null
+                      - def:
+                          type: boolean
+                        type: boolean
+                      - def:
+                          type: number
+                          checks: []
+                        type: number
+                        minValue: null
+                        maxValue: null
+                        isInt: false
+                        isFinite: true
+                        format: null
+                type: record
+                keyType:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                valueType:
+                  def:
+                    type: union
+                    options:
+                      - def:
+                          type: string
+                        type: string
+                        format: null
+                        minLength: null
+                        maxLength: null
+                      - def:
+                          type: boolean
+                        type: boolean
+                      - def:
+                          type: number
+                          checks: []
+                        type: number
+                        minValue: null
+                        maxValue: null
+                        isInt: false
+                        isFinite: true
+                        format: null
+                  type: union
+                  options:
+                    - def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    - def:
+                        type: boolean
+                      type: boolean
+                    - def:
+                        type: number
+                        checks: []
+                      type: number
+                      minValue: null
+                      maxValue: null
+                      isInt: false
+                      isFinite: true
+                      format: null
+            type: optional
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    createReportBodySchema:
+      def:
+        type: object
+        shape:
+          type:
+            def:
+              type: enum
+              entries:
+                trust_score_summary: trust_score_summary
+                bond_audit: bond_audit
+                attestation_export: attestation_export
+            type: enum
+            enum:
+              trust_score_summary: trust_score_summary
+              bond_audit: bond_audit
+              attestation_export: attestation_export
+            options:
+              - trust_score_summary
+              - bond_audit
+              - attestation_export
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    createSlashRequestBodySchema:
+      def:
+        type: object
+        shape:
+          targetAddress:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          reason:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          requestedBy:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          threshold:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 1
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+          totalSigners:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 1
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+      type: object
+    createWalletBodySchema:
+      def:
+        type: object
+        shape:
+          address:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          initialBalance:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+          currency:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+      type: object
+    dismissDisputeBodySchema:
+      def:
+        type: object
+        shape:
+          reason:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+      type: object
+    disputeErrorSchema:
+      def:
+        type: object
+        shape:
+          error:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          message:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+      type: object
+    disputePathParamsSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+      type: object
+    disputeSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          filedBy:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          respondent:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          reason:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          evidence:
+            def:
+              type: array
+              element:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: array
+            element:
+              def:
+                type: string
+              type: string
+              format: null
+              minLength: null
+              maxLength: null
+          status:
+            def:
+              type: enum
+              entries:
+                pending: pending
+                under_review: under_review
+                resolved: resolved
+                dismissed: dismissed
+                expired: expired
+            type: enum
+            enum:
+              pending: pending
+              under_review: under_review
+              resolved: resolved
+              dismissed: dismissed
+              expired: expired
+            options:
+              - pending
+              - under_review
+              - resolved
+              - dismissed
+              - expired
+          createdAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          deadline:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          resolution:
+            def:
+              type: nullable
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: nullable
+      type: object
+    disputeStatusSchema:
+      def:
+        type: enum
+        entries:
+          pending: pending
+          under_review: under_review
+          resolved: resolved
+          dismissed: dismissed
+          expired: expired
+      type: enum
+      enum:
+        pending: pending
+        under_review: under_review
+        resolved: resolved
+        dismissed: dismissed
+        expired: expired
+      options:
+        - pending
+        - under_review
+        - resolved
+        - dismissed
+        - expired
+    disputeTransitionErrorSchema:
+      def:
+        type: object
+        shape:
+          error:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          code:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          error_code:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          message:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+      type: object
+    featureFlagOverrideResponseSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          flagId:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          tenantId:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          enabled:
+            def:
+              type: boolean
+            type: boolean
+          createdAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          updatedAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+      type: object
+    featureFlagResponseSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          key:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+                - {}
+            type: string
+            format: regex
+            minLength: 1
+            maxLength: 128
+          description:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          defaultEnabled:
+            def:
+              type: boolean
+            type: boolean
+          rolloutPercent:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 100
+            isInt: true
+            isFinite: true
+            format: safeint
+          createdAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          updatedAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+      type: object
+    featureFlagTenantRolloutResponseSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          flagId:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          tenantId:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          rolloutPercent:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 100
+            isInt: true
+            isFinite: true
+            format: safeint
+          createdAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          updatedAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+      type: object
+    featureFlagWithOverrideResponseSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          key:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+                - {}
+            type: string
+            format: regex
+            minLength: 1
+            maxLength: 128
+          description:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          defaultEnabled:
+            def:
+              type: boolean
+            type: boolean
+          rolloutPercent:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 100
+            isInt: true
+            isFinite: true
+            format: safeint
+          createdAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          updatedAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          override:
+            def:
+              type: nullable
+              innerType:
+                def:
+                  type: object
+                  shape:
+                    id:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: uuid
+                              check: string_format
+                              abort: false
+                              pattern: {}
+                            type: string
+                            format: uuid
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: uuid
+                      minLength: null
+                      maxLength: null
+                    flagId:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: uuid
+                              check: string_format
+                              abort: false
+                              pattern: {}
+                            type: string
+                            format: uuid
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: uuid
+                      minLength: null
+                      maxLength: null
+                    tenantId:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    enabled:
+                      def:
+                        type: boolean
+                      type: boolean
+                    createdAt:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                    updatedAt:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                type: object
+            type: nullable
+          tenantRollout:
+            def:
+              type: nullable
+              innerType:
+                def:
+                  type: object
+                  shape:
+                    id:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: uuid
+                              check: string_format
+                              abort: false
+                              pattern: {}
+                            type: string
+                            format: uuid
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: uuid
+                      minLength: null
+                      maxLength: null
+                    flagId:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: uuid
+                              check: string_format
+                              abort: false
+                              pattern: {}
+                            type: string
+                            format: uuid
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: uuid
+                      minLength: null
+                      maxLength: null
+                    tenantId:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    rolloutPercent:
+                      def:
+                        type: number
+                        checks:
+                          - def:
+                              type: number
+                              check: number_format
+                              abort: false
+                              format: safeint
+                            type: number
+                            minValue: -9007199254740991
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                          - {}
+                          - {}
+                      type: number
+                      minValue: 0
+                      maxValue: 100
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    createdAt:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                    updatedAt:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                type: object
+            type: nullable
+          effectiveEnabled:
+            def:
+              type: boolean
+            type: boolean
+          effectiveRolloutPercent:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 100
+            isInt: true
+            isFinite: true
+            format: safeint
+      type: object
+    flagErrorResponseSchema:
+      def:
+        type: object
+        shape:
+          error:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+      type: object
+    flagKeyParamsSchema:
+      def:
+        type: object
+        shape:
+          key:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+                - {}
+            type: string
+            format: regex
+            minLength: 1
+            maxLength: 128
+      type: object
+    flagKeyTenantParamsSchema:
+      def:
+        type: object
+        shape:
+          key:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+                - {}
+            type: string
+            format: regex
+            minLength: 1
+            maxLength: 128
+          tenantId:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: 256
+      type: object
+    flagListResponseSchema:
+      def:
+        type: object
+        shape:
+          success:
+            def:
+              type: literal
+              values:
+                - true
+            type: literal
+            values: {}
+          data:
+            def:
+              type: array
+              element:
+                def:
+                  type: object
+                  shape:
+                    id:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: uuid
+                              check: string_format
+                              abort: false
+                              pattern: {}
+                            type: string
+                            format: uuid
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: uuid
+                      minLength: null
+                      maxLength: null
+                    key:
+                      def:
+                        type: string
+                        checks:
+                          - {}
+                          - {}
+                          - {}
+                      type: string
+                      format: regex
+                      minLength: 1
+                      maxLength: 128
+                    description:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    defaultEnabled:
+                      def:
+                        type: boolean
+                      type: boolean
+                    rolloutPercent:
+                      def:
+                        type: number
+                        checks:
+                          - def:
+                              type: number
+                              check: number_format
+                              abort: false
+                              format: safeint
+                            type: number
+                            minValue: -9007199254740991
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                          - {}
+                          - {}
+                      type: number
+                      minValue: 0
+                      maxValue: 100
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    createdAt:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                    updatedAt:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                    override:
+                      def:
+                        type: nullable
+                        innerType:
+                          def:
+                            type: object
+                            shape:
+                              id:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: uuid
+                                        check: string_format
+                                        abort: false
+                                        pattern: {}
+                                      type: string
+                                      format: uuid
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: uuid
+                                minLength: null
+                                maxLength: null
+                              flagId:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: uuid
+                                        check: string_format
+                                        abort: false
+                                        pattern: {}
+                                      type: string
+                                      format: uuid
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: uuid
+                                minLength: null
+                                maxLength: null
+                              tenantId:
+                                def:
+                                  type: string
+                                type: string
+                                format: null
+                                minLength: null
+                                maxLength: null
+                              enabled:
+                                def:
+                                  type: boolean
+                                type: boolean
+                              createdAt:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: datetime
+                                        check: string_format
+                                        offset: false
+                                        local: false
+                                        precision: null
+                                        pattern: {}
+                                      type: string
+                                      format: datetime
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: datetime
+                                minLength: null
+                                maxLength: null
+                              updatedAt:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: datetime
+                                        check: string_format
+                                        offset: false
+                                        local: false
+                                        precision: null
+                                        pattern: {}
+                                      type: string
+                                      format: datetime
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: datetime
+                                minLength: null
+                                maxLength: null
+                          type: object
+                      type: nullable
+                    tenantRollout:
+                      def:
+                        type: nullable
+                        innerType:
+                          def:
+                            type: object
+                            shape:
+                              id:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: uuid
+                                        check: string_format
+                                        abort: false
+                                        pattern: {}
+                                      type: string
+                                      format: uuid
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: uuid
+                                minLength: null
+                                maxLength: null
+                              flagId:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: uuid
+                                        check: string_format
+                                        abort: false
+                                        pattern: {}
+                                      type: string
+                                      format: uuid
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: uuid
+                                minLength: null
+                                maxLength: null
+                              tenantId:
+                                def:
+                                  type: string
+                                type: string
+                                format: null
+                                minLength: null
+                                maxLength: null
+                              rolloutPercent:
+                                def:
+                                  type: number
+                                  checks:
+                                    - def:
+                                        type: number
+                                        check: number_format
+                                        abort: false
+                                        format: safeint
+                                      type: number
+                                      minValue: -9007199254740991
+                                      maxValue: 9007199254740991
+                                      isInt: true
+                                      isFinite: true
+                                      format: safeint
+                                    - {}
+                                    - {}
+                                type: number
+                                minValue: 0
+                                maxValue: 100
+                                isInt: true
+                                isFinite: true
+                                format: safeint
+                              createdAt:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: datetime
+                                        check: string_format
+                                        offset: false
+                                        local: false
+                                        precision: null
+                                        pattern: {}
+                                      type: string
+                                      format: datetime
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: datetime
+                                minLength: null
+                                maxLength: null
+                              updatedAt:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: datetime
+                                        check: string_format
+                                        offset: false
+                                        local: false
+                                        precision: null
+                                        pattern: {}
+                                      type: string
+                                      format: datetime
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: datetime
+                                minLength: null
+                                maxLength: null
+                          type: object
+                      type: nullable
+                    effectiveEnabled:
+                      def:
+                        type: boolean
+                      type: boolean
+                    effectiveRolloutPercent:
+                      def:
+                        type: number
+                        checks:
+                          - def:
+                              type: number
+                              check: number_format
+                              abort: false
+                              format: safeint
+                            type: number
+                            minValue: -9007199254740991
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                          - {}
+                          - {}
+                      type: number
+                      minValue: 0
+                      maxValue: 100
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                type: object
+            type: array
+            element:
+              def:
+                type: object
+                shape:
+                  id:
+                    def:
+                      type: string
+                      checks:
+                        - def:
+                            type: string
+                            format: uuid
+                            check: string_format
+                            abort: false
+                            pattern: {}
+                          type: string
+                          format: uuid
+                          minLength: null
+                          maxLength: null
+                    type: string
+                    format: uuid
+                    minLength: null
+                    maxLength: null
+                  key:
+                    def:
+                      type: string
+                      checks:
+                        - {}
+                        - {}
+                        - {}
+                    type: string
+                    format: regex
+                    minLength: 1
+                    maxLength: 128
+                  description:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  defaultEnabled:
+                    def:
+                      type: boolean
+                    type: boolean
+                  rolloutPercent:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                        - {}
+                        - {}
+                    type: number
+                    minValue: 0
+                    maxValue: 100
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                  createdAt:
+                    def:
+                      type: string
+                      checks:
+                        - def:
+                            type: string
+                            format: datetime
+                            check: string_format
+                            offset: false
+                            local: false
+                            precision: null
+                            pattern: {}
+                          type: string
+                          format: datetime
+                          minLength: null
+                          maxLength: null
+                    type: string
+                    format: datetime
+                    minLength: null
+                    maxLength: null
+                  updatedAt:
+                    def:
+                      type: string
+                      checks:
+                        - def:
+                            type: string
+                            format: datetime
+                            check: string_format
+                            offset: false
+                            local: false
+                            precision: null
+                            pattern: {}
+                          type: string
+                          format: datetime
+                          minLength: null
+                          maxLength: null
+                    type: string
+                    format: datetime
+                    minLength: null
+                    maxLength: null
+                  override:
+                    def:
+                      type: nullable
+                      innerType:
+                        def:
+                          type: object
+                          shape:
+                            id:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: uuid
+                                      check: string_format
+                                      abort: false
+                                      pattern: {}
+                                    type: string
+                                    format: uuid
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: uuid
+                              minLength: null
+                              maxLength: null
+                            flagId:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: uuid
+                                      check: string_format
+                                      abort: false
+                                      pattern: {}
+                                    type: string
+                                    format: uuid
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: uuid
+                              minLength: null
+                              maxLength: null
+                            tenantId:
+                              def:
+                                type: string
+                              type: string
+                              format: null
+                              minLength: null
+                              maxLength: null
+                            enabled:
+                              def:
+                                type: boolean
+                              type: boolean
+                            createdAt:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: datetime
+                                      check: string_format
+                                      offset: false
+                                      local: false
+                                      precision: null
+                                      pattern: {}
+                                    type: string
+                                    format: datetime
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: datetime
+                              minLength: null
+                              maxLength: null
+                            updatedAt:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: datetime
+                                      check: string_format
+                                      offset: false
+                                      local: false
+                                      precision: null
+                                      pattern: {}
+                                    type: string
+                                    format: datetime
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: datetime
+                              minLength: null
+                              maxLength: null
+                        type: object
+                    type: nullable
+                  tenantRollout:
+                    def:
+                      type: nullable
+                      innerType:
+                        def:
+                          type: object
+                          shape:
+                            id:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: uuid
+                                      check: string_format
+                                      abort: false
+                                      pattern: {}
+                                    type: string
+                                    format: uuid
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: uuid
+                              minLength: null
+                              maxLength: null
+                            flagId:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: uuid
+                                      check: string_format
+                                      abort: false
+                                      pattern: {}
+                                    type: string
+                                    format: uuid
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: uuid
+                              minLength: null
+                              maxLength: null
+                            tenantId:
+                              def:
+                                type: string
+                              type: string
+                              format: null
+                              minLength: null
+                              maxLength: null
+                            rolloutPercent:
+                              def:
+                                type: number
+                                checks:
+                                  - def:
+                                      type: number
+                                      check: number_format
+                                      abort: false
+                                      format: safeint
+                                    type: number
+                                    minValue: -9007199254740991
+                                    maxValue: 9007199254740991
+                                    isInt: true
+                                    isFinite: true
+                                    format: safeint
+                                  - {}
+                                  - {}
+                              type: number
+                              minValue: 0
+                              maxValue: 100
+                              isInt: true
+                              isFinite: true
+                              format: safeint
+                            createdAt:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: datetime
+                                      check: string_format
+                                      offset: false
+                                      local: false
+                                      precision: null
+                                      pattern: {}
+                                    type: string
+                                    format: datetime
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: datetime
+                              minLength: null
+                              maxLength: null
+                            updatedAt:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: datetime
+                                      check: string_format
+                                      offset: false
+                                      local: false
+                                      precision: null
+                                      pattern: {}
+                                    type: string
+                                    format: datetime
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: datetime
+                              minLength: null
+                              maxLength: null
+                        type: object
+                    type: nullable
+                  effectiveEnabled:
+                    def:
+                      type: boolean
+                    type: boolean
+                  effectiveRolloutPercent:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                        - {}
+                        - {}
+                    type: number
+                    minValue: 0
+                    maxValue: 100
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+              type: object
+      type: object
+    flagResponseEnvelopeSchema:
+      def:
+        type: object
+        shape:
+          success:
+            def:
+              type: literal
+              values:
+                - true
+            type: literal
+            values: {}
+          data:
+            def:
+              type: object
+              shape:
+                id:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: uuid
+                          check: string_format
+                          abort: false
+                          pattern: {}
+                        type: string
+                        format: uuid
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+                key:
+                  def:
+                    type: string
+                    checks:
+                      - {}
+                      - {}
+                      - {}
+                  type: string
+                  format: regex
+                  minLength: 1
+                  maxLength: 128
+                description:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                defaultEnabled:
+                  def:
+                    type: boolean
+                  type: boolean
+                rolloutPercent:
+                  def:
+                    type: number
+                    checks:
+                      - def:
+                          type: number
+                          check: number_format
+                          abort: false
+                          format: safeint
+                        type: number
+                        minValue: -9007199254740991
+                        maxValue: 9007199254740991
+                        isInt: true
+                        isFinite: true
+                        format: safeint
+                      - {}
+                      - {}
+                  type: number
+                  minValue: 0
+                  maxValue: 100
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                createdAt:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: datetime
+                          check: string_format
+                          offset: false
+                          local: false
+                          precision: null
+                          pattern: {}
+                        type: string
+                        format: datetime
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+                updatedAt:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: datetime
+                          check: string_format
+                          offset: false
+                          local: false
+                          precision: null
+                          pattern: {}
+                        type: string
+                        format: datetime
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: object
+      type: object
+    governanceErrorSchema:
+      def:
+        type: object
+        shape:
+          error:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          message:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+      type: object
+    inviteMemberBodySchema:
+      def:
+        type: object
+        shape:
+          userId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          email:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: email
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: email
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: email
+            minLength: null
+            maxLength: null
+          role:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: enum
+                  entries:
+                    owner: owner
+                    admin: admin
+                    member: member
+                type: enum
+                enum:
+                  owner: owner
+                  admin: admin
+                  member: member
+                options:
+                  - owner
+                  - admin
+                  - member
+            type: optional
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    issueImpersonationTokenBodySchema:
+      def:
+        type: object
+        shape:
+          targetUserId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          reason:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          ttlSeconds:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                    - {}
+                type: number
+                minValue: 1
+                maxValue: 3600
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    overrideResponseEnvelopeSchema:
+      def:
+        type: object
+        shape:
+          success:
+            def:
+              type: literal
+              values:
+                - true
+            type: literal
+            values: {}
+          data:
+            def:
+              type: object
+              shape:
+                id:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: uuid
+                          check: string_format
+                          abort: false
+                          pattern: {}
+                        type: string
+                        format: uuid
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+                flagId:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: uuid
+                          check: string_format
+                          abort: false
+                          pattern: {}
+                        type: string
+                        format: uuid
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+                tenantId:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                enabled:
+                  def:
+                    type: boolean
+                  type: boolean
+                createdAt:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: datetime
+                          check: string_format
+                          offset: false
+                          local: false
+                          precision: null
+                          pattern: {}
+                        type: string
+                        format: datetime
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+                updatedAt:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: datetime
+                          check: string_format
+                          offset: false
+                          local: false
+                          precision: null
+                          pattern: {}
+                        type: string
+                        format: datetime
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: object
+      type: object
+    policyListQuerySchema:
+      def:
+        type: object
+        shape:
+          page:
+            def:
+              type: pipe
+              in:
+                def:
+                  type: transform
+                type: transform
+              out:
+                def:
+                  type: optional
+                  innerType:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                        - {}
+                    type: number
+                    minValue: 0
+                    maxValue: 9007199254740991
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                type: optional
+            type: pipe
+            in:
+              def:
+                type: transform
+              type: transform
+            out:
+              def:
+                type: optional
+                innerType:
+                  def:
+                    type: number
+                    checks:
+                      - def:
+                          type: number
+                          check: number_format
+                          abort: false
+                          format: safeint
+                        type: number
+                        minValue: -9007199254740991
+                        maxValue: 9007199254740991
+                        isInt: true
+                        isFinite: true
+                        format: safeint
+                      - {}
+                  type: number
+                  minValue: 0
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+              type: optional
+          limit:
+            def:
+              type: pipe
+              in:
+                def:
+                  type: transform
+                type: transform
+              out:
+                def:
+                  type: optional
+                  innerType:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                        - {}
+                        - {}
+                    type: number
+                    minValue: 0
+                    maxValue: 100
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                type: optional
+            type: pipe
+            in:
+              def:
+                type: transform
+              type: transform
+            out:
+              def:
+                type: optional
+                innerType:
+                  def:
+                    type: number
+                    checks:
+                      - def:
+                          type: number
+                          check: number_format
+                          abort: false
+                          format: safeint
+                        type: number
+                        minValue: -9007199254740991
+                        maxValue: 9007199254740991
+                        isInt: true
+                        isFinite: true
+                        format: safeint
+                      - {}
+                      - {}
+                  type: number
+                  minValue: 0
+                  maxValue: 100
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+              type: optional
+      type: object
+    policyOrgPathParamsSchema:
+      def:
+        type: object
+        shape:
+          orgId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+      type: object
+    policyRulePathParamsSchema:
+      def:
+        type: object
+        shape:
+          orgId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          ruleId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+      type: object
+    reconciliationFindingSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          settlementId:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          findingType:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          details:
+            def:
+              type: record
+              keyType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+              valueType:
+                def:
+                  type: unknown
+                type: unknown
+            type: record
+            keyType:
+              def:
+                type: string
+              type: string
+              format: null
+              minLength: null
+              maxLength: null
+            valueType:
+              def:
+                type: unknown
+              type: unknown
+          createdAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+      type: object
+    reconciliationRunSummarySchema:
+      def:
+        type: object
+        shape:
+          checked:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          discrepancies:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          errors:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          runAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+      type: object
+    reportJobParamsSchema:
+      def:
+        type: object
+        shape:
+          jobId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+      type: object
+    reportTypeSchema:
+      def:
+        type: enum
+        entries:
+          trust_score_summary: trust_score_summary
+          bond_audit: bond_audit
+          attestation_export: attestation_export
+      type: enum
+      enum:
+        trust_score_summary: trust_score_summary
+        bond_audit: bond_audit
+        attestation_export: attestation_export
+      options:
+        - trust_score_summary
+        - bond_audit
+        - attestation_export
+    resolveDisputeBodySchema:
+      def:
+        type: object
+        shape:
+          resolution:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+      type: object
+    revokeApiKeyBodySchema:
+      def:
+        type: object
+        shape:
+          userId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          apiKey:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    rolloutPercentSchema:
+      def:
+        type: number
+        checks:
+          - def:
+              type: number
+              check: number_format
+              abort: false
+              format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          - {}
+          - {}
+      type: number
+      minValue: 0
+      maxValue: 100
+      isInt: true
+      isFinite: true
+      format: safeint
+    setOverrideBodySchema:
+      def:
+        type: object
+        shape:
+          tenantId:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: 256
+          enabled:
+            def:
+              type: boolean
+            type: boolean
+      type: object
+    setTenantRolloutBodySchema:
+      def:
+        type: object
+        shape:
+          tenantId:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: 256
+          rolloutPercent:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 100
+            isInt: true
+            isFinite: true
+            format: safeint
+      type: object
+    settlementReconciliationQuerySchema:
+      def:
+        type: object
+        shape:
+          cursor:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+          limit:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: default
+                  innerType:
+                    def:
+                      type: number
+                      coerce: true
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                        - {}
+                        - {}
+                    type: number
+                    minValue: 1
+                    maxValue: 100
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                  defaultValue: 20
+                type: default
+            type: optional
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    settlementReconciliationResponseSchema:
+      def:
+        type: object
+        shape:
+          success:
+            def:
+              type: literal
+              values:
+                - true
+            type: literal
+            values: {}
+          data:
+            def:
+              type: nullable
+              innerType:
+                def:
+                  type: object
+                  shape:
+                    summary:
+                      def:
+                        type: object
+                        shape:
+                          checked:
+                            def:
+                              type: number
+                              checks:
+                                - def:
+                                    type: number
+                                    check: number_format
+                                    abort: false
+                                    format: safeint
+                                  type: number
+                                  minValue: -9007199254740991
+                                  maxValue: 9007199254740991
+                                  isInt: true
+                                  isFinite: true
+                                  format: safeint
+                                - {}
+                            type: number
+                            minValue: 0
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                          discrepancies:
+                            def:
+                              type: number
+                              checks:
+                                - def:
+                                    type: number
+                                    check: number_format
+                                    abort: false
+                                    format: safeint
+                                  type: number
+                                  minValue: -9007199254740991
+                                  maxValue: 9007199254740991
+                                  isInt: true
+                                  isFinite: true
+                                  format: safeint
+                                - {}
+                            type: number
+                            minValue: 0
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                          errors:
+                            def:
+                              type: number
+                              checks:
+                                - def:
+                                    type: number
+                                    check: number_format
+                                    abort: false
+                                    format: safeint
+                                  type: number
+                                  minValue: -9007199254740991
+                                  maxValue: 9007199254740991
+                                  isInt: true
+                                  isFinite: true
+                                  format: safeint
+                                - {}
+                            type: number
+                            minValue: 0
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                          runAt:
+                            def:
+                              type: string
+                              checks:
+                                - def:
+                                    type: string
+                                    format: datetime
+                                    check: string_format
+                                    offset: false
+                                    local: false
+                                    precision: null
+                                    pattern: {}
+                                  type: string
+                                  format: datetime
+                                  minLength: null
+                                  maxLength: null
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: object
+                    findings:
+                      def:
+                        type: object
+                        shape:
+                          data:
+                            def:
+                              type: array
+                              element:
+                                def:
+                                  type: object
+                                  shape:
+                                    id:
+                                      def:
+                                        type: string
+                                        checks:
+                                          - def:
+                                              type: string
+                                              format: uuid
+                                              check: string_format
+                                              abort: false
+                                              pattern: {}
+                                            type: string
+                                            format: uuid
+                                            minLength: null
+                                            maxLength: null
+                                      type: string
+                                      format: uuid
+                                      minLength: null
+                                      maxLength: null
+                                    settlementId:
+                                      def:
+                                        type: string
+                                        checks:
+                                          - def:
+                                              type: string
+                                              format: uuid
+                                              check: string_format
+                                              abort: false
+                                              pattern: {}
+                                            type: string
+                                            format: uuid
+                                            minLength: null
+                                            maxLength: null
+                                      type: string
+                                      format: uuid
+                                      minLength: null
+                                      maxLength: null
+                                    findingType:
+                                      def:
+                                        type: string
+                                      type: string
+                                      format: null
+                                      minLength: null
+                                      maxLength: null
+                                    details:
+                                      def:
+                                        type: record
+                                        keyType:
+                                          def:
+                                            type: string
+                                          type: string
+                                          format: null
+                                          minLength: null
+                                          maxLength: null
+                                        valueType:
+                                          def:
+                                            type: unknown
+                                          type: unknown
+                                      type: record
+                                      keyType:
+                                        def:
+                                          type: string
+                                        type: string
+                                        format: null
+                                        minLength: null
+                                        maxLength: null
+                                      valueType:
+                                        def:
+                                          type: unknown
+                                        type: unknown
+                                    createdAt:
+                                      def:
+                                        type: string
+                                        checks:
+                                          - def:
+                                              type: string
+                                              format: datetime
+                                              check: string_format
+                                              offset: false
+                                              local: false
+                                              precision: null
+                                              pattern: {}
+                                            type: string
+                                            format: datetime
+                                            minLength: null
+                                            maxLength: null
+                                      type: string
+                                      format: datetime
+                                      minLength: null
+                                      maxLength: null
+                                type: object
+                            type: array
+                            element:
+                              def:
+                                type: object
+                                shape:
+                                  id:
+                                    def:
+                                      type: string
+                                      checks:
+                                        - def:
+                                            type: string
+                                            format: uuid
+                                            check: string_format
+                                            abort: false
+                                            pattern: {}
+                                          type: string
+                                          format: uuid
+                                          minLength: null
+                                          maxLength: null
+                                    type: string
+                                    format: uuid
+                                    minLength: null
+                                    maxLength: null
+                                  settlementId:
+                                    def:
+                                      type: string
+                                      checks:
+                                        - def:
+                                            type: string
+                                            format: uuid
+                                            check: string_format
+                                            abort: false
+                                            pattern: {}
+                                          type: string
+                                          format: uuid
+                                          minLength: null
+                                          maxLength: null
+                                    type: string
+                                    format: uuid
+                                    minLength: null
+                                    maxLength: null
+                                  findingType:
+                                    def:
+                                      type: string
+                                    type: string
+                                    format: null
+                                    minLength: null
+                                    maxLength: null
+                                  details:
+                                    def:
+                                      type: record
+                                      keyType:
+                                        def:
+                                          type: string
+                                        type: string
+                                        format: null
+                                        minLength: null
+                                        maxLength: null
+                                      valueType:
+                                        def:
+                                          type: unknown
+                                        type: unknown
+                                    type: record
+                                    keyType:
+                                      def:
+                                        type: string
+                                      type: string
+                                      format: null
+                                      minLength: null
+                                      maxLength: null
+                                    valueType:
+                                      def:
+                                        type: unknown
+                                      type: unknown
+                                  createdAt:
+                                    def:
+                                      type: string
+                                      checks:
+                                        - def:
+                                            type: string
+                                            format: datetime
+                                            check: string_format
+                                            offset: false
+                                            local: false
+                                            precision: null
+                                            pattern: {}
+                                          type: string
+                                          format: datetime
+                                          minLength: null
+                                          maxLength: null
+                                    type: string
+                                    format: datetime
+                                    minLength: null
+                                    maxLength: null
+                              type: object
+                          page:
+                            def:
+                              type: object
+                              shape:
+                                nextCursor:
+                                  def:
+                                    type: nullable
+                                    innerType:
+                                      def:
+                                        type: string
+                                      type: string
+                                      format: null
+                                      minLength: null
+                                      maxLength: null
+                                  type: nullable
+                                hasMore:
+                                  def:
+                                    type: boolean
+                                  type: boolean
+                                limit:
+                                  def:
+                                    type: number
+                                    checks:
+                                      - def:
+                                          type: number
+                                          check: number_format
+                                          abort: false
+                                          format: safeint
+                                        type: number
+                                        minValue: -9007199254740991
+                                        maxValue: 9007199254740991
+                                        isInt: true
+                                        isFinite: true
+                                        format: safeint
+                                  type: number
+                                  minValue: -9007199254740991
+                                  maxValue: 9007199254740991
+                                  isInt: true
+                                  isFinite: true
+                                  format: safeint
+                            type: object
+                      type: object
+                type: object
+            type: nullable
+      type: object
+    slashRequestPathParamsSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+      type: object
+    slashRequestSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          targetAddress:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          reason:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          requestedBy:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          createdAt:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+          votes:
+            def:
+              type: array
+              element:
+                def:
+                  type: object
+                  shape:
+                    voterId:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    choice:
+                      def:
+                        type: enum
+                        entries:
+                          approve: approve
+                          reject: reject
+                      type: enum
+                      enum:
+                        approve: approve
+                        reject: reject
+                      options:
+                        - approve
+                        - reject
+                    timestamp:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                type: object
+            type: array
+            element:
+              def:
+                type: object
+                shape:
+                  voterId:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  choice:
+                    def:
+                      type: enum
+                      entries:
+                        approve: approve
+                        reject: reject
+                    type: enum
+                    enum:
+                      approve: approve
+                      reject: reject
+                    options:
+                      - approve
+                      - reject
+                  timestamp:
+                    def:
+                      type: string
+                      checks:
+                        - def:
+                            type: string
+                            format: datetime
+                            check: string_format
+                            offset: false
+                            local: false
+                            precision: null
+                            pattern: {}
+                          type: string
+                          format: datetime
+                          minLength: null
+                          maxLength: null
+                    type: string
+                    format: datetime
+                    minLength: null
+                    maxLength: null
+              type: object
+          status:
+            def:
+              type: enum
+              entries:
+                pending: pending
+                approved: approved
+                rejected: rejected
+            type: enum
+            enum:
+              pending: pending
+              approved: approved
+              rejected: rejected
+            options:
+              - pending
+              - approved
+              - rejected
+          threshold:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          totalSigners:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+      type: object
+    slashRequestStatusSchema:
+      def:
+        type: enum
+        entries:
+          pending: pending
+          approved: approved
+          rejected: rejected
+      type: enum
+      enum:
+        pending: pending
+        approved: approved
+        rejected: rejected
+      options:
+        - pending
+        - approved
+        - rejected
+    slashRequestsListResponseSchema:
+      def:
+        type: object
+        shape:
+          success:
+            def:
+              type: literal
+              values:
+                - true
+            type: literal
+            values: {}
+          data:
+            def:
+              type: array
+              element:
+                def:
+                  type: object
+                  shape:
+                    id:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    targetAddress:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    reason:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    requestedBy:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    createdAt:
+                      def:
+                        type: string
+                        checks:
+                          - def:
+                              type: string
+                              format: datetime
+                              check: string_format
+                              offset: false
+                              local: false
+                              precision: null
+                              pattern: {}
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: string
+                      format: datetime
+                      minLength: null
+                      maxLength: null
+                    votes:
+                      def:
+                        type: array
+                        element:
+                          def:
+                            type: object
+                            shape:
+                              voterId:
+                                def:
+                                  type: string
+                                type: string
+                                format: null
+                                minLength: null
+                                maxLength: null
+                              choice:
+                                def:
+                                  type: enum
+                                  entries:
+                                    approve: approve
+                                    reject: reject
+                                type: enum
+                                enum:
+                                  approve: approve
+                                  reject: reject
+                                options:
+                                  - approve
+                                  - reject
+                              timestamp:
+                                def:
+                                  type: string
+                                  checks:
+                                    - def:
+                                        type: string
+                                        format: datetime
+                                        check: string_format
+                                        offset: false
+                                        local: false
+                                        precision: null
+                                        pattern: {}
+                                      type: string
+                                      format: datetime
+                                      minLength: null
+                                      maxLength: null
+                                type: string
+                                format: datetime
+                                minLength: null
+                                maxLength: null
+                          type: object
+                      type: array
+                      element:
+                        def:
+                          type: object
+                          shape:
+                            voterId:
+                              def:
+                                type: string
+                              type: string
+                              format: null
+                              minLength: null
+                              maxLength: null
+                            choice:
+                              def:
+                                type: enum
+                                entries:
+                                  approve: approve
+                                  reject: reject
+                              type: enum
+                              enum:
+                                approve: approve
+                                reject: reject
+                              options:
+                                - approve
+                                - reject
+                            timestamp:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: datetime
+                                      check: string_format
+                                      offset: false
+                                      local: false
+                                      precision: null
+                                      pattern: {}
+                                    type: string
+                                    format: datetime
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: datetime
+                              minLength: null
+                              maxLength: null
+                        type: object
+                    status:
+                      def:
+                        type: enum
+                        entries:
+                          pending: pending
+                          approved: approved
+                          rejected: rejected
+                      type: enum
+                      enum:
+                        pending: pending
+                        approved: approved
+                        rejected: rejected
+                      options:
+                        - pending
+                        - approved
+                        - rejected
+                    threshold:
+                      def:
+                        type: number
+                        checks:
+                          - def:
+                              type: number
+                              check: number_format
+                              abort: false
+                              format: safeint
+                            type: number
+                            minValue: -9007199254740991
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    totalSigners:
+                      def:
+                        type: number
+                        checks:
+                          - def:
+                              type: number
+                              check: number_format
+                              abort: false
+                              format: safeint
+                            type: number
+                            minValue: -9007199254740991
+                            maxValue: 9007199254740991
+                            isInt: true
+                            isFinite: true
+                            format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                type: object
+            type: array
+            element:
+              def:
+                type: object
+                shape:
+                  id:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  targetAddress:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  reason:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  requestedBy:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  createdAt:
+                    def:
+                      type: string
+                      checks:
+                        - def:
+                            type: string
+                            format: datetime
+                            check: string_format
+                            offset: false
+                            local: false
+                            precision: null
+                            pattern: {}
+                          type: string
+                          format: datetime
+                          minLength: null
+                          maxLength: null
+                    type: string
+                    format: datetime
+                    minLength: null
+                    maxLength: null
+                  votes:
+                    def:
+                      type: array
+                      element:
+                        def:
+                          type: object
+                          shape:
+                            voterId:
+                              def:
+                                type: string
+                              type: string
+                              format: null
+                              minLength: null
+                              maxLength: null
+                            choice:
+                              def:
+                                type: enum
+                                entries:
+                                  approve: approve
+                                  reject: reject
+                              type: enum
+                              enum:
+                                approve: approve
+                                reject: reject
+                              options:
+                                - approve
+                                - reject
+                            timestamp:
+                              def:
+                                type: string
+                                checks:
+                                  - def:
+                                      type: string
+                                      format: datetime
+                                      check: string_format
+                                      offset: false
+                                      local: false
+                                      precision: null
+                                      pattern: {}
+                                    type: string
+                                    format: datetime
+                                    minLength: null
+                                    maxLength: null
+                              type: string
+                              format: datetime
+                              minLength: null
+                              maxLength: null
+                        type: object
+                    type: array
+                    element:
+                      def:
+                        type: object
+                        shape:
+                          voterId:
+                            def:
+                              type: string
+                            type: string
+                            format: null
+                            minLength: null
+                            maxLength: null
+                          choice:
+                            def:
+                              type: enum
+                              entries:
+                                approve: approve
+                                reject: reject
+                            type: enum
+                            enum:
+                              approve: approve
+                              reject: reject
+                            options:
+                              - approve
+                              - reject
+                          timestamp:
+                            def:
+                              type: string
+                              checks:
+                                - def:
+                                    type: string
+                                    format: datetime
+                                    check: string_format
+                                    offset: false
+                                    local: false
+                                    precision: null
+                                    pattern: {}
+                                  type: string
+                                  format: datetime
+                                  minLength: null
+                                  maxLength: null
+                            type: string
+                            format: datetime
+                            minLength: null
+                            maxLength: null
+                      type: object
+                  status:
+                    def:
+                      type: enum
+                      entries:
+                        pending: pending
+                        approved: approved
+                        rejected: rejected
+                    type: enum
+                    enum:
+                      pending: pending
+                      approved: approved
+                      rejected: rejected
+                    options:
+                      - pending
+                      - approved
+                      - rejected
+                  threshold:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                    type: number
+                    minValue: -9007199254740991
+                    maxValue: 9007199254740991
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                  totalSigners:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                    type: number
+                    minValue: -9007199254740991
+                    maxValue: 9007199254740991
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+              type: object
+          page:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          limit:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          total:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          hasNext:
+            def:
+              type: boolean
+            type: boolean
+      type: object
+    slashRequestsQuerySchema:
+      def:
+        type: object
+        shape:
+          status:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: enum
+                  entries:
+                    pending: pending
+                    approved: approved
+                    rejected: rejected
+                type: enum
+                enum:
+                  pending: pending
+                  approved: approved
+                  rejected: rejected
+                options:
+                  - pending
+                  - approved
+                  - rejected
+            type: optional
+          page:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  coerce: true
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 1
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+          limit:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  coerce: true
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                    - {}
+                type: number
+                minValue: 1
+                maxValue: 100
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+          offset:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  coerce: true
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+      type: object
+    stellarAddressSchema:
+      def:
+        type: string
+        checks:
+          - {}
+          - def:
+              type: custom
+              check: custom
+            type: custom
+      type: string
+      format: null
+      minLength: 1
+      maxLength: null
+    submitDisputeBodySchema:
+      def:
+        type: object
+        shape:
+          filedBy:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: regex
+            minLength: null
+            maxLength: null
+          respondent:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: regex
+            minLength: null
+            maxLength: null
+          reason:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 10
+            maxLength: null
+          evidence:
+            def:
+              type: array
+              element:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+              checks:
+                - {}
+            type: array
+            element:
+              def:
+                type: string
+              type: string
+              format: null
+              minLength: null
+              maxLength: null
+          deadlineMs:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+                - {}
+            type: number
+            minValue: 3600000
+            maxValue: 2592000000
+            isInt: true
+            isFinite: true
+            format: safeint
+      type: object
+    submitVoteBodySchema:
+      def:
+        type: object
+        shape:
+          voterId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          choice:
+            def:
+              type: enum
+              entries:
+                approve: approve
+                reject: reject
+            type: enum
+            enum:
+              approve: approve
+              reject: reject
+            options:
+              - approve
+              - reject
+      type: object
+    tenantRolloutResponseEnvelopeSchema:
+      def:
+        type: object
+        shape:
+          success:
+            def:
+              type: literal
+              values:
+                - true
+            type: literal
+            values: {}
+          data:
+            def:
+              type: object
+              shape:
+                id:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: uuid
+                          check: string_format
+                          abort: false
+                          pattern: {}
+                        type: string
+                        format: uuid
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+                flagId:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: uuid
+                          check: string_format
+                          abort: false
+                          pattern: {}
+                        type: string
+                        format: uuid
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+                tenantId:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                rolloutPercent:
+                  def:
+                    type: number
+                    checks:
+                      - def:
+                          type: number
+                          check: number_format
+                          abort: false
+                          format: safeint
+                        type: number
+                        minValue: -9007199254740991
+                        maxValue: 9007199254740991
+                        isInt: true
+                        isFinite: true
+                        format: safeint
+                      - {}
+                      - {}
+                  type: number
+                  minValue: 0
+                  maxValue: 100
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                createdAt:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: datetime
+                          check: string_format
+                          offset: false
+                          local: false
+                          precision: null
+                          pattern: {}
+                        type: string
+                        format: datetime
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+                updatedAt:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: datetime
+                          check: string_format
+                          offset: false
+                          local: false
+                          precision: null
+                          pattern: {}
+                        type: string
+                        format: datetime
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: object
+      type: object
+    transactionsHistoryQuerySchema:
+      def:
+        type: object
+        shape:
+          limit:
+            def:
+              type: pipe
+              in:
+                def:
+                  type: transform
+                type: transform
+              out:
+                def:
+                  type: optional
+                  innerType:
+                    def:
+                      type: number
+                      checks:
+                        - def:
+                            type: number
+                            check: number_format
+                            abort: false
+                            format: safeint
+                          type: number
+                          minValue: -9007199254740991
+                          maxValue: 9007199254740991
+                          isInt: true
+                          isFinite: true
+                          format: safeint
+                        - {}
+                        - {}
+                    type: number
+                    minValue: 1
+                    maxValue: 100
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                type: optional
+            type: pipe
+            in:
+              def:
+                type: transform
+              type: transform
+            out:
+              def:
+                type: optional
+                innerType:
+                  def:
+                    type: number
+                    checks:
+                      - def:
+                          type: number
+                          check: number_format
+                          abort: false
+                          format: safeint
+                        type: number
+                        minValue: -9007199254740991
+                        maxValue: 9007199254740991
+                        isInt: true
+                        isFinite: true
+                        format: safeint
+                      - {}
+                      - {}
+                  type: number
+                  minValue: 1
+                  maxValue: 100
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+              type: optional
+          cursor:
+            def:
+              type: pipe
+              in:
+                def:
+                  type: optional
+                  innerType:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                type: optional
+              out:
+                def:
+                  type: transform
+                type: transform
+            type: pipe
+            in:
+              def:
+                type: optional
+                innerType:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+              type: optional
+            out:
+              def:
+                type: transform
+              type: transform
+          bondId:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    trustExplainQuerySchema:
+      def:
+        type: object
+        shape:
+          snapshotId:
+            def:
+              type: pipe
+              in:
+                def:
+                  type: transform
+                type: transform
+              out:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 9007199254740991
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: pipe
+            in:
+              def:
+                type: transform
+              type: transform
+            out:
+              def:
+                type: number
+                checks:
+                  - def:
+                      type: number
+                      check: number_format
+                      abort: false
+                      format: safeint
+                    type: number
+                    minValue: -9007199254740991
+                    maxValue: 9007199254740991
+                    isInt: true
+                    isFinite: true
+                    format: safeint
+                  - {}
+              type: number
+              minValue: 0
+              maxValue: 9007199254740991
+              isInt: true
+              isFinite: true
+              format: safeint
+      type: object
+    trustPathParamsSchema:
+      def:
+        type: object
+        shape:
+          address:
+            def:
+              type: string
+              checks:
+                - {}
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+      type: object
+    trustQuerySchema:
+      def:
+        type: object
+        shape: {}
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    updateFlagBodySchema:
+      def:
+        type: object
+        shape:
+          description:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - {}
+                type: string
+                format: null
+                minLength: null
+                maxLength: 512
+            type: optional
+          defaultEnabled:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: boolean
+                type: boolean
+            type: optional
+          rolloutPercent:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: number
+                  checks:
+                    - def:
+                        type: number
+                        check: number_format
+                        abort: false
+                        format: safeint
+                      type: number
+                      minValue: -9007199254740991
+                      maxValue: 9007199254740991
+                      isInt: true
+                      isFinite: true
+                      format: safeint
+                    - {}
+                    - {}
+                type: number
+                minValue: 0
+                maxValue: 100
+                isInt: true
+                isFinite: true
+                format: safeint
+            type: optional
+        checks:
+          - def:
+              type: custom
+              check: custom
+            type: custom
+      type: object
+    updateMemberRoleBodySchema:
+      def:
+        type: object
+        shape:
+          role:
+            def:
+              type: enum
+              entries:
+                owner: owner
+                admin: admin
+                member: member
+            type: enum
+            enum:
+              owner: owner
+              admin: admin
+              member: member
+            options:
+              - owner
+              - admin
+              - member
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    updatePolicyBodySchema:
+      def:
+        type: object
+        shape:
+          subject:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - {}
+                type: string
+                format: null
+                minLength: 1
+                maxLength: null
+            type: optional
+          action:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: enum
+                  entries:
+                    org:read: org:read
+                    org:update: org:update
+                    org:delete: org:delete
+                    org:member:invite: org:member:invite
+                    org:member:remove: org:member:remove
+                    org:member:list: org:member:list
+                    org:role:assign: org:role:assign
+                    org:apikey:create: org:apikey:create
+                    org:apikey:revoke: org:apikey:revoke
+                    org:apikey:list: org:apikey:list
+                    org:audit:read: org:audit:read
+                    org:policy:read: org:policy:read
+                    org:policy:write: org:policy:write
+                    "*": "*"
+                type: enum
+                enum:
+                  org:read: org:read
+                  org:update: org:update
+                  org:delete: org:delete
+                  org:member:invite: org:member:invite
+                  org:member:remove: org:member:remove
+                  org:member:list: org:member:list
+                  org:role:assign: org:role:assign
+                  org:apikey:create: org:apikey:create
+                  org:apikey:revoke: org:apikey:revoke
+                  org:apikey:list: org:apikey:list
+                  org:audit:read: org:audit:read
+                  org:policy:read: org:policy:read
+                  org:policy:write: org:policy:write
+                  "*": "*"
+                options:
+                  - org:read
+                  - org:update
+                  - org:delete
+                  - org:member:invite
+                  - org:member:remove
+                  - org:member:list
+                  - org:role:assign
+                  - org:apikey:create
+                  - org:apikey:revoke
+                  - org:apikey:list
+                  - org:audit:read
+                  - org:policy:read
+                  - org:policy:write
+                  - "*"
+            type: optional
+          resource:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                  checks:
+                    - {}
+                type: string
+                format: null
+                minLength: 1
+                maxLength: null
+            type: optional
+          effect:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: enum
+                  entries:
+                    allow: allow
+                    deny: deny
+                type: enum
+                enum:
+                  allow: allow
+                  deny: deny
+                options:
+                  - allow
+                  - deny
+            type: optional
+          conditions:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: record
+                  keyType:
+                    def:
+                      type: string
+                    type: string
+                    format: null
+                    minLength: null
+                    maxLength: null
+                  valueType:
+                    def:
+                      type: union
+                      options:
+                        - def:
+                            type: string
+                          type: string
+                          format: null
+                          minLength: null
+                          maxLength: null
+                        - def:
+                            type: boolean
+                          type: boolean
+                        - def:
+                            type: number
+                            checks: []
+                          type: number
+                          minValue: null
+                          maxValue: null
+                          isInt: false
+                          isFinite: true
+                          format: null
+                    type: union
+                    options:
+                      - def:
+                          type: string
+                        type: string
+                        format: null
+                        minLength: null
+                        maxLength: null
+                      - def:
+                          type: boolean
+                        type: boolean
+                      - def:
+                          type: number
+                          checks: []
+                        type: number
+                        minValue: null
+                        maxValue: null
+                        isInt: false
+                        isFinite: true
+                        format: null
+                type: record
+                keyType:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                valueType:
+                  def:
+                    type: union
+                    options:
+                      - def:
+                          type: string
+                        type: string
+                        format: null
+                        minLength: null
+                        maxLength: null
+                      - def:
+                          type: boolean
+                        type: boolean
+                      - def:
+                          type: number
+                          checks: []
+                        type: number
+                        minValue: null
+                        maxValue: null
+                        isInt: false
+                        isFinite: true
+                        format: null
+                  type: union
+                  options:
+                    - def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                    - def:
+                        type: boolean
+                      type: boolean
+                    - def:
+                        type: number
+                        checks: []
+                      type: number
+                      minValue: null
+                      maxValue: null
+                      isInt: false
+                      isFinite: true
+                      format: null
+            type: optional
+        catchall:
+          def:
+            type: never
+          type: never
+      type: object
+    voteChoiceSchema:
+      def:
+        type: enum
+        entries:
+          approve: approve
+          reject: reject
+      type: enum
+      enum:
+        approve: approve
+        reject: reject
+      options:
+        - approve
+        - reject
+    voteResultSchema:
+      def:
+        type: object
+        shape:
+          slashRequestId:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          voterId:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          choice:
+            def:
+              type: enum
+              entries:
+                approve: approve
+                reject: reject
+            type: enum
+            enum:
+              approve: approve
+              reject: reject
+            options:
+              - approve
+              - reject
+          approveCount:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          rejectCount:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+            type: number
+            minValue: -9007199254740991
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+          status:
+            def:
+              type: enum
+              entries:
+                pending: pending
+                approved: approved
+                rejected: rejected
+            type: enum
+            enum:
+              pending: pending
+              approved: approved
+              rejected: rejected
+            options:
+              - pending
+              - approved
+              - rejected
+      type: object
+    voteSchema:
+      def:
+        type: object
+        shape:
+          voterId:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          choice:
+            def:
+              type: enum
+              entries:
+                approve: approve
+                reject: reject
+            type: enum
+            enum:
+              approve: approve
+              reject: reject
+            options:
+              - approve
+              - reject
+          timestamp:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: datetime
+                    check: string_format
+                    offset: false
+                    local: false
+                    precision: null
+                    pattern: {}
+                  type: string
+                  format: datetime
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: datetime
+            minLength: null
+            maxLength: null
+      type: object
+    walletDebitBodySchema:
+      def:
+        type: object
+        shape:
+          amount:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+      type: object
+    walletDebitResponseSchema:
+      def:
+        type: object
+        shape:
+          wallet:
+            def:
+              type: object
+              shape:
+                id:
+                  def:
+                    type: string
+                    checks:
+                      - def:
+                          type: string
+                          format: uuid
+                          check: string_format
+                          abort: false
+                          pattern: {}
+                        type: string
+                        format: uuid
+                        minLength: null
+                        maxLength: null
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+                address:
+                  def:
+                    type: string
+                    checks:
+                      - {}
+                  type: string
+                  format: null
+                  minLength: 1
+                  maxLength: null
+                balance:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                currency:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                createdAt:
+                  def:
+                    type: date
+                  type: date
+                  minDate: null
+                  maxDate: null
+                updatedAt:
+                  def:
+                    type: date
+                  type: date
+                  minDate: null
+                  maxDate: null
+            type: object
+          previousBalance:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          newBalance:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          debitedAmount:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+      type: object
+    walletErrorSchema:
+      def:
+        type: object
+        shape:
+          error:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+      type: object
+    walletSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - def:
+                    type: string
+                    format: uuid
+                    check: string_format
+                    abort: false
+                    pattern: {}
+                  type: string
+                  format: uuid
+                  minLength: null
+                  maxLength: null
+            type: string
+            format: uuid
+            minLength: null
+            maxLength: null
+          address:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          balance:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          currency:
+            def:
+              type: string
+            type: string
+            format: null
+            minLength: null
+            maxLength: null
+          createdAt:
+            def:
+              type: date
+            type: date
+            minDate: null
+            maxDate: null
+          updatedAt:
+            def:
+              type: date
+            type: date
+            minDate: null
+            maxDate: null
+      type: object
+    withdrawalEventSchema:
+      def:
+        type: object
+        shape:
+          id:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          pagingToken:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          type:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          createdAt:
+            def:
+              type: union
+              options:
+                - def:
+                    type: date
+                  type: date
+                  minDate: null
+                  maxDate: null
+                - def:
+                    type: string
+                    checks:
+                      - {}
+                  type: string
+                  format: regex
+                  minLength: null
+                  maxLength: null
+            type: union
+            options:
+              - def:
+                  type: date
+                type: date
+                minDate: null
+                maxDate: null
+              - def:
+                  type: string
+                  checks:
+                    - {}
+                type: string
+                format: regex
+                minLength: null
+                maxLength: null
+          bondId:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          account:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          amount:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: regex
+            minLength: null
+            maxLength: null
+          assetType:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          assetCode:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+          assetIssuer:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+          transactionHash:
+            def:
+              type: string
+              checks:
+                - {}
+            type: string
+            format: null
+            minLength: 1
+            maxLength: null
+          operationIndex:
+            def:
+              type: number
+              checks:
+                - def:
+                    type: number
+                    check: number_format
+                    abort: false
+                    format: safeint
+                  type: number
+                  minValue: -9007199254740991
+                  maxValue: 9007199254740991
+                  isInt: true
+                  isFinite: true
+                  format: safeint
+                - {}
+            type: number
+            minValue: 0
+            maxValue: 9007199254740991
+            isInt: true
+            isFinite: true
+            format: safeint
+      type: object
+    Wallet:
       type: object
       properties:
         name:
@@ -460,11 +6312,621 @@ components:
           type: integer
           example: 3599
       required:
-        - name
-        - lockStatus
-        - acquiredAt
-        - pid
-        - ttlSeconds
+        - id
+        - targetAddress
+        - reason
+        - requestedBy
+        - createdAt
+        - votes
+        - status
+        - threshold
+        - totalSigners
+    Vote:
+      type: object
+      properties:
+        voterId:
+          type: string
+          example: validator-3
+        choice:
+          $ref: "#/components/schemas/VoteChoice"
+        timestamp:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp the vote was cast
+          example: 2024-01-15T10:00:00.000Z
+      required:
+        - voterId
+        - choice
+        - timestamp
+    VoteChoice:
+      type: string
+      enum:
+        - approve
+        - reject
+    SlashRequestStatus:
+      type: string
+      enum:
+        - pending
+        - approved
+        - rejected
+    GovernanceError:
+      type: object
+      properties:
+        error:
+          type: string
+          example: NotFound
+        message:
+          type: string
+          example: Slash request not found
+      required:
+        - error
+        - message
+    CreateSlashRequestBody:
+      type: object
+      properties:
+        targetAddress:
+          type: string
+          minLength: 1
+          description: On-chain address of the entity being slashed
+          example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+        reason:
+          type: string
+          minLength: 1
+          description: Reason for requesting the slash
+          example: Repeated SLA violations on delivery commitments
+        requestedBy:
+          type: string
+          minLength: 1
+          description: Identifier of the requester
+          example: validator-12
+        threshold:
+          type: integer
+          minimum: 1
+          description: "Approve votes required to pass (default: 3)"
+          example: 3
+        totalSigners:
+          type: integer
+          minimum: 1
+          description: "Total eligible signers (default: 5)"
+          example: 5
+      required:
+        - targetAddress
+        - reason
+        - requestedBy
+    SlashRequestsListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/SlashRequest"
+        page:
+          type: integer
+          example: 1
+        limit:
+          type: integer
+          example: 20
+        total:
+          type: integer
+          example: 1
+        hasNext:
+          type: boolean
+          example: false
+      required:
+        - success
+        - data
+        - page
+        - limit
+        - total
+        - hasNext
+    VoteResult:
+      type: object
+      properties:
+        slashRequestId:
+          type: string
+          example: a1b2c3d4e5f6a7b8
+        voterId:
+          type: string
+          example: validator-3
+        choice:
+          $ref: "#/components/schemas/VoteChoice"
+        approveCount:
+          type: integer
+          example: 2
+        rejectCount:
+          type: integer
+          example: 0
+        status:
+          $ref: "#/components/schemas/SlashRequestStatus"
+      required:
+        - slashRequestId
+        - voterId
+        - choice
+        - approveCount
+        - rejectCount
+        - status
+    SubmitVoteBody:
+      type: object
+      properties:
+        voterId:
+          type: string
+          minLength: 1
+          example: validator-3
+        choice:
+          $ref: "#/components/schemas/VoteChoice"
+      required:
+        - voterId
+        - choice
+    Dispute:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 5f8d0d55-1c1b-4e9a-9b1a-4e6f6f6f6f6f
+        filedBy:
+          type: string
+          example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+        respondent:
+          type: string
+          example: GBVFLWXYZ6JJ7TUSU6QDJ6DOY4J5G5VHGJWSCMHL7QSAHRDEQU3EXFW2
+        reason:
+          type: string
+          example: Goods delivered did not match the agreed specification
+        evidence:
+          type: array
+          items:
+            type: string
+          example:
+            - ipfs://bafybeih...
+        status:
+          $ref: "#/components/schemas/DisputeStatus"
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-15T09:00:00.000Z
+        deadline:
+          type: string
+          format: date-time
+          example: 2024-01-16T09:00:00.000Z
+        resolution:
+          type: string
+          nullable: true
+          example: null
+      required:
+        - id
+        - filedBy
+        - respondent
+        - reason
+        - evidence
+        - status
+        - createdAt
+        - deadline
+        - resolution
+    DisputeStatus:
+      type: string
+      enum:
+        - pending
+        - under_review
+        - resolved
+        - dismissed
+        - expired
+    DisputeError:
+      type: object
+      properties:
+        error:
+          type: string
+          example: NotFound
+        message:
+          type: string
+          example: Dispute not found
+      required:
+        - error
+        - message
+    SubmitDisputeBody:
+      type: object
+      properties:
+        filedBy:
+          type: string
+          pattern: ^G[A-Z2-7]{55}$
+          description: Stellar address of the party filing the dispute
+          example: GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX
+        respondent:
+          type: string
+          pattern: ^G[A-Z2-7]{55}$
+          description: Stellar address of the respondent
+          example: GBVFLWXYZ6JJ7TUSU6QDJ6DOY4J5G5VHGJWSCMHL7QSAHRDEQU3EXFW2
+        reason:
+          type: string
+          minLength: 10
+          description: Reason for the dispute (minimum 10 characters)
+          example: Goods delivered did not match the agreed specification
+        evidence:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: Evidence references (URIs, hashes, etc.) supporting the dispute
+          example:
+            - ipfs://bafybeih...
+        deadlineMs:
+          type: integer
+          minimum: 3600000
+          maximum: 2592000000
+          description: Resolution deadline expressed as milliseconds from now (min 1 hour,
+            max 30 days)
+          example: 86400000
+      required:
+        - filedBy
+        - respondent
+        - reason
+        - evidence
+        - deadlineMs
+    DisputeTransitionError:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Invalid dispute state transition
+        code:
+          type: string
+          example: invalid_dispute_transition
+        error_code:
+          type: string
+          example: invalid_dispute_transition
+        message:
+          type: string
+          example: Invalid transition from "resolved" to "resolved"
+      required:
+        - error
+        - code
+        - error_code
+        - message
+    ResolveDisputeBody:
+      type: object
+      properties:
+        resolution:
+          type: string
+          minLength: 1
+          description: Resolution text describing the outcome
+          example: Respondent agreed to a partial refund of 20%
+      required:
+        - resolution
+    DismissDisputeBody:
+      type: object
+      properties:
+        reason:
+          type: string
+          minLength: 1
+          description: Reason the dispute is being dismissed
+          example: Insufficient evidence provided
+      required:
+        - reason
+    FlagListResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/FeatureFlagWithOverrideResponse"
+      required:
+        - success
+        - data
+    FeatureFlagWithOverrideResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        key:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: ^[a-z0-9_-]+$
+          description: Unique flag identifier (slug)
+          example: new-scoring-weights
+        description:
+          type: string
+          example: Enable new scoring algorithm
+        defaultEnabled:
+          type: boolean
+          example: false
+        rolloutPercent:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Rollout percentage (0–100). 0 = disabled for all, 100 = enabled for
+            all.
+          example: 25
+        createdAt:
+          type: string
+          format: date-time
+          example: 2025-01-01T00:00:00.000Z
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2025-01-15T12:00:00.000Z
+        override:
+          $ref: "#/components/schemas/FeatureFlagOverrideResponse"
+        tenantRollout:
+          $ref: "#/components/schemas/FeatureFlagTenantRolloutResponse"
+        effectiveEnabled:
+          type: boolean
+          description: Resolved enabled state for the current tenant (accounts for
+            override, per-tenant rollout, global rollout, and default)
+          example: true
+        effectiveRolloutPercent:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Effective rollout percentage used for user-level sticky bucketing
+            (per-tenant rollout takes precedence over global)
+          example: 25
+      required:
+        - id
+        - key
+        - description
+        - defaultEnabled
+        - rolloutPercent
+        - createdAt
+        - updatedAt
+        - override
+        - tenantRollout
+        - effectiveEnabled
+        - effectiveRolloutPercent
+    FeatureFlagOverrideResponse:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 5d7e4a12-0a3b-4c9d-bf82-1e2f3a4b5c6d
+        flagId:
+          type: string
+          format: uuid
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        tenantId:
+          type: string
+          example: tenant-abc
+        enabled:
+          type: boolean
+          example: true
+        createdAt:
+          type: string
+          format: date-time
+          example: 2025-01-01T00:00:00.000Z
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2025-01-15T12:00:00.000Z
+      required:
+        - id
+        - flagId
+        - tenantId
+        - enabled
+        - createdAt
+        - updatedAt
+      description: Per-tenant boolean override, if set
+    FeatureFlagTenantRolloutResponse:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+        flagId:
+          type: string
+          format: uuid
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        tenantId:
+          type: string
+          example: tenant-abc
+        rolloutPercent:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Rollout percentage (0–100). 0 = disabled for all, 100 = enabled for
+            all.
+          example: 25
+        createdAt:
+          type: string
+          format: date-time
+          example: 2025-01-01T00:00:00.000Z
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2025-01-15T12:00:00.000Z
+      required:
+        - id
+        - flagId
+        - tenantId
+        - rolloutPercent
+        - createdAt
+        - updatedAt
+      description: Per-tenant rollout percentage override, if set
+    FlagErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Feature flag 'unknown-flag' not found
+      required:
+        - error
+    FlagResponseEnvelope:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        data:
+          $ref: "#/components/schemas/FeatureFlagResponse"
+      required:
+        - success
+        - data
+    FeatureFlagResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        key:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: ^[a-z0-9_-]+$
+          description: Unique flag identifier (slug)
+          example: new-scoring-weights
+        description:
+          type: string
+          example: Enable new scoring algorithm
+        defaultEnabled:
+          type: boolean
+          example: false
+        rolloutPercent:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Rollout percentage (0–100). 0 = disabled for all, 100 = enabled for
+            all.
+          example: 25
+        createdAt:
+          type: string
+          format: date-time
+          example: 2025-01-01T00:00:00.000Z
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2025-01-15T12:00:00.000Z
+      required:
+        - id
+        - key
+        - description
+        - defaultEnabled
+        - rolloutPercent
+        - createdAt
+        - updatedAt
+    CreateFlagBody:
+      type: object
+      properties:
+        key:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: ^[a-z0-9_-]+$
+          description: Unique flag identifier (slug)
+          example: new-scoring-weights
+        description:
+          type: string
+          maxLength: 512
+          default: ""
+          description: Human-readable description of the flag
+          example: Enable new scoring algorithm for gradual rollout
+        defaultEnabled:
+          type: boolean
+          default: false
+          description: Default enabled state when no override or rollout applies
+          example: false
+        rolloutPercent:
+          type: integer
+          minimum: 0
+          maximum: 100
+          default: 0
+          description: Rollout percentage (0–100). 0 = disabled for all, 100 = enabled for
+            all.
+          example: 25
+      required:
+        - key
+    UpdateFlagBody:
+      type: object
+      properties:
+        description:
+          type: string
+          maxLength: 512
+          description: New description for the flag
+          example: Updated description
+        defaultEnabled:
+          type: boolean
+          description: New default enabled state
+          example: true
+        rolloutPercent:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Rollout percentage (0–100). 0 = disabled for all, 100 = enabled for
+            all.
+          example: 25
+    OverrideResponseEnvelope:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        data:
+          $ref: "#/components/schemas/FeatureFlagOverrideResponse"
+      required:
+        - success
+        - data
+    SetOverrideBody:
+      type: object
+      properties:
+        tenantId:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Tenant identifier to apply the override to
+          example: tenant-abc
+        enabled:
+          type: boolean
+          description: Whether the flag is enabled for this tenant (overrides rollout)
+          example: true
+      required:
+        - tenantId
+        - enabled
+    TenantRolloutResponseEnvelope:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum:
+            - true
+        data:
+          $ref: "#/components/schemas/FeatureFlagTenantRolloutResponse"
+      required:
+        - success
+        - data
+    SetTenantRolloutBody:
+      type: object
+      properties:
+        tenantId:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Tenant identifier to apply the per-tenant rollout to
+          example: tenant-abc
+        rolloutPercent:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Rollout percentage (0–100). 0 = disabled for all, 100 = enabled for
+            all.
+          example: 25
+      required:
+        - tenantId
+        - rolloutPercent
   securitySchemes:
     bearerAuth:
       type: http
@@ -567,3 +7029,1077 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties:
+                  nullable: true
+  /api/trust/{address}:
+    get:
+      summary: Get trust score
+      description: Returns computed trust score and identity data.
+      tags:
+        - Trust
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: address
+          in: path
+      responses:
+        "200":
+          description: Trust data
+          content:
+            application/json:
+              schema:
+                nullable: true
+        "400":
+          description: Invalid address format
+          content:
+            application/json:
+              schema:
+                nullable: true
+        "404":
+          description: No identity record
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/trust:
+    post:
+      summary: Trust query (internal)
+      description: Trust lookup entrypoint.
+      tags:
+        - Trust
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              nullable: true
+      responses:
+        "200":
+          description: Trust data
+          content:
+            application/json:
+              schema:
+                nullable: true
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/attestations/{address}:
+    get:
+      summary: List attestations
+      description: Returns attestations for a subject address.
+      tags:
+        - Attestations
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: address
+          in: path
+      responses:
+        "200":
+          description: Attestations
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/attestations:
+    post:
+      summary: Create attestation
+      description: Creates an attestation and emits events.
+      tags:
+        - Attestations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bondId:
+                  type: integer
+                  minimum: 0
+                  exclusiveMinimum: true
+                attesterAddress:
+                  type: string
+                  minLength: 1
+                subject:
+                  type: string
+                  minLength: 1
+                value:
+                  type: string
+                  minLength: 1
+                  maxLength: 2048
+                key:
+                  type: string
+                  minLength: 1
+                  maxLength: 128
+                score:
+                  type: integer
+                  nullable: true
+                  minimum: 0
+                  maximum: 100
+              required:
+                - subject
+                - value
+              additionalProperties: false
+      responses:
+        "201":
+          description: Attestation created
+          content:
+            application/json:
+              schema:
+                nullable: true
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                nullable: true
+        "409":
+          description: Duplicate attestation
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/bulk:
+    post:
+      summary: Bulk operations
+      description: Performs bulk operations.
+      tags:
+        - Bulk
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              nullable: true
+      responses:
+        "200":
+          description: Bulk result
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/imports:
+    post:
+      summary: Imports
+      description: Imports data.
+      tags:
+        - Imports
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              nullable: true
+      responses:
+        "200":
+          description: Import result
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/orgs/{orgId}/policies:
+    get:
+      summary: List policies
+      description: Lists policies for an organization.
+      tags:
+        - Policy
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: orgId
+          in: path
+      responses:
+        "200":
+          description: Policies
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/analytics:
+    get:
+      summary: Analytics
+      description: Returns analytics summary.
+      tags:
+        - Analytics
+      responses:
+        "200":
+          description: Analytics
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/payouts:
+    post:
+      summary: Create payout
+      description: Creates a payout job.
+      tags:
+        - Payouts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bondId:
+                  anyOf:
+                    - type: string
+                    - type: number
+                amount:
+                  type: string
+                  pattern: ^\d+(\.\d{1,18})?$
+                transactionHash:
+                  type: string
+                  minLength: 1
+                  maxLength: 128
+                settledAt:
+                  type: string
+                  format: date-time
+                status:
+                  type: string
+                  enum:
+                    - pending
+                    - settled
+                    - failed
+              required:
+                - bondId
+                - amount
+                - transactionHash
+      responses:
+        "201":
+          description: Payout created
+          content:
+            application/json:
+              schema:
+                nullable: true
+  /api/wallets:
+    post:
+      summary: Create a wallet
+      description: Creates a new wallet with an optional initial balance.
+      tags:
+        - Wallets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateWalletBody"
+      responses:
+        "201":
+          description: Wallet created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Wallet"
+        "409":
+          description: A wallet with this address already exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletError"
+  /api/wallets/{id}/debit:
+    post:
+      summary: Debit a wallet
+      description: Atomically debits the specified amount from a wallet balance. Fails
+        if the balance would go negative.
+      tags:
+        - Wallets
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+          required: true
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WalletDebitBody"
+      responses:
+        "200":
+          description: Debit successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletDebitResponse"
+        "404":
+          description: Wallet not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletError"
+        "422":
+          description: Insufficient balance
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WalletError"
+  /api/bond/{address}:
+    get:
+      summary: Get bond status
+      description: Returns the current bond status and lifecycle state for a wallet address.
+      tags:
+        - Bond
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            description: Ethereum (0x…) or Stellar (G…) wallet address
+            example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+          required: true
+          description: Ethereum (0x…) or Stellar (G…) wallet address
+          name: address
+          in: path
+      responses:
+        "200":
+          description: Bond record found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BondResponse"
+        "400":
+          description: Invalid address format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BondError"
+        "404":
+          description: No bond record for this address
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BondError"
+  /api/bond:
+    post:
+      summary: Create or top-up a bond
+      description: Creates a new bond or tops up an existing one for the given wallet
+        address.
+      tags:
+        - Bond
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBondBody"
+      responses:
+        "201":
+          description: Bond created or updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BondResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BondError"
+  /api/governance/slash-requests:
+    post:
+      summary: Create a slash request
+      description: Opens a new slash request awaiting governance votes.
+      tags:
+        - Governance
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSlashRequestBody"
+      responses:
+        "201":
+          description: Slash request created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SlashRequest"
+        "400":
+          description: Validation error (e.g. threshold < 1, or totalSigners < threshold)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+    get:
+      summary: List slash requests
+      description: Returns a paginated list of slash requests, optionally filtered by
+        status.
+      tags:
+        - Governance
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            $ref: "#/components/schemas/SlashRequestStatus"
+          required: false
+          name: status
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            example: 1
+          required: false
+          name: page
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            example: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            nullable: true
+            minimum: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Paginated list of slash requests
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SlashRequestsListResponse"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+  /api/governance/slash-requests/{id}:
+    get:
+      summary: Get a slash request
+      description: Returns a single slash request by ID.
+      tags:
+        - Governance
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            description: Slash request ID
+            example: a1b2c3d4e5f6a7b8
+          required: true
+          description: Slash request ID
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Slash request found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SlashRequest"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+        "404":
+          description: No slash request with this ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+  /api/governance/slash-requests/{id}/votes:
+    post:
+      summary: Vote on a slash request
+      description: Casts an approve/reject vote on a pending slash request.
+      tags:
+        - Governance
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            description: Slash request ID
+            example: a1b2c3d4e5f6a7b8
+          required: true
+          description: Slash request ID
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitVoteBody"
+      responses:
+        "201":
+          description: Vote recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VoteResult"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+        "404":
+          description: No slash request with this ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+        "409":
+          description: Request already resolved, or voter has already voted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GovernanceError"
+  /api/disputes:
+    post:
+      summary: Submit a dispute
+      description: Files a new dispute between two Stellar addresses with supporting
+        evidence.
+      tags:
+        - Disputes
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitDisputeBody"
+      responses:
+        "201":
+          description: Dispute submitted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dispute"
+        "400":
+          description: Validation error (invalid Stellar address, reason too short,
+            missing evidence, or deadline out of range)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeError"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeError"
+  /api/disputes/{id}:
+    get:
+      summary: Get a dispute
+      description: Returns a single dispute by ID.
+      tags:
+        - Disputes
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Dispute ID
+            example: 5f8d0d55-1c1b-4e9a-9b1a-4e6f6f6f6f6f
+          required: true
+          description: Dispute ID
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Dispute found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dispute"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeError"
+        "404":
+          description: No dispute with this ID
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeError"
+  /api/disputes/{id}/review:
+    post:
+      summary: Mark a dispute under review
+      description: Transitions a pending dispute to `under_review`.
+      tags:
+        - Disputes
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Dispute ID
+            example: 5f8d0d55-1c1b-4e9a-9b1a-4e6f6f6f6f6f
+          required: true
+          description: Dispute ID
+          name: id
+          in: path
+      responses:
+        "200":
+          description: Dispute marked under review
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dispute"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeError"
+        "422":
+          description: Invalid state transition (e.g. dispute is not pending)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeTransitionError"
+  /api/disputes/{id}/resolve:
+    post:
+      summary: Resolve a dispute
+      description: Transitions a pending or under-review dispute to `resolved` with a
+        resolution note.
+      tags:
+        - Disputes
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Dispute ID
+            example: 5f8d0d55-1c1b-4e9a-9b1a-4e6f6f6f6f6f
+          required: true
+          description: Dispute ID
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResolveDisputeBody"
+      responses:
+        "200":
+          description: Dispute resolved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dispute"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeError"
+        "422":
+          description: Invalid state transition, missing resolution text, or dispute has
+            expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeTransitionError"
+  /api/disputes/{id}/dismiss:
+    post:
+      summary: Dismiss a dispute
+      description: Transitions a pending or under-review dispute to `dismissed` with a
+        reason.
+      tags:
+        - Disputes
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            format: uuid
+            description: Dispute ID
+            example: 5f8d0d55-1c1b-4e9a-9b1a-4e6f6f6f6f6f
+          required: true
+          description: Dispute ID
+          name: id
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DismissDisputeBody"
+      responses:
+        "200":
+          description: Dispute dismissed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dispute"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeError"
+        "422":
+          description: Invalid state transition or missing dismiss reason
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DisputeTransitionError"
+  /api/admin/feature-flags:
+    get:
+      summary: List feature flags
+      description: Returns all feature flags with their effective state (override,
+        per-tenant rollout, global rollout, or default) for the caller's tenant.
+      tags:
+        - Feature Flags
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Feature flag list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagListResponse"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+    post:
+      summary: Create a feature flag
+      description: Creates a new feature flag. The flag key must be unique across the
+        system.
+      tags:
+        - Feature Flags
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFlagBody"
+      responses:
+        "201":
+          description: Feature flag created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagResponseEnvelope"
+        "400":
+          description: Validation error (e.g. invalid key format, rolloutPercent out of
+            range)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+  /api/admin/feature-flags/{key}:
+    put:
+      summary: Update a feature flag
+      description: Updates one or more fields on an existing feature flag. All fields
+        are optional.
+      tags:
+        - Feature Flags
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+            pattern: ^[a-z0-9_-]+$
+            description: Unique flag identifier (slug)
+            example: new-scoring-weights
+          required: true
+          description: Unique flag identifier (slug)
+          name: key
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFlagBody"
+      responses:
+        "200":
+          description: Feature flag updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagResponseEnvelope"
+        "400":
+          description: Validation error or no fields provided
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "404":
+          description: Feature flag not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+  /api/admin/feature-flags/{key}/overrides:
+    post:
+      summary: Set a per-tenant boolean override
+      description: Creates or updates a boolean on/off override for a specific tenant.
+        A boolean override always takes the highest precedence, superseding any
+        per-tenant rollout or global rollout.
+      tags:
+        - Feature Flags
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+            pattern: ^[a-z0-9_-]+$
+            description: Unique flag identifier (slug)
+            example: new-scoring-weights
+          required: true
+          description: Unique flag identifier (slug)
+          name: key
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetOverrideBody"
+      responses:
+        "201":
+          description: Override created or updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OverrideResponseEnvelope"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "404":
+          description: Feature flag not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+  /api/admin/feature-flags/{key}/overrides/{tenantId}:
+    delete:
+      summary: Remove a per-tenant boolean override
+      description: Removes a boolean override for a specific tenant. After removal the
+        tenant falls back to per-tenant rollout (if configured), global rollout,
+        or defaultEnabled.
+      tags:
+        - Feature Flags
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+            pattern: ^[a-z0-9_-]+$
+            description: Unique flag identifier (slug)
+            example: new-scoring-weights
+          required: true
+          description: Unique flag identifier (slug)
+          name: key
+          in: path
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 256
+            description: Tenant identifier
+            example: tenant-abc
+          required: true
+          description: Tenant identifier
+          name: tenantId
+          in: path
+      responses:
+        "200":
+          description: Override removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                required:
+                  - success
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "404":
+          description: Override not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+  /api/admin/feature-flags/{key}/tenant-rollouts:
+    post:
+      summary: Set a per-tenant rollout percentage
+      description: Creates or updates a per-tenant rollout percentage for a flag.
+        Allows different tenants to receive the flag at different rollout
+        speeds. Sticky user-id bucketing (SHA-256 hash of flagKey:userId) still
+        applies within the tenant's percentage window. A boolean override (if
+        present) always takes precedence over this setting.
+      tags:
+        - Feature Flags
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+            pattern: ^[a-z0-9_-]+$
+            description: Unique flag identifier (slug)
+            example: new-scoring-weights
+          required: true
+          description: Unique flag identifier (slug)
+          name: key
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetTenantRolloutBody"
+      responses:
+        "201":
+          description: Per-tenant rollout created or updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantRolloutResponseEnvelope"
+        "400":
+          description: Validation error (e.g. rolloutPercent out of range)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "404":
+          description: Feature flag not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+  /api/admin/feature-flags/{key}/tenant-rollouts/{tenantId}:
+    delete:
+      summary: Remove a per-tenant rollout percentage
+      description: Removes a per-tenant rollout percentage. After removal the tenant
+        falls back to the global rollout percent (or defaultEnabled if that is
+        also 0).
+      tags:
+        - Feature Flags
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+            pattern: ^[a-z0-9_-]+$
+            description: Unique flag identifier (slug)
+            example: new-scoring-weights
+          required: true
+          description: Unique flag identifier (slug)
+          name: key
+          in: path
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 256
+            description: Tenant identifier
+            example: tenant-abc
+          required: true
+          description: Tenant identifier
+          name: tenantId
+          in: path
+      responses:
+        "200":
+          description: Per-tenant rollout removed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                required:
+                  - success
+        "401":
+          description: Missing or invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"
+        "404":
+          description: Per-tenant rollout not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FlagErrorResponse"

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,7 @@ import { createCostMeterMiddleware } from "./middleware/costMeter.js";
 import { validateConfig } from "./config/index.js";
 import { createAttestationRouter } from "./routes/attestations.js";
 import { tenantContextMiddleware } from './middleware/tenantContext.js'
+import { gracefulDegradeMiddleware } from "./middleware/gracefulDegrade.js";
 import {
   compressionMiddleware,
   compressionMetricsMiddleware,
@@ -220,6 +221,7 @@ app.use(compressionMiddleware);
 app.use(jsonBodyParser);
 app.use(requestSizeLimitErrorHandler);
 app.use(tenantContextMiddleware);
+app.use(gracefulDegradeMiddleware);
 
 app.use("/.well-known/jwks.json", createJwksRouter());
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,9 +1,7 @@
 /** Maximum tolerated age of the oldest unpublished outbox event before readiness fails. */
-export const OUTBOX_MAX_LAG_SECONDS = 60;
-export const OUTBOX_MAX_LAG_MS = OUTBOX_MAX_LAG_SECONDS * 1000;
+export const OUTBOX_MAX_LAG_SECONDS = 60
+export const OUTBOX_MAX_LAG_MS = OUTBOX_MAX_LAG_SECONDS * 1000
 
-/** Periodic pg_stat_activity snapshot cadence used for postmortem capture. */
-export const PG_STAT_ACTIVITY_SNAPSHOT_INTERVAL_MS = 60_000;
+/** Header name used to trigger graceful degradation / read-only mode */
+export const READ_ONLY_HEADER = 'x-read-only'
 
-/** Retention window for persisted pg_stat_activity snapshots. */
-export const PG_STAT_ACTIVITY_SNAPSHOT_RETENTION_HOURS = 24;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,3 +5,7 @@ export const OUTBOX_MAX_LAG_MS = OUTBOX_MAX_LAG_SECONDS * 1000
 /** Header name used to trigger graceful degradation / read-only mode */
 export const READ_ONLY_HEADER = 'x-read-only'
 
+/** Default replay safety setting for handler side effects. */
+export const DEFAULT_REPLAY_SAFE = false
+
+

--- a/src/middleware/__tests__/gracefulDegrade.test.ts
+++ b/src/middleware/__tests__/gracefulDegrade.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { gracefulDegradeMiddleware } from '../gracefulDegrade.js'
+import { errorHandler } from '../errorHandler.js'
+
+describe('Graceful Degrade Middleware', () => {
+  let app: express.Express
+
+  beforeEach(() => {
+    app = express()
+    app.use(gracefulDegradeMiddleware)
+    
+    const handler = (req: express.Request, res: express.Response) => {
+      res.json({ ok: true })
+    }
+    
+    app.get('/test', handler)
+    app.post('/test', handler)
+    app.put('/test', handler)
+    app.patch('/test', handler)
+    app.delete('/test', handler)
+    
+    app.use(errorHandler)
+  })
+
+  describe('when X-Read-Only header is not present', () => {
+    it('allows GET requests', async () => {
+      const res = await request(app).get('/test')
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ ok: true })
+    })
+
+    it('allows POST requests', async () => {
+      const res = await request(app).post('/test')
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ ok: true })
+    })
+
+    it('allows PUT requests', async () => {
+      const res = await request(app).put('/test')
+      expect(res.status).toBe(200)
+    })
+
+    it('allows PATCH requests', async () => {
+      const res = await request(app).patch('/test')
+      expect(res.status).toBe(200)
+    })
+
+    it('allows DELETE requests', async () => {
+      const res = await request(app).delete('/test')
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('when X-Read-Only header is "true"', () => {
+    it('allows GET requests', async () => {
+      const res = await request(app)
+        .get('/test')
+        .set('x-read-only', 'true')
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ ok: true })
+    })
+
+    it('blocks POST requests with 503 and service_unavailable code', async () => {
+      const res = await request(app)
+        .post('/test')
+        .set('x-read-only', 'true')
+      expect(res.status).toBe(503)
+      expect(res.body.code).toBe('service_unavailable')
+      expect(res.body.error_code).toBe('service_unavailable')
+    })
+
+    it('blocks PUT requests with 503 and service_unavailable code', async () => {
+      const res = await request(app)
+        .put('/test')
+        .set('x-read-only', 'true')
+      expect(res.status).toBe(503)
+      expect(res.body.code).toBe('service_unavailable')
+    })
+
+    it('blocks PATCH requests with 503 and service_unavailable code', async () => {
+      const res = await request(app)
+        .patch('/test')
+        .set('x-read-only', 'true')
+      expect(res.status).toBe(503)
+      expect(res.body.code).toBe('service_unavailable')
+    })
+
+    it('blocks DELETE requests with 503 and service_unavailable code', async () => {
+      const res = await request(app)
+        .delete('/test')
+        .set('x-read-only', 'true')
+      expect(res.status).toBe(503)
+      expect(res.body.code).toBe('service_unavailable')
+    })
+  })
+
+  describe('when X-Read-Only header is "1"', () => {
+    it('allows GET requests', async () => {
+      const res = await request(app)
+        .get('/test')
+        .set('x-read-only', '1')
+      expect(res.status).toBe(200)
+    })
+
+    it('blocks POST requests with 503 and service_unavailable code', async () => {
+      const res = await request(app)
+        .post('/test')
+        .set('x-read-only', '1')
+      expect(res.status).toBe(503)
+      expect(res.body.code).toBe('service_unavailable')
+    })
+  })
+
+  describe('when X-Read-Only header is "false" or other values', () => {
+    it('allows POST requests when X-Read-Only is "false"', async () => {
+      const res = await request(app)
+        .post('/test')
+        .set('x-read-only', 'false')
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ ok: true })
+    })
+
+    it('allows POST requests when X-Read-Only is some other string', async () => {
+      const res = await request(app)
+        .post('/test')
+        .set('x-read-only', 'arbitrary')
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ ok: true })
+    })
+  })
+})

--- a/src/middleware/gracefulDegrade.ts
+++ b/src/middleware/gracefulDegrade.ts
@@ -1,0 +1,20 @@
+import type { Request, Response, NextFunction } from 'express'
+import { ServiceUnavailableError } from '../lib/errors.js'
+import { READ_ONLY_HEADER } from '../config/constants.js'
+
+/**
+ * Middleware that gracefully degrades request handling when X-Read-Only header is present.
+ * It rejects write requests (POST, PUT, DELETE, PATCH) with a ServiceUnavailableError (503).
+ */
+export function gracefulDegradeMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const readOnlyHeader = req.headers[READ_ONLY_HEADER]
+  
+  if (readOnlyHeader === 'true' || readOnlyHeader === '1') {
+    const writeMethods = ['POST', 'PUT', 'DELETE', 'PATCH']
+    if (writeMethods.includes(req.method.toUpperCase())) {
+      throw new ServiceUnavailableError('Writes are temporarily disabled due to maintenance')
+    }
+  }
+  
+  next()
+}


### PR DESCRIPTION
Closes #717  Description: Add "graceful degrade" middleware honouring X-Read-Only header
## Goal
Implement a graceful degradation (read-only) middleware that allows operators to disable state-mutating requests (writes) dynamically by passing an `X-Read-Only` header set to `true` or `1`.
## Proposed Changes
- **Constant**: Landed the `READ_ONLY_HEADER` constant in `src/config/constants.ts`.
- **Middleware**: Added `gracefulDegradeMiddleware` in `src/middleware/gracefulDegrade.ts`. It intercepts requests, checks the `X-Read-Only` header, and throws `ServiceUnavailableError` (resulting in a clean HTTP `503 Service Unavailable` response with error code `service_unavailable`) if a write method (`POST`, `PUT`, `PATCH`, `DELETE`) is called. Read-only methods (`GET`, `HEAD`, `OPTIONS`) are untouched.
- **Application Hook**: Mounted the middleware globally in `src/app.ts`.
- **Tests**: Created a comprehensive test suite in `src/middleware/__tests__/gracefulDegrade.test.ts` to verify the middleware's behavior under various request methods and header values.
- **Documentation**:
  - Created a runbook/usage documentation in `docs/graceful-degrade.md`.
  - Updated `api.md` and `README.md`.
  - Regenerated the OpenAPI specification `docs/openapi.yaml`.
## Verification
- Run local typecheck (`npx tsc --noEmit`) - passed.
- Run local test suite (`npx vitest run src/middleware/__tests__/gracefulDegrade.test.ts`) - all 14 tests passed.
- Run local SBOM check (`npm run sbom:check`) - passed.