### PR TITLE
Feature/replay safe handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,12 @@ On `SIGTERM` or `SIGINT`, the Credence Backend API executes an ordered graceful 
 
 The grace period is configurable via `SHUTDOWN_GRACE_PERIOD_MS` (default: 30,000 ms). For more details, see **[docs/graceful-shutdown.md](docs/graceful-shutdown.md)**.
 
+## Replay-Safe Handlers & Side-Effects
+
+To prevent duplicate side-effects (e.g., duplicate webhooks or notifications) when failed inbound events are replayed or retried, the system implements a context-aware replay-safe handler wrapper and a side-effect execution helper.
+
+For details on configuration and usage, see **[docs/REPLAY_SAFE_HANDLERS.md](docs/REPLAY_SAFE_HANDLERS.md)**.
+
 ## Security
 
 For security policies, reporting, and architecture documentation:

--- a/docs/REPLAY_SAFE_HANDLERS.md
+++ b/docs/REPLAY_SAFE_HANDLERS.md
@@ -1,0 +1,90 @@
+# Replay-Safe Handlers & Side-Effects
+
+This document details the replay-safety mechanism in the Credence Backend. This architecture ensures that side-effects (e.g., sending webhooks, email notifications, external API integration) are handled correctly when failed inbound events are replayed or retried.
+
+---
+
+## 1. Problem Statement
+
+In an at-least-once message processing system, failed events are captured and replayed (either automatically by queues or manually by operators via the Admin API/Ledger Replays).
+
+When an event handler is replayed:
+1. **Idempotent Actions** (such as database upserts or local cache updates) are safe to re-execute.
+2. **Effectful Actions** (such as charging a customer, notifying downstream systems, or sending external notifications) should **not** run more than once. Re-running them causes unwanted duplicate side-effects.
+
+---
+
+## 2. Replay-Safety Architecture
+
+To address this, the system introduces a context-aware wrapper that differentiates between:
+- **First Attempt Execution**: The handler is executing for the first time. All side-effects must execute.
+- **Retry/Replay Execution**: The handler is executing in response to a replay. Only side-effects explicitly marked as `replaySafe` should execute.
+
+The context is tracked using Node's `AsyncLocalStorage` so that the execution path doesn't require passing context parameters down the call stack.
+
+```
+                    ┌─────────────────────────┐
+                    │ Handler Execution Path  │
+                    └─────────────────────────┘
+                                 │
+                                 ▼
+                     Is this a Retry/Replay?
+                       /                 \
+                     YES                  NO
+                     /                     \
+        ┌─────────────────────────┐   ┌─────────────────────────┐
+        │ Only execute side-      │   │ Execute all side-       │
+        │ effects marked as       │   │ effects (safe & unsafe) │
+        │ replay-safe             │   └─────────────────────────┘
+        └─────────────────────────┘
+```
+
+---
+
+## 3. API Reference
+
+The core implementation lives in `src/lib/replaySafe.ts`.
+
+### `replaySafeHandler(handler)`
+
+A higher-order function/wrapper used to wrap event handlers registered with the `ReplayService`. It ensures that when the handler is executed by the replay system, a retry context is established.
+
+```typescript
+import { replaySafeHandler } from '../lib/replaySafe.js';
+
+// Registers wrapped handler:
+replayService.registerHandler('my_event', replaySafeHandler(new MyReplayHandler()));
+```
+
+### `runSideEffect(name, fn, options)`
+
+Wraps a side-effect block. In a retry/replay context, the function `fn` is executed **only** if `options.replaySafe` is set to `true`. Otherwise, it is skipped.
+
+- **`name`** (`string`): A descriptor for the side-effect (used for logging).
+- **`fn`** (`() => Promise<T>`): The asynchronous operation to perform.
+- **`options.replaySafe`** (`boolean`): If `true`, the side-effect executes on retry/replay. Defaults to `false`.
+
+---
+
+## 4. Usage Example
+
+```typescript
+import { runSideEffect } from '../lib/replaySafe.js';
+
+export class WithdrawalReplayHandler implements ReplayHandler {
+  async handle(eventData: any): Promise<void> {
+    // 1. Safe DB operation (runs on first attempt AND retry)
+    await this.db.bonds.update(eventData);
+
+    // 2. Non-replay-safe side-effect (skipped on retry)
+    await runSideEffect('send-slack-alert', async () => {
+      await slackClient.send(`Withdrawal processed: ${eventData.id}`);
+    }, { replaySafe: false }); // Defaults to false
+
+    // 3. Replay-safe side-effect (runs on first attempt AND retry)
+    await runSideEffect('emit-metric', async () => {
+      await metrics.counter('withdrawal_retry_attempt').inc();
+    }, { replaySafe: true });
+  }
+}
+```

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,25 +1,21 @@
-# feat(shutdown): drain in-flight requests, close DB pools, and exit cleanly on SIGTERM
+# feat(replay): add replay-safe wrapper around effectful handlers
 
 ## Description
 
-This PR fixes a bug where `SIGTERM` and `SIGINT` signals bypassed the configured `GracefulShutdownManager` in production (due to duplicate signal handlers in `src/index.ts` that immediately called `process.exit(0)` when the HTTP server closed, bypassing the closing of DB pools, Redis connections, and background schedulers).
+This PR implements a context-aware replay-safety mechanism in the Credence Backend. This ensures that effectful event handlers (e.g. sending webhooks, notification emails, external API integration) do not run duplicate side-effects when failed inbound events are replayed or retried.
 
-With this fix, signals are correctly routed to the `GracefulShutdownManager`, which performs a clean, ordered graceful shutdown sequence before exiting.
+Only side-effects explicitly marked as `replaySafe` will be executed during replay/retry runs, while others are safely skipped.
 
-Closes #<this-issue>
+Closes #
 
 ## Changes
 
-- **`src/index.ts`**: Removed duplicate local `shutdown` handler and its signal registrations to ensure `GracefulShutdownManager` manages the shutdown process.
-- **`src/__tests__/gracefulShutdown.test.ts`**: Added a new sequence verification test to ensure that the server closing/draining, database pools closing, and process exiting occur in the correct order.
-- **`README.md`**: Documented the graceful shutdown behavior.
-- **`docs/graceful-shutdown.md`**: Updated signal handling architecture notes.
-
-## Commits
-
-1. `fix(shutdown): remove redundant signal handlers in index.ts`
-2. `test(shutdown): add test to verify shutdown sequence order`
-3. `docs(shutdown): document production graceful shutdown and signal handling`
+- **`src/lib/replaySafe.ts`**: Core utility implementing the `replayContext` (`AsyncLocalStorage`), the `replaySafeHandler` wrapper (supporting both function and object-based handlers), and the `runSideEffect` helper.
+- **`src/lib/replaySafe.test.ts`**: Unit tests verifying the retry context isolation, the behavior of `runSideEffect` under normal vs retry conditions, and default fallback settings.
+- **`src/config/constants.ts`**: Added central `DEFAULT_REPLAY_SAFE` constant.
+- **`src/services/replayHandlers.ts`**: Integrated the `replaySafeHandler` wrapper in `registerAllReplayHandlers` to automatically enforce the retry context for all registered replay handlers.
+- **`docs/REPLAY_SAFE_HANDLERS.md`**: Created a detailed architecture and API usage guide.
+- **`README.md`**: Updated documentation references.
 
 ## Checklist
 
@@ -27,4 +23,4 @@ Closes #<this-issue>
 - [x] No regression in the existing test suite.
 - [x] The change is documented where it is observable (README, docs/).
 - [x] Lint, type-check, and tests all pass locally.
-- [x] PR description references this issue with `Closes #<this-issue>`.
+- [x] PR description references this issue with `Closes #`.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,7 @@
 /** Maximum tolerated age of the oldest unpublished outbox event before readiness fails. */
 export const OUTBOX_MAX_LAG_SECONDS = 60
 export const OUTBOX_MAX_LAG_MS = OUTBOX_MAX_LAG_SECONDS * 1000
+
+/** Default replay safety setting for handler side effects. */
+export const DEFAULT_REPLAY_SAFE = false
+

--- a/src/lib/replaySafe.test.ts
+++ b/src/lib/replaySafe.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  replaySafeHandler,
+  runSideEffect,
+  isRetry,
+  runInRetryContext,
+} from './replaySafe.js'
+
+describe('Replay-Safe mechanism', () => {
+  it('should identify retry context correctly', async () => {
+    expect(isRetry()).toBe(false)
+
+    const result = await runInRetryContext(async () => {
+      expect(isRetry()).toBe(true)
+      return 42
+    })
+
+    expect(result).toBe(42)
+    expect(isRetry()).toBe(false)
+  })
+
+  describe('runSideEffect', () => {
+    it('runs all side-effects on first attempt (non-retry context)', async () => {
+      const effect1 = vi.fn().mockResolvedValue('value-1')
+      const effect2 = vi.fn().mockResolvedValue('value-2')
+
+      const res1 = await runSideEffect('non-replay-safe', effect1, { replaySafe: false })
+      const res2 = await runSideEffect('replay-safe', effect2, { replaySafe: true })
+
+      expect(effect1).toHaveBeenCalledTimes(1)
+      expect(effect2).toHaveBeenCalledTimes(1)
+      expect(res1).toBe('value-1')
+      expect(res2).toBe('value-2')
+    })
+
+    it('only runs replay-safe side-effects on retry', async () => {
+      const effect1 = vi.fn().mockResolvedValue('value-1')
+      const effect2 = vi.fn().mockResolvedValue('value-2')
+
+      await runInRetryContext(async () => {
+        const res1 = await runSideEffect('non-replay-safe', effect1, { replaySafe: false })
+        const res2 = await runSideEffect('replay-safe', effect2, { replaySafe: true })
+
+        expect(effect1).not.toHaveBeenCalled()
+        expect(effect2).toHaveBeenCalledTimes(1)
+        expect(res1).toBeUndefined()
+        expect(res2).toBe('value-2')
+      })
+    })
+
+    it('defaults replaySafe to false if not specified', async () => {
+      const effect = vi.fn().mockResolvedValue('value')
+
+      await runInRetryContext(async () => {
+        const res = await runSideEffect('default-non-safe', effect)
+        expect(effect).not.toHaveBeenCalled()
+        expect(res).toBeUndefined()
+      })
+    })
+  })
+
+  describe('replaySafeHandler wrapper', () => {
+    it('wraps handler functions to execute in retry context', async () => {
+      const handlerFn = vi.fn(async (eventData) => {
+        expect(isRetry()).toBe(true)
+        return `processed ${eventData}`
+      })
+
+      const wrapped = replaySafeHandler(handlerFn)
+      const res = await wrapped('event-123')
+
+      expect(handlerFn).toHaveBeenCalledWith('event-123')
+      expect(res).toBe('processed event-123')
+      expect(isRetry()).toBe(false)
+    })
+
+    it('wraps ReplayHandler objects to execute in retry context', async () => {
+      const handlerObj = {
+        handle: vi.fn(async (eventData) => {
+          expect(isRetry()).toBe(true)
+        }),
+      }
+
+      const wrapped = replaySafeHandler(handlerObj)
+      await wrapped.handle('event-456')
+
+      expect(handlerObj.handle).toHaveBeenCalledWith('event-456')
+      expect(isRetry()).toBe(false)
+    })
+  })
+})

--- a/src/lib/replaySafe.ts
+++ b/src/lib/replaySafe.ts
@@ -1,0 +1,74 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { DEFAULT_REPLAY_SAFE } from '../config/constants.js'
+
+export interface ReplayHandler {
+  handle(eventData: any): Promise<void>
+}
+
+export interface ReplayContext {
+  isRetry: boolean
+}
+
+export const replayContext = new AsyncLocalStorage<ReplayContext>()
+
+/**
+ * Runs a function within a retry context.
+ */
+export function runInRetryContext<T>(fn: () => Promise<T>): Promise<T> {
+  return replayContext.run({ isRetry: true }, fn)
+}
+
+/**
+ * Returns true if the current execution is within a retry/replay context.
+ */
+export function isRetry(): boolean {
+  return replayContext.getStore()?.isRetry ?? false
+}
+
+/**
+ * Wraps a handler function or a ReplayHandler object to execute within a retry context.
+ */
+export function replaySafeHandler(
+  handler: ReplayHandler | ((eventData: any) => Promise<any>)
+): any {
+  if (typeof handler === 'function') {
+    return async (eventData: any) => {
+      return await runInRetryContext(async () => {
+        return await handler(eventData)
+      })
+    }
+  }
+
+  return {
+    handle: async (eventData: any) => {
+      return await runInRetryContext(async () => {
+        return await handler.handle(eventData)
+      })
+    }
+  }
+}
+
+export interface SideEffectOptions {
+  replaySafe?: boolean
+}
+
+/**
+ * Executes a side-effect function. If currently in a retry context, the side-effect
+ * will only execute if `options.replaySafe` is explicitly set to true. Otherwise,
+ * it is skipped and returns `undefined`.
+ */
+export async function runSideEffect<T>(
+  name: string,
+  fn: () => Promise<T>,
+  options: SideEffectOptions = {}
+): Promise<T | undefined> {
+  const isCurrentlyRetry = isRetry()
+  const replaySafe = options.replaySafe ?? DEFAULT_REPLAY_SAFE
+
+  if (isCurrentlyRetry && !replaySafe) {
+    console.log(`[ReplaySafe] Skipping non-replay-safe side-effect on retry: ${name}`)
+    return undefined
+  }
+
+  return await fn()
+}

--- a/src/services/replayHandlers.ts
+++ b/src/services/replayHandlers.ts
@@ -1,6 +1,7 @@
 import { ReplayHandler, ReplayService } from './replayService.js'
 import { IdentityRepository } from '../db/repositories/identityRepository.js'
 import { BondsRepository } from '../db/repositories/bondsRepository.js'
+import { replaySafeHandler } from '../lib/replaySafe.js'
 
 /**
  * Handler for bond creation events.
@@ -60,13 +61,14 @@ export function registerAllReplayHandlers(
   attestationProcessor?: any,
   withdrawalProcessor?: any
 ): void {
-  replayService.registerHandler('bond_creation', new BondCreationReplayHandler(identityRepo, bondsRepo))
+  replayService.registerHandler('bond_creation', replaySafeHandler(new BondCreationReplayHandler(identityRepo, bondsRepo)))
   
   if (attestationProcessor) {
-    replayService.registerHandler('attestation', new AttestationReplayHandler(attestationProcessor))
+    replayService.registerHandler('attestation', replaySafeHandler(new AttestationReplayHandler(attestationProcessor)))
   }
   
   if (withdrawalProcessor) {
-    replayService.registerHandler('withdrawal', new WithdrawalReplayHandler(withdrawalProcessor))
+    replayService.registerHandler('withdrawal', replaySafeHandler(new WithdrawalReplayHandler(withdrawalProcessor)))
   }
 }
+


### PR DESCRIPTION
Closes #688 
This PR implements a context-aware replay-safety mechanism in the Credence Backend. This ensures that effectful event handlers (e.g. sending webhooks, notification emails, external API integration) do not run duplicate side-effects when failed inbound events are replayed or retried.

Only side-effects explicitly marked as replaySafe will be executed during replay/retry runs, while others are safely skipped.

Closes #

Changes
src/lib/replaySafe.ts: Core utility implementing the replayContext (AsyncLocalStorage), the replaySafeHandler wrapper (supporting both function and object-based handlers), and the runSideEffect helper.
src/lib/replaySafe.test.ts: Unit tests verifying the retry context isolation, the behavior of runSideEffect under normal vs retry conditions, and default fallback settings.
src/config/constants.ts: Added central DEFAULT_REPLAY_SAFE constant.
src/services/replayHandlers.ts: Integrated the replaySafeHandler wrapper in registerAllReplayHandlers to automatically enforce the retry context for all registered replay handlers.
docs/REPLAY_SAFE_HANDLERS.md: Created a detailed architecture and API usage guide.
README.md: Updated documentation references.
Checklist
 The change matches the summary above.
 No regression in the existing test suite.
 The change is documented where it is observable (README, docs/).
 Lint, type-check, and tests all pass locally.
 PR description references this issue with Closes #.