### PR TITLE
security: centralize Cache-Control decisions, default privileged endpoints to no-store

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { BondService, BondStore } from "./services/bond/index.js";
 import { createBondRouter } from "./routes/bond.js";
 import { pool } from "./db/pool.js";
 import { requestIdMiddleware } from "./middleware/requestId.js";
+import { cacheControlMiddleware } from "./middleware/cacheControl.js";
 import { errorHandler } from "./middleware/errorHandler.js";
 import { createRateLimitMiddleware } from "./middleware/rateLimit.js";
 import { createCostMeterMiddleware } from "./middleware/costMeter.js";
@@ -64,6 +65,7 @@ try {
 const rateLimitMiddleware = createRateLimitMiddleware(rateLimitConfig);
 
 app.use(requestIdMiddleware);
+app.use(cacheControlMiddleware);
 
 const metricsCidrs = process.env.METRICS_ALLOWED_CIDRS
   ?.split(',')

--- a/src/middleware/__tests__/cacheControl.test.ts
+++ b/src/middleware/__tests__/cacheControl.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import express, { type Express, type Request, type Response, type NextFunction } from 'express'
+import request from 'supertest'
+import { cacheControlMiddleware } from '../cacheControl.js'
+
+describe('Cache-Control middleware', () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = express()
+    app.use(cacheControlMiddleware)
+  })
+
+  describe('privileged requests (identity attached by auth middleware)', () => {
+    it('sets Cache-Control: no-store when req.user is present (authenticated session)', async () => {
+      app.use((req: Request, _res: Response, next: NextFunction) => {
+        ;(req as any).user = { id: 'admin-1', role: 'admin' }
+        next()
+      })
+      app.get('/api/admin/users', (_req, res) => {
+        res.json({ success: true, data: [] })
+      })
+
+      const response = await request(app).get('/api/admin/users')
+
+      expect(response.headers['cache-control']).toBe('no-store')
+      expect(response.headers['pragma']).toBe('no-cache')
+    })
+
+    it('sets Cache-Control: no-store when req.apiKey is present (enforced API key)', async () => {
+      app.use((req: Request, _res: Response, next: NextFunction) => {
+        ;(req as any).apiKey = { key: 'test-payouts-write-key', scopes: ['payouts:write'] }
+        next()
+      })
+      app.get('/api/payouts', (_req, res) => {
+        res.json({ success: true, data: [] })
+      })
+
+      const response = await request(app).get('/api/payouts')
+
+      expect(response.headers['cache-control']).toBe('no-store')
+    })
+
+    it('sets Cache-Control: no-store when req.apiKeyRecord is present', async () => {
+      app.use((req: Request, _res: Response, next: NextFunction) => {
+        ;(req as any).apiKeyRecord = { key: 'k', scopes: ['write'] }
+        next()
+      })
+      app.get('/api/bond', (_req, res) => {
+        res.json({ success: true })
+      })
+
+      const response = await request(app).get('/api/bond')
+
+      expect(response.headers['cache-control']).toBe('no-store')
+    })
+
+    it('defaults to no-store for known privileged path prefixes even without an identity property', async () => {
+      // Defence-in-depth: a route added under /api/admin that forgets to wire
+      // up auth should still not leak into shared caches.
+      app.get('/api/admin/anything', (_req, res) => {
+        res.json({ success: true })
+      })
+
+      const response = await request(app).get('/api/admin/anything')
+
+      expect(response.headers['cache-control']).toBe('no-store')
+    })
+
+    it('THE NEGATIVE CASE: a privileged, authenticated response is not cacheable', async () => {
+      // This is the scenario the fix closes: an admin endpoint returning
+      // sensitive data (here standing in for an audit-log export) must never
+      // be eligible for storage in a shared HTTP cache or the browser
+      // back/forward cache. Before this middleware existed, no Cache-Control
+      // header was set at all on this response, so it was heuristically
+      // cacheable by intermediaries and the browser's disk cache.
+      app.use((req: Request, _res: Response, next: NextFunction) => {
+        ;(req as any).user = { id: 'admin-1', role: 'admin', email: 'admin@credence.org' }
+        next()
+      })
+      app.get('/api/admin/audit-logs', (_req, res) => {
+        res.json({ success: true, data: { logs: [{ id: 1, actorId: 'admin-1' }] } })
+      })
+
+      const response = await request(app).get('/api/admin/audit-logs')
+
+      expect(response.headers['cache-control']).toBe('no-store')
+      expect(response.headers['cache-control']).not.toBe('public, max-age=60')
+      expect(response.headers['cache-control']).not.toBeUndefined()
+    })
+  })
+
+  describe('non-privileged requests', () => {
+    it('does not set Cache-Control on an unauthenticated, non-privileged route', async () => {
+      app.get('/api/health', (_req, res) => {
+        res.json({ status: 'ok' })
+      })
+
+      const response = await request(app).get('/api/health')
+
+      expect(response.headers['cache-control']).toBeUndefined()
+    })
+  })
+
+  describe('explicit route overrides', () => {
+    it('does not clobber a Cache-Control header the route set explicitly', async () => {
+      app.use((req: Request, _res: Response, next: NextFunction) => {
+        ;(req as any).apiKey = { key: 'test-trust-read-key', scopes: ['trust:read'] }
+        next()
+      })
+      app.get('/api/trust/:address', (_req, res) => {
+        res.set('Cache-Control', 'public, max-age=60')
+        res.json({ score: 42 })
+      })
+
+      const response = await request(app).get('/api/trust/GABC123')
+
+      expect(response.headers['cache-control']).toBe('public, max-age=60')
+    })
+
+    it('leaves a non-default Cache-Control set on a privileged path prefix untouched', async () => {
+      app.get('/api/admin/public-config', (_req, res) => {
+        res.set('Cache-Control', 'public, max-age=3600')
+        res.json({ feature: 'on' })
+      })
+
+      const response = await request(app).get('/api/admin/public-config')
+
+      expect(response.headers['cache-control']).toBe('public, max-age=3600')
+    })
+  })
+
+  describe('res.send / res.end compatibility', () => {
+    it('applies no-store when the handler uses res.send instead of res.json', async () => {
+      app.use((req: Request, _res: Response, next: NextFunction) => {
+        ;(req as any).user = { id: 'admin-1', role: 'admin' }
+        next()
+      })
+      app.get('/api/admin/ping', (_req, res) => {
+        res.send('pong')
+      })
+
+      const response = await request(app).get('/api/admin/ping')
+
+      expect(response.headers['cache-control']).toBe('no-store')
+    })
+  })
+})

--- a/src/middleware/cacheControl.ts
+++ b/src/middleware/cacheControl.ts
@@ -1,0 +1,68 @@
+import type { Request, Response, NextFunction } from 'express'
+
+/**
+ * Path prefixes treated as privileged even when the route's auth middleware
+ * hasn't attached an identity to the request. Acts as a defense-in-depth
+ * backstop alongside the identity check in `isPrivilegedRequest` below, so a
+ * future route added under one of these groups is covered by default even if
+ * it forgets to wire up authentication.
+ */
+const PRIVILEGED_PATH_PREFIXES = [
+  '/api/admin',
+  '/api/payouts',
+  '/api/bulk',
+  '/api/imports',
+  '/api/orgs',
+]
+
+function matchesPrivilegedPrefix(path: string): boolean {
+  return PRIVILEGED_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`)
+  )
+}
+
+/**
+ * A request is privileged when it carries authenticated identity (a user
+ * session via `requireUserAuth`, or an enforced API key via `requireApiKey`)
+ * or targets a known privileged route group.
+ */
+function isPrivilegedRequest(req: Request): boolean {
+  if ((req as any).user) return true
+  if ((req as any).apiKey) return true
+  if ((req as any).apiKeyRecord) return true
+  return matchesPrivilegedPrefix(req.path)
+}
+
+/**
+ * Centralised, per-response Cache-Control decision.
+ *
+ * Threat model: without an explicit `Cache-Control: no-store`, a 200 response
+ * from an authenticated endpoint (admin user/audit-log listings, payout and
+ * settlement data, impersonation tokens, replay diffs) is heuristically
+ * cacheable by shared HTTP proxies and by the browser's disk / back-forward
+ * cache. On a shared or public machine, or behind a misconfigured
+ * intermediary cache, a later party could replay a previously authenticated
+ * response after the session that produced it has ended, recovering
+ * privileged data without ever presenting valid credentials. Defaulting
+ * privileged responses to `no-store` closes that gap without requiring every
+ * route author to remember to set the header themselves.
+ *
+ * Routes that intentionally serve cacheable, non-sensitive data (the public
+ * trust-score endpoint, the JWKS document) set their own `Cache-Control`
+ * header before the response is flushed; this middleware only fills in a
+ * default when the route hasn't made an explicit choice, so it never
+ * clobbers an intentional override.
+ */
+export function cacheControlMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const originalEnd = res.end.bind(res)
+
+  ;(res as any).end = function patchedEnd(...args: unknown[]) {
+    if (!res.headersSent && !res.getHeader('Cache-Control') && isPrivilegedRequest(req)) {
+      res.setHeader('Cache-Control', 'no-store')
+      res.setHeader('Pragma', 'no-cache')
+    }
+    return (originalEnd as (...a: unknown[]) => Response)(...args)
+  }
+
+  next()
+}


### PR DESCRIPTION
## Summary

- Adds a single, centralized `cacheControlMiddleware` (`src/middleware/cacheControl.ts`) that decides the `Cache-Control` header for every response, instead of leaving it up to each route to remember.
- Mounted globally in `src/app.ts` right after `requestIdMiddleware`, so it applies consistently across the whole API surface.
- Privileged responses default to `Cache-Control: no-store` + `Pragma: no-cache`. A request is treated as privileged when:
  - `req.user` is set (authenticated user session via `requireUserAuth`), or
  - `req.apiKey` / `req.apiKeyRecord` is set (an enforced API key via `requireApiKey`), or
  - the path falls under a known privileged route group (`/api/admin`, `/api/payouts`, `/api/bulk`, `/api/imports`, `/api/orgs`) — a defense-in-depth backstop for a future route that forgets to wire up auth.
- The middleware patches `res.end` and only fills in the header if the route hasn't already set one, so routes that intentionally serve cacheable, non-sensitive data (`/api/trust/:address`, `/.well-known/jwks.json`) are completely unaffected — their explicit `Cache-Control` values win.

## Threat being mitigated

Before this change, most authenticated endpoints (admin user/audit-log listings, audit-log NDJSON export, impersonation token issuance, payout/settlement data, replay diffs) returned **no `Cache-Control` header at all**. A GET response with a 200 status and no caching directive is heuristically cacheable by:

- Shared/corporate HTTP proxies and CDNs sitting in front of the API,
- The browser's disk cache and back/forward cache (bfcache).

On a shared or public machine, or behind a misconfigured intermediary cache, this means a *subsequent* user of that machine/proxy — or an attacker who gains access to the cache store — could retrieve a previously authenticated response (e.g. another admin's audit log export, a list of users, an issued impersonation token) **after the session that produced it has ended, without ever presenting valid credentials**. This is the class of issue tracked as CWE-525 (Information Exposure Through Browser Caching) / OWASP's "sensitive data left cacheable" finding — exactly the kind of gap a careful auditor flags during review, even with no prior report of exploitation.

Centralizing the decision in one middleware, defaulting to the secure choice (`no-store`), removes the need for every route author to remember to opt out of caching, and closes the gap for any privileged route (present or future) that doesn't explicitly set its own header.

## Test plan

- [x] Added `src/middleware/__tests__/cacheControl.test.ts` (9 cases), including a negative test (`THE NEGATIVE CASE: a privileged, authenticated response is not cacheable`) that fails without the middleware and passes with it — asserting an authenticated admin-style response is not left cacheable, and that unauthenticated/public routes and routes with an explicit override are unaffected.
- [x] `npx vitest run src/middleware/__tests__/cacheControl.test.ts` — 9/9 passed.
- [x] `npx tsc --noEmit` — passes (required `NODE_OPTIONS=--max-old-space-size=8192` locally; the default heap OOMs on this project regardless of this change).
- [x] Lint on changed files (`src/app.ts`, `src/middleware/cacheControl.ts`) — clean; the full `npm run lint` surfaces pre-existing `no-console` errors elsewhere in the repo, unrelated to this change.
- [x] `npm run sbom:check` — OK (CycloneDX 1.6, 744 components).
- [x] `npm run security:scan` — pre-existing transitive-dependency advisories (`@opentelemetry/core`, `body-parser`, `brace-expansion`), unrelated to this change.
- Full `npm test` (500+ files) was started locally but several suites depend on `DATABASE_URL`/`REDIS_URL` service dependencies not available in this sandbox and did not converge in a reasonable time; CI has those services provisioned.

## Cost

The middleware does O(1) property checks (`req.user`, `req.apiKey`, `req.apiKeyRecord`, a short prefix-array scan) once per response, at flush time — negligible relative to the existing per-request work (auth, DB access) already on these paths.

## Out of scope

- No new env vars were introduced, so `.env.example` is unchanged.
- Did not touch `trust.ts` / `jwks.ts` — their explicit `Cache-Control` overrides already work correctly against the new default and didn't need modification.

Closes #693