### PR TITLE
Prevent Admin Crawling

### DIFF
--- a/src/lib/errorCatalog.ts
+++ b/src/lib/errorCatalog.ts
@@ -163,6 +163,14 @@ export const ERROR_CATALOG = freezeCatalog({
     defaultMessage: 'The authenticated caller is not allowed to perform this action',
     category: 'authorization',
   },
+  CRAWLER_BLOCKED: {
+    code: 'crawler_blocked',
+    sdkClassName: 'CrawlerBlockedCredenceError',
+    kind: 'api',
+    httpStatus: 403,
+    defaultMessage: 'Automated crawling of admin surfaces is forbidden.',
+    category: 'authorization',
+  },
   NOT_FOUND: {
     code: 'not_found',
     sdkClassName: 'NotFoundCredenceError',

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -91,6 +91,17 @@ export class AppError extends Error {
   }
 }
 
+export class CrawlerBlockedError extends Error {
+  public readonly statusCode = 403;
+  public readonly code = 'ADMIN_CRAWLER_BLOCKED';
+
+  constructor(message = 'Automated crawling of admin surfaces is forbidden.') {
+    super(message);
+    this.name = 'CrawlerBlockedError';
+    Object.setPrototypeOf(this, CrawlerBlockedError.prototype);
+  }
+}
+
 /**
  * Specific error for validation failures (e.g. Zod).
  */

--- a/src/middleware/preventAdminCrawling.ts
+++ b/src/middleware/preventAdminCrawling.ts
@@ -1,0 +1,30 @@
+// src/middleware/preventAdminCrawling.ts
+
+import { Request, Response, NextFunction } from 'express';
+import { CrawlerBlockedError } from '../lib/errors.js';
+
+const KNOWN_CRAWLERS = [
+  'googlebot',
+  'bingbot',
+  'yandexbot',
+  'duckduckbot',
+  'slurp',
+  'baiduspider',
+  'ia_archiver',
+  'bot',
+  'crawler',
+  'spider'
+];
+
+export const preventAdminCrawling = (req: Request, res: Response, next: NextFunction) => {
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow, noarchive, nosnippet');
+
+  const userAgent = (req.headers['user-agent'] || '').toLowerCase();
+  const isCrawler = KNOWN_CRAWLERS.some((bot) => userAgent.includes(bot));
+
+  if (isCrawler) {
+    return next(new CrawlerBlockedError());
+  }
+
+  next();
+};

--- a/src/routes/admin/admin.test.ts
+++ b/src/routes/admin/admin.test.ts
@@ -170,3 +170,28 @@ describe('Admin Router - Strict Validation', () => {
     })
   })
 })
+
+describe('Admin Anti-Crawling Defenses', () => {
+  it('should reject requests from known crawler User-Agents with a typed error', async () => {
+    const response = await request(setup())
+      .get('/admin') // Adjust if the path is wrong
+      .set('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
+
+    expect(response.status).toBe(403);
+    
+    // Adjust Zod/Error catalog shape is wrong.
+    expect(response.body).toMatchObject({
+      error: expect.objectContaining({
+        code: 'ADMIN_CRAWLER_BLOCKED'
+      })
+    });
+  });
+
+  it('should attach X-Robots-Tag headers to legitimate admin requests', async () => {
+    const response = await request(setup())
+      .get('/admin')
+      .set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
+
+    expect(response.headers['x-robots-tag']).toBe('noindex, nofollow, noarchive, nosnippet');
+  });
+});

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -31,6 +31,7 @@ import { BondsRepository } from "../../db/repositories/bondsRepository.js";
 import { pool } from "../../db/pool.js";
 import { validate } from '../../middleware/validate.js'
 import { z } from 'zod'
+import { preventAdminCrawling } from "../../middleware/preventAdminCrawling.ts";
 
 /**
  * Create the admin router with role and user management endpoints
@@ -49,6 +50,8 @@ export function createAdminRouter(): Router {
 
   // Register handlers
   registerAllReplayHandlers(replayService, identityRepo, bondsRepo);
+
+  router.use(preventAdminCrawling);
 
   /**
    * GET /api/admin/users


### PR DESCRIPTION
Closes #699 

- Added `CRAWLER_BLOCKED` to the admin catalog
- Added a middleware to prevent admin crawling and used in the admin route
- Added Admin Anti-Crawling Defenses