### PR TITLE
Add pool utilization alert and related metrics and tests

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -305,6 +305,7 @@ Active stream names today: `bond_creation`, `bond_withdrawal`.
 | `pg_pool_total_count`             | Gauge | `pool` (`api`/`worker`)                       | [`src/observability/poolMetrics.ts`](../src/observability/poolMetrics.ts)                               | `collect()` callback sampling `pool.totalCount` at scrape time                                          |
 | `pg_pool_idle_count`              | Gauge | `pool`                                        | same                                                                                                   | same, `pool.idleCount`                                                                                 |
 | `pg_pool_waiting_count`           | Gauge | `pool`                                        | same                                                                                                   | same, `pool.waitingCount`                                                                              |
+| `pg_pool_utilization_percent`     | Gauge | `pool`                                        | same                                                                                                   | same, calculated as `(total - idle) / total * 100`; used by `PoolHighUtilization` alert              |
 | `pg_advisory_lock_age_seconds`    | Gauge | `lock_id`, `pid`, `database`, `query`         | [`src/jobs/advisoryLockMonitor.ts`](../src/jobs/advisoryLockMonitor.ts)                                 | `collectStaleAdvisoryLocks(pool)` populates one sample per lock held > 300 s                          |
 
 ### 3.12 Database transactions & WebSocket
@@ -474,6 +475,7 @@ and [`docs/alert-routing.md`](./alert-routing.md). At a glance:
 | `HighBulkVerificationFailureRate`  | SEV2     | `rate(…status="error"[5m]) / rate(…[5m]) > 0.1`                                                                          | —                                                 |
 | `PgPoolSaturation`                 | SEV2     | `pg_pool_waiting_count{pool="api"} > 0` for 2 m                                                                           | `docs/monitoring.md`                              |
 | `PgWorkerPoolSaturation`           | SEV3     | `pg_pool_waiting_count{pool="worker"} > 0` for 5 m                                                                       | `docs/monitoring.md`                              |
+| `PoolHighUtilization`              | SEV2     | `pg_pool_utilization_percent{pool="api"} > 80` for 5 m                                                                    | `docs/monitoring.md`                              |
 | `AuditChainIntegrityViolation`     | SEV1     | `audit_chain_integrity_violation_total > 0`                                                                              | `docs/audit-log.md`                               |
 | `AuditChainVerifierStale`          | SEV2     | `time() - audit_chain_verifier_last_run_timestamp > 1800`                                                                | `docs/audit-log.md`                               |
 

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -6,7 +6,7 @@ groups:
       # SEV1 - Trust score critical: page on-call immediately
       - alert: SuccessRateSLOViolation
         expr: |
-          sum(rate(http_requests_status_total{status_class="5xx"}[5m])) 
+          sum(rate(http_requests_status_total{status_class="5xx"}[5m]))
           / sum(rate(http_requests_status_total[5m])) > 0.001
         for: 2m
         labels:
@@ -24,7 +24,7 @@ groups:
       - alert: ErrorBudgetBurnRateHigh
         expr: |
           (
-            sum(rate(http_requests_status_total{status_class="5xx"}[1h])) 
+            sum(rate(http_requests_status_total{status_class="5xx"}[1h]))
             / sum(rate(http_requests_status_total[1h]))
           ) / 0.001 > 2
         for: 2m
@@ -43,7 +43,7 @@ groups:
         expr: |
           (
             sum(rate(http_request_duration_seconds_bucket{le="0.25", status_class="2xx"}[5m])) by (route)
-            / 
+            /
             sum(rate(http_request_duration_seconds_count{status_class="2xx"}[5m])) by (route)
           ) < 0.95
         for: 5m
@@ -60,7 +60,7 @@ groups:
       # SEV2 - High latency: investigate and ticket
       - alert: HighP99Latency
         expr: |
-          histogram_quantile(0.99, 
+          histogram_quantile(0.99,
             sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route)
           ) > 1
         for: 5m
@@ -77,7 +77,7 @@ groups:
       # SEV3 - Performance concern: low priority
       - alert: HighLatency
         expr: |
-          histogram_quantile(0.95, 
+          histogram_quantile(0.95,
             sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route)
           ) > 1
         for: 5m
@@ -196,6 +196,23 @@ groups:
             Worker pool has {{ $value }} jobs queued waiting for a
             connection for >5 minutes.
           runbook_url: "https://docs.credence.org/runbooks/database#worker-pool-saturation"
+
+      # High pool utilization
+      # SEV2 - Resource pressure: ticket required
+      - alert: PoolHighUtilization
+        expr: |
+          pg_pool_utilization_percent{job="credence-backend", pool="api"} > 80
+        for: 5m
+        labels:
+          severity: SEV2
+          service: database
+          team: infrastructure
+        annotations:
+          summary: "PostgreSQL connection pool high utilization"
+          description: >-
+            API pool utilization is {{ $value | humanize }}%.
+            Consider increasing DB_POOL_MAX or investigating slow queries.
+          runbook_url: "https://docs.credence.org/runbooks/database#pool-utilization"
 
       # ─── Audit Log Tamper Detection ────────────────────────────────
       - alert: AuditChainIntegrityViolation

--- a/src/observability/poolMetrics.test.ts
+++ b/src/observability/poolMetrics.test.ts
@@ -42,4 +42,114 @@ describe('Pool Metrics Exporter', () => {
     expect(updatedMetricsStr).toContain('pg_pool_total_count{pool="api"} 20')
     expect(updatedMetricsStr).toContain('pg_pool_waiting_count{pool="api"} 5')
   })
+
+  it('calculates pool utilization percentage correctly', async () => {
+    const registry = new client.Registry()
+
+    // Mock pools with specific states
+    const apiPool = {
+      totalCount: 20,
+      idleCount: 5,
+      waitingCount: 0,
+    } as Pool
+
+    const workerPool = {
+      totalCount: 10,
+      idleCount: 2,
+      waitingCount: 0,
+    } as Pool
+
+    registerPoolMetrics(registry, apiPool, workerPool)
+
+    const metricsStr = await registry.metrics()
+
+    // API pool: 20 total, 5 idle, 15 active = 75% utilization
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="api"} 75')
+
+    // Worker pool: 10 total, 2 idle, 8 active = 80% utilization
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="worker"} 80')
+  })
+
+  it('handles high pool utilization (alert threshold)', async () => {
+    const registry = new client.Registry()
+
+    // Mock pools at high utilization
+    const apiPool = {
+      totalCount: 20,
+      idleCount: 2,
+      waitingCount: 0,
+    } as Pool
+
+    const workerPool = {
+      totalCount: 10,
+      idleCount: 1,
+      waitingCount: 0,
+    } as Pool
+
+    registerPoolMetrics(registry, apiPool, workerPool)
+
+    const metricsStr = await registry.metrics()
+
+    // API pool: 20 total, 2 idle, 18 active = 90% utilization (exceeds 80% threshold)
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="api"} 90')
+
+    // Worker pool: 10 total, 1 idle, 9 active = 90% utilization (exceeds 80% threshold)
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="worker"} 90')
+  })
+
+  it('handles edge case of empty pool (zero total)', async () => {
+    const registry = new client.Registry()
+
+    // Mock pools with zero total count
+    const apiPool = {
+      totalCount: 0,
+      idleCount: 0,
+      waitingCount: 0,
+    } as Pool
+
+    const workerPool = {
+      totalCount: 0,
+      idleCount: 0,
+      waitingCount: 0,
+    } as Pool
+
+    registerPoolMetrics(registry, apiPool, workerPool)
+
+    const metricsStr = await registry.metrics()
+
+    // Should report 0% utilization when pool is empty
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="api"} 0')
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="worker"} 0')
+  })
+
+  it('updates pool utilization on dynamic pool changes', async () => {
+    const registry = new client.Registry()
+
+    const apiPool = {
+      totalCount: 20,
+      idleCount: 10,
+      waitingCount: 0,
+    } as Pool
+
+    const workerPool = {
+      totalCount: 10,
+      idleCount: 5,
+      waitingCount: 0,
+    } as Pool
+
+    registerPoolMetrics(registry, apiPool, workerPool)
+
+    let metricsStr = await registry.metrics()
+
+    // Initial: 50% utilization
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="api"} 50')
+
+    // Simulate pool usage increase
+    apiPool.idleCount = 2
+
+    metricsStr = await registry.metrics()
+
+    // Updated: 90% utilization
+    expect(metricsStr).toContain('pg_pool_utilization_percent{pool="api"} 90')
+  })
 })

--- a/src/observability/poolMetrics.ts
+++ b/src/observability/poolMetrics.ts
@@ -53,4 +53,21 @@ export function registerPoolMetrics(
       this.set({ pool: "worker" }, workerPool.waitingCount);
     },
   });
+
+  new client.Gauge({
+    name: "pg_pool_utilization_percent",
+    help: "Percentage of pool capacity in use (active connections / total connections * 100)",
+    labelNames: ["pool"] as const,
+    registers: [registry],
+    collect() {
+      const apiUtilization = apiPool.totalCount > 0
+        ? ((apiPool.totalCount - apiPool.idleCount) / apiPool.totalCount) * 100
+        : 0;
+      const workerUtilization = workerPool.totalCount > 0
+        ? ((workerPool.totalCount - workerPool.idleCount) / workerPool.totalCount) * 100
+        : 0;
+      this.set({ pool: "api" }, apiUtilization);
+      this.set({ pool: "worker" }, workerUtilization);
+    },
+  });
 }


### PR DESCRIPTION
## Description

Implements a Prometheus alert that fires when database pool utilization exceeds 80% for 5 consecutive minutes.

## Changes

- **New metric**: `pg_pool_utilization_percent` gauge calculated as `(total - idle) / total * 100` for both API and worker pools
- **New alert**: `PoolHighUtilization` (SEV2) fires at >80% utilization for 5 minutes, routed to infrastructure team
- **Tests**: 4 new test cases covering normal calculations, alert threshold, edge cases (empty pool), and dynamic pool changes
- **Docs**: Updated `docs/OBSERVABILITY.md` with metric and alert details

## Verification

- [x] TypeScript syntax valid
- [x] Alert YAML structure valid
- [x] Tests added and passing
- [x] Documentation updated with metric and alert reference
- [x] Alert severity (SEV2) matches alert-routing matrix

## Backwards Compatibility

✅ No breaking changes. New metric and alert are purely additive.

## Related Issue
Closes #729