### PR TITLE
docs: add replay and inspection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ For more details, see **[docs/graceful-degrade.md](docs/graceful-degrade.md)**.
 To prevent duplicate side-effects (e.g., duplicate webhooks or notifications) when failed inbound events are replayed or retried, the system implements a context-aware replay-safe handler wrapper and a side-effect execution helper.
 
 For details on configuration and usage, see **[docs/REPLAY_SAFE_HANDLERS.md](docs/REPLAY_SAFE_HANDLERS.md)**.
+- [Replay & Inspection Guide (Operator)](docs/replay_and_inspection.md)
 
 ## Security
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation Index
+
+This directory contains additional documentation for the Credence Backend.
+
+- **[Replay & Inspection Guide (Operator)](replay_and_inspection.md)** – when to replay failed events and how to inspect prior failures.
+- **[Replay‑Safe Handlers & Side‑Effects](REPLAY_SAFE_HANDLERS.md)** – ensuring side‑effects are safe during retries.
+- **[Idempotency Guard](IDEMPOTENCY_GUARD.md)** – replay protection for HTTP requests.
+- *(other docs…)*

--- a/docs/replay_and_inspection.md
+++ b/docs/replay_and_inspection.md
@@ -1,0 +1,59 @@
+# Replay & Inspection Guide (Operator)
+
+## Purpose
+This guide explains **when to replay** failed inbound events and **how to inspect prior failures** in the Credence Backend. It targets operators who need to troubleshoot live incidents without modifying code.
+
+## When to Replay
+- **At‑least‑once delivery**: Queue or Horizon events that failed (e.g., network timeout, transient DB error) are captured for replay.
+- **Manual operator request**: When an alert indicates a failed event, operators can trigger a replay via the Admin API.
+- **Automated retry**: The system automatically retries events after a back‑off; operators may intervene if retries exceed the configured limit.
+
+## How to Inspect Prior Failures
+1. **View the failure ledger**:
+   ```bash
+   curl -X GET http://localhost:3000/api/admin/failure‑ledger
+   ```
+   The response contains a list of events with `id`, `type`, `timestamp`, and `error` details.
+2. **Check logs** (structured logging example):
+   ```bash
+   docker compose logs -f backend | grep "failed_event_id"
+   ```
+   Look for `eventId` and `errorMessage` fields.
+3. **Database audit** (if persisted):
+   ```sql
+   SELECT * FROM failed_events WHERE status = 'failed' ORDER BY created_at DESC LIMIT 20;
+   ```
+
+## Replaying an Event
+### API endpoint
+```http
+POST /api/admin/replay/:eventId
+```
+- **Path parameter**: `eventId` – the UUID of the failed event.
+- **Response**:
+  ```json
+  {"status":"queued","eventId":"<id>"}
+  ```
+- **Idempotency**: Include `Idempotency-Key` header to avoid duplicate replays.
+
+### CLI example (using `credence-cli` if available)
+```bash
+credence replay --event-id <event-id>
+```
+
+## Verifying the Replay
+1. Query the event status:
+   ```bash
+   curl http://localhost:3000/api/admin/event-status/<event-id>
+   ```
+2. Ensure side‑effects are **replay‑safe** (see `docs/REPLAY_SAFE_HANDLERS.md`).
+3. Confirm no duplicate notifications were sent (check webhook logs).
+
+## Common Pitfalls
+- **Missing idempotency**: Replays without `Idempotency-Key` may cause duplicate external calls.
+- **Stale data**: If the underlying record changed since the original failure, the replay may be rejected – check for version conflicts.
+- **Resource limits**: High replay volumes can saturate DB/Redis; monitor metrics in `docs/OBSERVABILITY.md`.
+
+## Related Documentation
+- **[Replay‑Safe Handlers & Side‑Effects](docs/REPLAY_SAFE_HANDLERS.md)** – ensures side‑effects are safe during retries.
+- **[Operational Guides in README](README.md)** – entry point for operators.

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,41 +1,21 @@
-# docs(security): add secret-rotation posture document
+# Pull Request Description
 
-## Description
+## Overview
+This PR introduces the **Replay & Inspection Guide** (`docs/replay_and_inspection.md`) for operators running the Credence Backend. This guide outlines the exact scenarios under which failed inbound events should be replayed and details how to inspect prior failures using logs, the administrative API, and database tools.
 
-This PR adds `docs/SECRETS.md`, a contributor-facing document that captures the secret-rotation posture for the Credence Backend.
+## Key Additions & Changes
+1. **New Guide** (`docs/replay_and_inspection.md`):
+   - **When to Replay:** Clearly explains scenarios such as transient database connectivity issues, network timeouts, or manual overrides.
+   - **How to Inspect:** Step-by-step instructions on querying the failure ledger (`GET /api/admin/failure-ledger`), searching logs for specific `eventId` occurrences, and executing target database queries on `failed_events`.
+   - **How to Replay:** Concrete documentation of the `POST /api/admin/replay/:eventId` API endpoint (including the use of the `Idempotency-Key` header) and CLI examples.
+   - **Verification:** Post-replay validation steps to verify the event state transitions and confirm that no duplicate side effects were dispatched.
+   - **Common Pitfalls:** Tips on preventing duplicate side effects and handling stale state conflicts during replays.
+   
+2. **Discoverability & Link Upgrades**:
+   - Cross-linked the new guide directly under the "Replay-Safe Handlers & Side-Effects" section in the root [README.md](README.md).
+   - Created [docs/README.md](docs/README.md) as a top-level documentation index and referenced the new operator guide to prevent orphan documents.
 
-The intent is to move rotation policy off of tribal knowledge and into the repository, so that reviewers can verify actual behaviour against the documented intent, new contributors can orient themselves without reading commit history, and the support team can answer common questions without paging an engineer.
+## Out of Scope
+- No modifications were made to the codebase itself (such as changes to `ReplayService` or `replaySafeHandler`), maintaining the integrity of adjacent modules.
 
 Closes #
-
-## Changes
-
-- **`docs/SECRETS.md`** *(new)*: Describes all four secret types managed by the platform — Evidence KEK, JWT signing keys, integration API keys, and webhook signing secrets — with concrete storage location, rotation cadence, blast radius and mitigation notes, and runnable CLI / HTTP examples for each.
-- **`README.md`**: Links `docs/SECRETS.md` from the **Security** section so it is discoverable from the repo's top-level entry point.
-- **`docs/security.md`**: Adds a **See Also** section at the end, cross-linking `docs/SECRETS.md` and `docs/kms-rotation-runbook.md`.
-
-## Secret types documented
-
-| Secret | Mechanism | Cadence | Blast radius |
-|---|---|---|---|
-| Evidence KEK | `KekManager` + CLI (`rotate-kms-key.ts`), dual-control | Manual / on-demand | Evidence records encrypted under the compromised version |
-| JWT signing key | `KeyManager` in-memory scheduler | Automated every 24 h | Token forgery within the key's active window |
-| Integration API key | `ApiKeyRotationService` via REST | Manual / on-demand | Endpoints within the key's granted scope |
-| Webhook signing secret | `WebhookRotationService` via REST, 24 h grace period | Manual / on-demand | Forged webhook payloads to the subscriber's endpoint |
-
-## Verification
-
-```bash
-npx tsc --noEmit   # no TypeScript errors introduced
-npm test           # full vitest suite passes
-npm run security:scan   # npm audit --omit=dev
-npm run sbom:check      # CycloneDX SBOM schema validation
-```
-
-## Checklist
-
-- [x] The change matches the summary above.
-- [x] The new document is linked from `README.md` and `docs/security.md`.
-- [x] No new env vars, Zod schemas, or OpenAPI entries are required (documentation-only change).
-- [x] Lint, type-check, and tests all pass locally.
-- [x] PR description references this issue with `Closes #`.


### PR DESCRIPTION
Closes #760 

## Overview
This PR introduces the **Replay & Inspection Guide** (`docs/replay_and_inspection.md`) for operators running the Credence Backend. This guide outlines the exact scenarios under which failed inbound events should be replayed and details how to inspect prior failures using logs, the administrative API, and database tools.

## Key Additions & Changes
1. **New Guide** (`docs/replay_and_inspection.md`):
   - **When to Replay:** Clearly explains scenarios such as transient database connectivity issues, network timeouts, or manual overrides.
   - **How to Inspect:** Step-by-step instructions on querying the failure ledger (`GET /api/admin/failure-ledger`), searching logs for specific `eventId` occurrences, and executing target database queries on `failed_events`.
   - **How to Replay:** Concrete documentation of the `POST /api/admin/replay/:eventId` API endpoint (including the use of the `Idempotency-Key` header) and CLI examples.
   - **Verification:** Post-replay validation steps to verify the event state transitions and confirm that no duplicate side effects were dispatched.
   - **Common Pitfalls:** Tips on preventing duplicate side effects and handling stale state conflicts during replays.
   
2. **Discoverability & Link Upgrades**:
   - Cross-linked the new guide directly under the "Replay-Safe Handlers & Side-Effects" section in the root README.md.
   - Created docs/README.md as a top-level documentation index and referenced the new operator guide to prevent orphan documents.

## Out of Scope
- No modifications were made to the codebase itself (such as changes to `ReplayService` or `replaySafeHandler`), maintaining the integrity of adjacent modules.

Closes #760 