### PR TITLE
test: add req.metrics namespace isolation test and fix leakage

### DIFF
--- a/src/middleware/__tests__/req_metrics_isolation.test.ts
+++ b/src/middleware/__tests__/req_metrics_isolation.test.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { metricsMiddleware } from '../metrics.js';
+
+test('req.metrics namespace is isolated per request', async () => {
+  const app = express();
+  app.use(metricsMiddleware);
+
+  // Route that mutates req.metrics
+  app.get('/set', (req: Request, res: Response) => {
+    (req as any).metrics.foo = 'bar';
+    res.json({ set: true });
+  });
+
+  // Route that checks for the existence of the property
+  app.get('/check', (req: Request, res: Response) => {
+    const hasFoo = Object.prototype.hasOwnProperty.call((req as any).metrics, 'foo');
+    res.json({ hasFoo });
+  });
+
+  // First request sets the property
+  await request(app).get('/set').expect(200, { set: true });
+
+  // Second request should NOT see the property set in the previous request
+  const response = await request(app).get('/check').expect(200);
+  expect(response.body.hasFoo).toBe(false);
+});

--- a/src/middleware/metrics.ts
+++ b/src/middleware/metrics.ts
@@ -211,6 +211,8 @@ export const oomEventsTotal = new client.Counter({
  * ```
  */
 export function metricsMiddleware(req: Request, res: Response, next: NextFunction) {
+  // Initialize a fresh metrics namespace for each request to avoid leakage
+  (req as any).metrics = {};
   const start = Date.now()
   const hrStart = process.hrtime.bigint()
   


### PR DESCRIPTION
### Summary
This PR addresses namespace leakage of request metrics across distinct requests. Previously, the `req.metrics` object could persist/leak properties across requests if not initialized fresh per request. We now explicitly initialize a fresh `req.metrics` namespace for every request processed by `metricsMiddleware`.

### Changes
- **`src/middleware/metrics.ts`**: Set `(req as any).metrics = {}` on incoming requests to guarantee isolation.
- **`src/middleware/__tests__/req_metrics_isolation.test.ts`**: Introduced a unit test simulating consecutive HTTP requests where the first request mutates its `req.metrics` and the second request asserts the mutation is not present.

### Verification
- Ran new unit tests with Vitest (passes).
- Type checking (`tsc --noEmit`) passes successfully.

Closes #807
