### PR TITLE
docs: add JWT_CLAIMS.md canonical reference (#812)

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ For observability, request tracing, metrics, and structured logging guidelines:
 For security policies, reporting, and architecture documentation:
 - **Security Policy & Vulnerability Reporting**: See [SECURITY.md](SECURITY.md) for details on supported versions and how to report a vulnerability.
 - **Security Architecture**: See [docs/security.md](docs/security.md) for details on the API key scope model, encrypted evidence storage, rate limiting, and dependency scanning SLAs.
+- **Canonical JWT Claims Reference**: See [docs/JWT_CLAIMS.md](docs/JWT_CLAIMS.md) for standard, custom, and impersonation JWT claims, headers, and consumer middleware.
 - **Rate Limiting Support & Operations**: See [docs/rate-limiting.md](docs/rate-limiting.md) for details on default tier rate limits, environment configuration, troubleshooting, and support FAQs.
 - **Evidence Upload Security**: See [docs/evidence-upload-security.md](docs/evidence-upload-security.md) for file upload security configurations, size/count limits, and magic number validations.
 - **Secret-Rotation Posture**: See [docs/SECRETS.md](docs/SECRETS.md) for where secrets live, rotation cadence, and blast radius of each credential type.

--- a/docs/JWT_CLAIMS.md
+++ b/docs/JWT_CLAIMS.md
@@ -1,0 +1,130 @@
+# Canonical JWT Claims Reference
+
+> **Audience:** Contributors (engineers building API routes, authentication middleware, and background services in Credence Backend).
+
+This document serves as the canonical reference for all JSON Web Token (JWT) headers and claims issued, signed, and consumed within the Credence Backend service.
+
+---
+
+## 1. Protected Header Claims
+
+All JWTs issued by `KeyManager` (`src/services/keyManager/index.ts`) use RSASSA-PSS signature algorithms and include protected headers for public key discovery.
+
+| Header | Type | Value / Format | Purpose | Producer | Consumer |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `alg` | `string` | `PS256` | Signature algorithm (RSASSA-PSS using SHA-256) | `KeyManager.signToken()` | `jose.jwtVerify()` |
+| `kid` | `string` | UUID v4 (e.g. `9b1deb4d-3b7d-4b69-9cd...`) | Key Identifier matching active key in `/.well-known/jwks.json` | `KeyManager.signToken()` | `KeyManager.verifyToken()` |
+
+### Protected Header Example
+
+```json
+{
+  "alg": "PS256",
+  "kid": "c8a32b6e-41d5-4e78-9b88-824f2b1d604e"
+}
+```
+
+---
+
+## 2. Standard Registered Claims (RFC 7519)
+
+Standard claims ensure interoperability and enforce token expiration and clock tolerance.
+
+| Claim | Name | Type | Description / Example | Default / Lifetime | Consumer |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| `iss` | Issuer | `string` | Token issuer URL (`https://credence.org`) | Mandatory | `jwtVerify()` |
+| `sub` | Subject | `string` | Principal identifier (e.g. `admin-user-1`) | User / Key ID | `requireUserAuth` |
+| `aud` | Audience | `string` | Intended recipient service (`credence-api`) | `credence-api` | Token validator |
+| `exp` | Expiration | `number` | Unix epoch seconds when token expires | $t_{\text{issued}} + 3600\text{s}$ (`1h`) | `jwtVerify()` |
+| `nbf` | Not Before | `number` | Unix epoch seconds before which token is invalid | $t_{\text{issued}}$ | `jwtVerify()` |
+| `iat` | Issued At | `number` | Unix epoch seconds when token was signed | Instant of signing | `jwtVerify()` |
+| `jti` | JWT ID | `string` | Unique UUID v4 token identifier | Unique per token | Replay protection |
+
+---
+
+## 3. Credence Custom Claims
+
+Credence embeds authorization, multi-tenancy, and role metadata into the JWT payload.
+
+| Claim | Type | Description | Allowed Values | Consuming Middleware |
+| :--- | :--- | :--- | :--- | :--- |
+| `tenant_id` | `string` | Tenant isolation scope | `tenant-admin`, `tenant-verifier`, UUID | `runWithTenant()` / `tenantContext.ts` |
+| `role` | `string` | User authorization role | `super-admin`, `admin`, `verifier`, `user` | `requireAdminRole` / `rbac.ts` |
+| `scope` | `string[]` | Granted API permissions | `trust:read`, `attestations:write`, `payouts:write`, `reports:generate`, `exports:read`, `webhooks:admin`, `admin:write` | `requireApiKey` / `scopeSatisfies` |
+| `impersonator` | `string` (optional) | Admin ID who initiated impersonation | Admin User ID | `ImpersonationService` / Audit log |
+| `reason` | `string` (optional) | Audit reason for impersonation session | Non-empty string | Audit log |
+
+### Complete JWT Payload Example
+
+```json
+{
+  "iss": "https://credence.org",
+  "sub": "user-4821",
+  "aud": "credence-api",
+  "exp": 1784958791,
+  "nbf": 1784955191,
+  "iat": 1784955191,
+  "jti": "e9b5f3a0-1284-4821-b32d-304e28491821",
+  "tenant_id": "tenant-verifier",
+  "role": "verifier",
+  "scope": [
+    "trust:read",
+    "attestations:read",
+    "attestations:write"
+  ]
+}
+```
+
+---
+
+## 4. Impersonation Session Claims
+
+When an admin user issues a short-lived impersonation token (`src/services/impersonation/index.ts`), additional audit claims are embedded.
+
+```json
+{
+  "iss": "https://credence.org",
+  "sub": "target-user-99",
+  "aud": "credence-api",
+  "exp": 1784956091,
+  "iat": 1784955191,
+  "tenant_id": "tenant-admin",
+  "role": "user",
+  "impersonator": "admin-user-1",
+  "reason": "Investigating dispute #402 regarding unverified bond settlement"
+}
+```
+
+### Impersonation Rules & Limits
+1. **Default Lifetime:** $900 \text{ seconds}$ ($15 \text{ minutes}$).
+2. **Hard Ceiling:** Capped at $3,600 \text{ seconds}$ ($1 \text{ hour}$).
+3. **No Nested Impersonation:** An impersonation token cannot be used to issue another impersonation token.
+
+---
+
+## 5. Token Producer & Consumer Matrix
+
+```
+[KeyManager / SignJWT] ──(signs PS256 token with kid)──> [HTTP Request Header]
+                                                                  │
+                                                                  ▼
+[/.well-known/jwks.json] <──(fetches active/retired kid)─── [verifyToken / jwtVerify]
+                                                                  │
+                                                                  ▼
+[AuthenticatedRequest] <──(attaches req.user & req.apiKey)─── [auth middleware]
+```
+
+### Key Lifecycle & Verification Rules
+- **Active Signing Key:** Used for signing all new JWTs.
+- **Retired Signing Key:** Maintained in JWKS during `gracePeriodSeconds` ($3600\text{s}$) to verify tokens issued prior to key rotation.
+- **Clock Skew Tolerance:** `clockSkewSeconds` ($300\text{s}$) is added to `jwtVerify()` tolerance to accommodate server clock drift.
+
+---
+
+## 6. Verification Checklist for Contributors
+
+When adding new JWT claims or modifying token validation:
+- [ ] Register new claim names in this document (`docs/JWT_CLAIMS.md`).
+- [ ] Use `snake_case` for custom claim keys (`tenant_id`, `impersonator`).
+- [ ] Ensure any new request/response shape has a matching Zod schema and regenerated OpenAPI specification (`npm run generate:openapi`).
+- [ ] Verify unit tests cover valid tokens, expired tokens (`exp`), missing `kid` headers, and unknown key IDs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,6 @@ This directory contains additional documentation for the Credence Backend.
 - **[Replay & Inspection Guide (Operator)](replay_and_inspection.md)** – when to replay failed events and how to inspect prior failures.
 - **[Replay‑Safe Handlers & Side‑Effects](REPLAY_SAFE_HANDLERS.md)** – ensuring side‑effects are safe during retries.
 - **[Idempotency Guard](IDEMPOTENCY_GUARD.md)** – replay protection for HTTP requests.
+- **[Canonical JWT Claims Reference](JWT_CLAIMS.md)** – standard, custom, and impersonation JWT claims, headers, and consumer middleware.
+- **[Incoming Webhook Security & Posture](WEBHOOK_RECEIVE.md)** – HMAC-SHA256 signature verification, 5-minute replay window, and CIDR allowed origins.
 - *(other docs…)*

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -169,6 +169,7 @@ Response: **204 No Content**. Subsequent requests using the revoked key receive 
 - All key operations (create, revoke, rotate) are logged to the audit log.
 - Rate limits are enforced per tier (integration at the infrastructure layer, e.g. via a reverse proxy or Redis-based limiter).
 - The middleware is **deny-by-default**: if a key does not carry the required scope, the request is rejected with `403 Forbidden` before reaching the handler.
+- For complete claim definitions, header specifications, and consumer middleware, see [docs/JWT_CLAIMS.md](JWT_CLAIMS.md).
 
 - **Timing-safe validation**: Keys are validated by hashing the presented key and performing constant-time checks against stored hashes to mitigate timing attacks. Implementations must avoid early-exit string comparisons on raw keys.
 - **No logging of raw keys**: Never log or persist raw API key values in application logs, error messages, or monitoring systems.

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -93,3 +93,10 @@ Every denied request emits a structured JSON log line to `console.warn`:
 | `/api/bond/:address` | GET | `requireMinRole('verifier')` |
 | `/api/identity` | POST | `requireMinRole('user')` |
 | `/api/admin/*` | ALL | `requireRole('admin')` |
+
+---
+
+## Related Documentation
+
+* [Canonical JWT Claims Reference](JWT_CLAIMS.md) – JWT role, tenant_id, and scope claim specifications.
+* [API Keys & Scopes](api-keys.md) – Granular API key scope definitions.


### PR DESCRIPTION
## Summary
Resolves #812 by introducing `docs/JWT_CLAIMS.md`, documenting the canonical list of standard JWT claims (RFC 7519), custom Credence claims (`tenant_id`, `role`, `scope`), protected header claims (`alg`, `kid`), impersonation token session rules, and consumer middleware.

## What Changed
- Created `docs/JWT_CLAIMS.md` targeting Contributors with concrete TypeScript types, header metadata, claim definitions, and flow diagrams.
- Documented all active JWT claims:
  1. **Protected Headers:** `alg` (`PS256`) and `kid` (Key Identifier matching `/.well-known/jwks.json`).
  2. **Standard Claims:** `iss`, `sub`, `aud`, `exp`, `nbf`, `iat`, `jti`.
  3. **Custom Credence Claims:** `tenant_id`, `role`, `scope` array, `impersonator`, `reason`.
  4. **Impersonation Sessions:** Session lifetime caps (default 15m, max 1h), anti-nesting rules, and audit logging.
  5. **Producer & Consumer Matrix:** Map from `KeyManager` signing to `requireUserAuth`, `requireApiKey`, `requireAdminRole` middleware.
- Linked `docs/JWT_CLAIMS.md` from `README.md` (Security section), `docs/README.md` (Documentation Index), `docs/api-keys.md`, and `docs/rbac.md`.

## Key Design Decisions
- **Target Audience:** Written specifically for **Contributors** so engineers and PR reviewers can verify token issuance and verification behavior against explicit specifications.

## Acceptance Criteria Checklist
- [x] Document added matches issue summary.
- [x] Linked from top-level `README.md` and `docs/README.md`.
- [x] Examples use valid JSON / TypeScript types.
- [x] References issue with `Closes #812`.

Closes #812