### PR TITLE
docs: add WEBHOOK_SIGNING.md operator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ For security policies, reporting, and architecture documentation:
 - **Rate Limiting Support & Operations**: See [docs/rate-limiting.md](docs/rate-limiting.md) for details on default tier rate limits, environment configuration, troubleshooting, and support FAQs.
 - **Evidence Upload Security**: See [docs/evidence-upload-security.md](docs/evidence-upload-security.md) for file upload security configurations, size/count limits, and magic number validations.
 - **Secret-Rotation Posture**: See [docs/SECRETS.md](docs/SECRETS.md) for where secrets live, rotation cadence, and blast radius of each credential type.
+- **Webhook Signature Operator Guide**: See [docs/WEBHOOK_SIGNING.md](docs/WEBHOOK_SIGNING.md) for HMAC-SHA256 signature generation, verification, replay tolerance, 24-hour secret rotation grace period, Express middleware, and troubleshooting runbook.
 
 ## Testing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,5 @@ This directory contains additional documentation for the Credence Backend.
 - **[Replay & Inspection Guide (Operator)](replay_and_inspection.md)** – when to replay failed events and how to inspect prior failures.
 - **[Replay‑Safe Handlers & Side‑Effects](REPLAY_SAFE_HANDLERS.md)** – ensuring side‑effects are safe during retries.
 - **[Idempotency Guard](IDEMPOTENCY_GUARD.md)** – replay protection for HTTP requests.
+- **[Webhook Signature Generation & Verification (Operator Guide)](WEBHOOK_SIGNING.md)** – HMAC-SHA256 signatures, replay tolerance, 24-hour secret rotation grace period, Express middleware, and troubleshooting runbook.
 - *(other docs…)*

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -172,7 +172,7 @@ Content-Type: application/json
 ## 4. Webhook Signing Secrets
 
 ### Purpose & Architecture
-Used to sign payloads sent to external subscribers via `X-Credence-Signature` HMAC headers so receiving servers can verify the authenticity of the webhook event. Handled by [WebhookRotationService](file:///c:/Users/DELL/Documents/GitHub/Credence-Backend/src/services/webhooks/rotationService.ts).
+Used to sign payloads sent to external subscribers via `X-Webhook-Signature` HMAC headers so receiving servers can verify the authenticity of the webhook event. Handled by [WebhookRotationService](../src/services/webhooks/rotationService.ts). For full operator procedures, see **[Webhook Signature Operator Guide](WEBHOOK_SIGNING.md)**.
 
 ### Where They Live
 - Stored plain-text (or encrypted) in the database in the webhooks subscription table.

--- a/docs/WEBHOOK_SIGNING.md
+++ b/docs/WEBHOOK_SIGNING.md
@@ -1,0 +1,141 @@
+# Webhook Signature Generation & Verification — Operator Guide
+
+This guide describes how webhook signatures are generated, transmitted, verified, and rotated within the Credence platform. It is written for **system operators, DevOps engineers, and support engineers** maintaining webhook delivery infrastructure, configuring verification gateways, and troubleshooting integration failures.
+
+---
+
+## Overview
+
+Credence uses HMAC-SHA256 signatures to ensure the authenticity and integrity of outgoing webhook notifications. Webhook payloads are signed with a shared secret assigned to each webhook endpoint subscriber.
+
+When receiving a webhook delivery, operators and consumer applications must verify the signature header before processing the event body to prevent unauthorized injection, tampering, or replay attacks.
+
+---
+
+## 1. Webhook Signature Specification
+
+### 1.1 Signature Algorithm & Format
+- **Algorithm**: HMAC-SHA256 (`crypto.createHmac('sha256', secret)`)
+- **Digest Output**: 64-character hexadecimal string (`digest('hex')`)
+- **Header Name**: `x-webhook-signature` (case-insensitive)
+- **Header Formats Supported**:
+  - `sha256=<hex_digest>` (e.g. `sha256=a1b2c3d4e5f6...`)
+  - `<hex_digest>` (e.g. `a1b2c3d4e5f6...`)
+
+### 1.2 Payload Signing Mechanism
+The signature is generated over the exact UTF-8 encoded JSON string body sent in the HTTP POST request.
+
+**Server Signing Logic ([`src/services/webhooks/delivery.ts`](../src/services/webhooks/delivery.ts)):**
+```typescript
+import { createHmac } from 'node:crypto';
+
+export function signPayload(payload: string, secret: string): string {
+  return createHmac('sha256', secret).update(payload).digest('hex');
+}
+```
+
+---
+
+## 2. Replay Protection & Timestamp Verification
+
+To defend against replay attacks where an attacker re-sends a captured valid webhook request, Credence embeds an ISO-8601 UTC timestamp inside every webhook payload body:
+
+```json
+{
+  "id": "evt_123456789",
+  "event": "bond.status.updated",
+  "timestamp": "2026-07-25T06:30:00.000Z",
+  "data": {
+    "identityId": "id_987654321",
+    "status": "active"
+  }
+}
+```
+
+### Replay Window Tolerance
+- **Default Tolerance**: 5 minutes (`300,000 ms`).
+- **Verification Rule**: The receiver must evaluate `Math.abs(Date.now() - timestamp) <= tolerance`.
+- Requests with missing timestamps, invalid date formats, or timestamps skewed outside the 5-minute tolerance window are rejected immediately.
+
+---
+
+## 3. Timing-Safe Signature Verification
+
+Signature verification must perform fixed-time byte comparisons to prevent side-channel timing attacks that leak signature characters.
+
+**Verification Logic ([`src/lib/webhookVerifier.ts`](../src/lib/webhookVerifier.ts)):**
+```typescript
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export function safeCompareHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+}
+```
+
+---
+
+## 4. Secret Rotation & Dual-Key Grace Period
+
+Operators can rotate a webhook's shared secret without incurring downtime or dropping events during client migration.
+
+**Rotation Semantics ([`src/services/webhooks/rotationService.ts`](../src/services/webhooks/rotationService.ts)):**
+1. **New Secret Generation**: A new 32-byte cryptographically random hex secret is generated (`randomBytes(32).toString('hex')`).
+2. **24-Hour Grace Period**: The old secret is preserved in the database as `previousSecret` with an expiration timestamp (`previousSecretExpiresAt = now + 24 hours`).
+3. **Dual-Key Verification**: During the 24-hour window, verification attempts check `currentSecret` first, falling back to `previousSecret` if `currentSecret` fails.
+4. **Audit Logging**: Every secret rotation triggers an immutable audit log entry (`ROTATE_WEBHOOK_SECRET`).
+
+---
+
+## 5. Express Middleware Integration
+
+Credence provides an Express middleware [`verifyWebhookSignature`](../src/middleware/webhookSignature.ts) for receiver endpoints.
+
+### Usage Example
+```typescript
+import express from 'express';
+import { verifyWebhookSignature } from './src/middleware/webhookSignature.js';
+
+const app = express();
+
+// Configure raw or JSON body parsing
+app.use(express.json());
+
+// Protect inbound webhook receiver endpoint
+app.post(
+  '/webhooks/receiver',
+  verifyWebhookSignature({
+    secret: process.env.WEBHOOK_SHARED_SECRET!,
+    signatureHeader: 'x-webhook-signature',
+    tolerance: 300000, // 5 minutes tolerance
+  }),
+  (req, res) => {
+    // Verified request handler
+    res.status(200).json({ received: true });
+  }
+);
+```
+
+---
+
+## 6. Operator Troubleshooting & Diagnostics Runbook
+
+When an incoming webhook request fails verification, the middleware rejects it with HTTP `401 Unauthorized`. Use the table below to diagnose and resolve failure reasons returned by [`verifySignature`](../src/lib/webhookVerifier.ts):
+
+| Failure Reason | Description | Root Cause | Operator Action |
+| --- | --- | --- | --- |
+| `missing_secret` | Secret undefined on server | No active or previous secret configured for endpoint | Check database configuration / subscriber secret mapping. |
+| `missing_signature` | `x-webhook-signature` header absent | Request header stripped by reverse proxy or API gateway | Verify proxy header forwarding (`x-webhook-signature`). |
+| `malformed_signature` | Signature format invalid | Header value is non-hex or not 64 hexadecimal characters | Inspect sender header formatting; ensure SHA-256 hex encoding. |
+| `missing_timestamp` | Body missing `timestamp` field | Raw payload string altered before parsing or invalid JSON | Ensure raw body is preserved prior to JSON parsing middleware. |
+| `invalid_timestamp` | Timestamp string invalid | `timestamp` field contains non-ISO-8601 string or non-numeric value | Inspect clock sync on originating event publisher. |
+| `expired` | Timestamp skew exceeds tolerance | Clock drift between sender and receiver > 5 minutes (`300,000 ms`) | Check NTP sync on servers or increase `tolerance` option. |
+| `invalid_signature` | HMAC mismatch | Payload modified in transit or incorrect shared secret used | Verify shared secret match or test against `previousSecret`. |
+
+---
+
+## Related Documentation
+- [Webhooks Architecture Guide](webhooks.md) — Delivery pipeline, retries, and dead-letter queues.
+- [Secrets Management Policy](SECRETS.md) — Secret lifecycle, KMS integration, and rotation schedules.
+- [Security Architecture](SECURITY.md) — Security posture, API key scopes, and threat models.
+- [Replay-Safe Handlers](REPLAY_SAFE_HANDLERS.md) — Preventing duplicate side-effects during retries.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -80,6 +80,8 @@ if (signature !== request.headers["x-webhook-signature"]) {
 }
 ```
 
+For full operator guidance on signature verification, replay window tolerances, 24-hour secret rotation grace periods, Express middleware usage, and failure troubleshooting, see **[WEBHOOK_SIGNING.md](WEBHOOK_SIGNING.md)**.
+
 ## Mutual TLS (mTLS) Support
 
 For enterprise subscribers requiring mutual TLS authentication, webhooks can be configured with client certificates and server certificate pinning.


### PR DESCRIPTION
Closes #826

### Summary
Adds [`docs/WEBHOOK_SIGNING.md`](docs/WEBHOOK_SIGNING.md) documenting webhook signature generation, header format (`x-webhook-signature`), replay window tolerance (5 minutes / 300,000 ms), timing-safe comparisons (`safeCompareHex`), 24-hour secret rotation grace period (`PREVIOUS_SECRET_TTL_MS = 86,400,000 ms`), Express middleware configuration (`verifyWebhookSignature`), and an operational troubleshooting runbook table.

### What Changed
- Created [`docs/WEBHOOK_SIGNING.md`](docs/WEBHOOK_SIGNING.md) targeted at system operators, DevOps engineers, and support teams.
- Documented HMAC-SHA256 signature generation (`signPayload`) and payload timestamp verification rules.
- Documented secret rotation semantics (32-byte secret generation and 24-hour dual-key grace period supporting `previousSecret` verification fallback).
- Added an Express middleware integration example for [`verifyWebhookSignature`](src/middleware/webhookSignature.ts).
- Added a comprehensive troubleshooting runbook table mapping HTTP 401 failure reasons (`missing_secret`, `missing_signature`, `malformed_signature`, `invalid_signature`, `expired`, `missing_timestamp`, `invalid_timestamp`) to concrete operator resolution actions.
- Cross-linked `docs/WEBHOOK_SIGNING.md` from `README.md`, `docs/README.md`, `docs/webhooks.md`, and `docs/SECRETS.md`.

### Key Design Decisions
- **Target Audience**: Written explicitly for **operators** managing webhook delivery infrastructure, configuring verification gateways, and diagnosing HTTP 401 verification failures.

### Acceptance Criteria Checklist
- [x] Document covers signature generation and verification.
- [x] Document is cross-linked from top-level `README.md` and `docs/README.md` index.
- [x] Examples in the document reference real entrypoints (`src/lib/webhookVerifier.ts`, `src/middleware/webhookSignature.ts`, `src/services/webhooks/rotationService.ts`) and compile cleanly.
- [x] Lint, type-check, and test commands verified.
- [x] PR description references issue with `Closes #826`.

### Security Note
- Documentation-only change. No secrets, keys, or security logic modified.