### PR TITLE
feat(migrations): add CI gate for blocking ADD COLUMN NOT NULL and unique indexes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "migrate:dev": "npm run build && npm run migrate",
     "migrate:dry-run": "npm run build && tsx scripts/migrate-dry-run.ts",
     "migrate:lint": "tsx src/migrations/linter.ts check",
+    "migrate:lint:ci": "tsx scripts/migration-lint-ci.ts",
     "migrate:preflight": "tsx src/migrations/linter.ts pre-flight",
     "migrate:template": "tsx src/migrations/linter.ts template",
     "migrate:safety": "tsx src/migrations/linter.ts check --strict",

--- a/scripts/migration-lint-ci.ts
+++ b/scripts/migration-lint-ci.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * Migration lint CI gate (issue #681).
+ *
+ * Threat mitigated: a merge that introduces locking DDL —
+ * `ADD COLUMN … NOT NULL` or non-concurrent `CREATE UNIQUE INDEX` —
+ * can take production tables offline under write load (AccessExclusiveLock /
+ * table rewrite). Without a PR-scoped gate, that risk ships unnoticed even when
+ * historical migrations already contain similar patterns.
+ *
+ * This script only lints numbered migration files changed relative to the PR
+ * base ref, so existing history does not block every PR.
+ */
+import { execSync } from 'node:child_process'
+import { readFileSync, existsSync } from 'node:fs'
+import { basename } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  isNumberedMigrationFile,
+  lintCiBlockingPatterns,
+  type MigrationLintResult,
+} from '../src/migrations/guardrails.js'
+
+function changedMigrationFiles(baseRef: string): string[] {
+  // Accept a full SHA or a ref name. Prefer three-dot diff from merge-base → HEAD.
+  const raw = execSync(`git diff --name-only --diff-filter=ACMR ${baseRef}...HEAD -- src/migrations`, {
+    encoding: 'utf8',
+  })
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((path) => isNumberedMigrationFile(basename(path)))
+}
+
+export function lintChangedMigrations(paths: string[]): MigrationLintResult[] {
+  const failures: MigrationLintResult[] = []
+  for (const path of paths) {
+    if (!existsSync(path)) continue
+    const content = readFileSync(path, 'utf8')
+    const result = lintCiBlockingPatterns(content, path)
+    if (!result.ok) {
+      failures.push(result)
+    }
+  }
+  return failures
+}
+
+export function runCli(argv = process.argv.slice(2)): number {
+  const baseArg = argv[0] ?? process.env.MIGRATION_LINT_BASE_SHA ?? process.env.GITHUB_BASE_REF
+  if (!baseArg) {
+    console.log(
+      'migration-lint-ci: no base ref provided; skipping PR-scoped check (pass a git SHA/ref or MIGRATION_LINT_BASE_SHA).',
+    )
+    return 0
+  }
+
+  // Full SHAs are used as-is; short branch names are resolved via origin/.
+  const looksLikeSha = /^[0-9a-f]{7,40}$/i.test(baseArg)
+  const resolvedBase = looksLikeSha || baseArg.includes('/') ? baseArg : `origin/${baseArg}`
+
+  let paths: string[]
+  try {
+    paths = changedMigrationFiles(resolvedBase)
+  } catch (error) {
+    console.error(
+      `migration-lint-ci: failed to diff against ${resolvedBase}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+    return 1
+  }
+
+  if (paths.length === 0) {
+    console.log('migration-lint-ci: no numbered migration files changed; OK')
+    return 0
+  }
+
+  console.log(`migration-lint-ci: checking ${paths.length} changed migration(s):`)
+  paths.forEach((p) => console.log(`  - ${p}`))
+
+  const failures = lintChangedMigrations(paths)
+  if (failures.length === 0) {
+    console.log('migration-lint-ci: OK — no ADD COLUMN NOT NULL / CREATE UNIQUE INDEX blockers')
+    return 0
+  }
+
+  for (const failure of failures) {
+    if (failure.ok) continue
+    console.error(`migration-lint-ci: [${failure.code}] ${failure.message}`)
+    for (const issue of failure.issues) {
+      console.error(`  suggestion: ${issue.suggestion}`)
+    }
+  }
+  return 1
+}
+
+const entry = process.argv[1]
+const isDirectRun = Boolean(entry && import.meta.url === pathToFileURL(entry).href)
+
+if (isDirectRun) {
+  process.exit(runCli())
+}

--- a/src/migrations/__tests__/guardrails.blocking.test.ts
+++ b/src/migrations/__tests__/guardrails.blocking.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import {
+  analyzeMigrationContent,
+  lintCiBlockingPatterns,
+  isNumberedMigrationFile,
+} from '../guardrails.js'
+
+/**
+ * Negative tests for issue #681: these fixtures fail the CI gate today when the
+ * blocking pattern is present, and pass once the migration uses a safe form.
+ */
+describe('migration CI blocking patterns (issue #681)', () => {
+  it('fails with ADD_COLUMN_NOT_NULL for SQL ADD COLUMN … NOT NULL', () => {
+    const content = `
+export async function up(pgm) {
+  await pgm.sql(\`ALTER TABLE identities ADD COLUMN slug TEXT NOT NULL\`)
+}
+export async function down(pgm) {}
+`
+    const result = lintCiBlockingPatterns(content, '999_bad_not_null.ts')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('ADD_COLUMN_NOT_NULL')
+      expect(result.message).toContain('ADD_COLUMN_NOT_NULL')
+      expect(result.issues.some((i) => i.code === 'ADD_COLUMN_NOT_NULL')).toBe(true)
+    }
+  })
+
+  it('fails with CREATE_UNIQUE_INDEX for non-concurrent unique index SQL', () => {
+    const content = `
+export async function up(pgm) {
+  await pgm.sql(\`CREATE UNIQUE INDEX idx_identities_slug ON identities (slug)\`)
+}
+export async function down(pgm) {}
+`
+    const result = lintCiBlockingPatterns(content, '999_bad_unique.ts')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('CREATE_UNIQUE_INDEX')
+      expect(result.issues.some((i) => i.code === 'CREATE_UNIQUE_INDEX')).toBe(true)
+    }
+  })
+
+  it('fails with ADD_COLUMN_NOT_NULL for pgm.addColumn with notNull: true', () => {
+    const content = `
+/** docs */
+export async function up(pgm) {
+  pgm.addColumn('identities', 'slug', { type: 'text', notNull: true })
+}
+export async function down(pgm) {}
+`
+    const result = lintCiBlockingPatterns(content, '999_bad_pgm_not_null.ts')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('ADD_COLUMN_NOT_NULL')
+    }
+  })
+
+  it('fails with CREATE_UNIQUE_INDEX for pgm.createIndex with unique: true', () => {
+    const content = `
+/** docs */
+export async function up(pgm) {
+  pgm.createIndex('identities', 'slug', { unique: true })
+}
+export async function down(pgm) {}
+`
+    const result = lintCiBlockingPatterns(content, '999_bad_pgm_unique.ts')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('CREATE_UNIQUE_INDEX')
+    }
+  })
+
+  it('passes when ADD COLUMN is nullable', () => {
+    const content = `
+/**
+ * Safe: nullable column first.
+ */
+export async function up(pgm) {
+  await pgm.sql(\`ALTER TABLE identities ADD COLUMN slug TEXT NULL\`)
+}
+export async function down(pgm) {
+  await pgm.sql(\`ALTER TABLE identities DROP COLUMN slug\`)
+}
+`
+    const result = lintCiBlockingPatterns(content, '999_safe_null.ts')
+    expect(result.ok).toBe(true)
+  })
+
+  it('passes when CREATE UNIQUE INDEX uses CONCURRENTLY', () => {
+    const content = `
+/**
+ * Safe: concurrent unique index.
+ */
+export async function up(pgm) {
+  await pgm.sql(\`CREATE UNIQUE INDEX CONCURRENTLY idx_identities_slug ON identities (slug)\`)
+}
+export async function down(pgm) {
+  await pgm.sql(\`DROP INDEX CONCURRENTLY IF EXISTS idx_identities_slug\`)
+}
+`
+    const result = lintCiBlockingPatterns(content, '999_safe_concurrent.ts')
+    expect(result.ok).toBe(true)
+  })
+
+  it('passes when pgm.createIndex sets unique with concurrently: true', () => {
+    const content = `
+/**
+ * Safe online unique index via pgm API.
+ */
+export async function up(pgm) {
+  pgm.createIndex('identities', 'slug', { unique: true, concurrently: true })
+}
+export async function down(pgm) {
+  pgm.dropIndex('identities', 'slug', { concurrently: true })
+}
+`
+    const result = lintCiBlockingPatterns(content, '999_safe_pgm_concurrent.ts')
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('analyzeMigrationContent', () => {
+  it('attaches typed codes on blocking SQL matches', () => {
+    const result = analyzeMigrationContent(
+      'ALTER TABLE t ADD COLUMN c TEXT NOT NULL;\n',
+      'fixture.ts',
+    )
+    expect(result.passed).toBe(false)
+    expect(result.issues[0]?.code).toBe('ADD_COLUMN_NOT_NULL')
+  })
+
+  it('ignores comment-only lines that mention blocked patterns', () => {
+    const result = analyzeMigrationContent(
+      `// CREATE UNIQUE INDEX bad ON t (c)\n/** ADD COLUMN x NOT NULL */\nexport async function up() {}\nexport async function down() {}\n`,
+      'fixture.ts',
+    )
+    const ci = lintCiBlockingPatterns(
+      `// CREATE UNIQUE INDEX bad ON t (c)\n/** ADD COLUMN x NOT NULL */\nexport async function up() {}\nexport async function down() {}\n`,
+      'fixture.ts',
+    )
+    expect(ci.ok).toBe(true)
+    expect(result.issues.filter((i) => i.code === 'CREATE_UNIQUE_INDEX')).toHaveLength(0)
+  })
+})
+
+describe('isNumberedMigrationFile', () => {
+  it('accepts numbered migrations only', () => {
+    expect(isNumberedMigrationFile('001_initial_schema.ts')).toBe(true)
+    expect(isNumberedMigrationFile('guardrails.ts')).toBe(false)
+    expect(isNumberedMigrationFile('example-guardrails-migration.ts')).toBe(false)
+    expect(isNumberedMigrationFile('001_foo.test.ts')).toBe(false)
+  })
+})

--- a/src/migrations/guardrails.ts
+++ b/src/migrations/guardrails.ts
@@ -10,6 +10,8 @@ import { join } from 'path'
 
 export interface MigrationIssue {
   type: 'blocking' | 'long-running' | 'unsafe' | 'warning'
+  /** Stable machine-readable code for CI gates and typed error handling. */
+  code?: MigrationLintErrorCode
   message: string
   suggestion: string
   line?: number
@@ -23,34 +25,115 @@ export interface PreflightResult {
 }
 
 /**
+ * Typed error codes for migration lint failures.
+ * Used by the CI gate so callers can branch without parsing free-form messages.
+ *
+ * Threat mitigated: a PR that introduces locking DDL (ADD COLUMN NOT NULL or
+ * CREATE UNIQUE INDEX without CONCURRENTLY) can take production tables offline
+ * under write load. Without a merge gate, that risk ships unnoticed.
+ */
+export type MigrationLintErrorCode =
+  | 'ADD_COLUMN_NOT_NULL'
+  | 'CREATE_UNIQUE_INDEX'
+  | 'ADD_PRIMARY_KEY'
+  | 'DROP_COLUMN'
+  | 'READ_FAILURE'
+
+export type MigrationLintResult =
+  | { ok: true; issues: []; warnings: MigrationIssue[] }
+  | {
+      ok: false
+      code: MigrationLintErrorCode
+      message: string
+      issues: MigrationIssue[]
+      warnings: MigrationIssue[]
+    }
+
+/**
  * Patterns that indicate potentially blocking operations
  */
-const BLOCKING_PATTERNS = [
+const BLOCKING_PATTERNS: Array<{
+  pattern: RegExp
+  type: 'blocking'
+  code: MigrationLintErrorCode
+  message: string
+  suggestion: string
+  /** When true for a line match, the pattern is treated as allowed (e.g. CONCURRENTLY). */
+  allowIf?: RegExp
+}> = [
   {
     pattern: /ADD\s+COLUMN.*NOT\s+NULL/i,
-    type: 'blocking' as const,
+    type: 'blocking',
+    code: 'ADD_COLUMN_NOT_NULL',
     message: 'Adding NOT NULL column without default can block writes',
-    suggestion: 'Add column as NULL, backfill data, then add NOT NULL constraint'
+    suggestion: 'Add column as NULL, backfill data, then add NOT NULL constraint',
   },
   {
-    pattern: /CREATE\s+UNIQUE\s+INDEX/i,
-    type: 'blocking' as const,
+    // Block non-concurrent unique indexes; CONCURRENTLY is the online-safe form.
+    pattern: /CREATE\s+UNIQUE\s+INDEX(?!\s+CONCURRENTLY)/i,
+    type: 'blocking',
+    code: 'CREATE_UNIQUE_INDEX',
     message: 'Creating unique index blocks writes to the table',
-    suggestion: 'Use CREATE UNIQUE INDEX CONCURRENTLY or add index without unique constraint first'
+    suggestion: 'Use CREATE UNIQUE INDEX CONCURRENTLY or add index without unique constraint first',
   },
   {
     pattern: /ALTER\s+TABLE.*ADD\s+PRIMARY\s+KEY/i,
-    type: 'blocking' as const,
+    type: 'blocking',
+    code: 'ADD_PRIMARY_KEY',
     message: 'Adding primary key blocks writes',
-    suggestion: 'Use ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY USING INDEX if possible'
+    suggestion: 'Use ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY USING INDEX if possible',
   },
   {
     pattern: /ALTER\s+TABLE.*DROP\s+COLUMN/i,
-    type: 'blocking' as const,
+    type: 'blocking',
+    code: 'DROP_COLUMN',
     message: 'Dropping columns blocks reads and may break applications',
-    suggestion: 'Mark column as unused first, then drop in later migration'
-  }
+    suggestion: 'Mark column as unused first, then drop in later migration',
+  },
 ]
+
+/** node-pg-migrate API forms that are equivalent to the SQL blocking patterns above. */
+function collectPgmBlockingIssues(
+  content: string,
+  filePath: string,
+): MigrationIssue[] {
+  const issues: MigrationIssue[] = []
+
+  // pgm.addColumn(..., { notNull: true | null: false })
+  const addColumnCalls = Array.from(content.matchAll(/addColumn\s*\(([\s\S]*?)\)/gi))
+  for (const match of addColumnCalls) {
+    const call = match[0]
+    if (/notNull\s*:\s*true|null\s*:\s*false/i.test(call)) {
+      issues.push({
+        type: 'blocking',
+        code: 'ADD_COLUMN_NOT_NULL',
+        message: 'pgm.addColumn with NOT NULL can block writes during rewrite',
+        suggestion:
+          'Add column as nullable, backfill, then set NOT NULL in a follow-up migration',
+        migration: filePath,
+      })
+    }
+  }
+
+  // pgm.createIndex(..., { unique: true }) without concurrently: true
+  const createIndexCalls = Array.from(content.matchAll(/createIndex\s*\(([\s\S]*?)\)/gi))
+  for (const match of createIndexCalls) {
+    const call = match[0]
+    if (/unique\s*:\s*true/i.test(call) && !/concurrently\s*:\s*true/i.test(call)) {
+      issues.push({
+        type: 'blocking',
+        code: 'CREATE_UNIQUE_INDEX',
+        message:
+          'pgm.createIndex with unique: true blocks writes unless created concurrently',
+        suggestion:
+          'Pass { unique: true, concurrently: true } or create a non-unique index first',
+        migration: filePath,
+      })
+    }
+  }
+
+  return issues
+}
 
 /**
  * Patterns that indicate long-running operations requiring batching
@@ -113,118 +196,127 @@ const UNSAFE_PATTERNS = [
 ]
 
 /**
- * Analyze a single migration file for potential issues
+ * Analyze migration source content (pure — used by tests and CI).
  */
-export function analyzeMigration(filePath: string): PreflightResult {
+export function analyzeMigrationContent(
+  content: string,
+  filePath = '<memory>',
+): PreflightResult {
   const issues: MigrationIssue[] = []
   const warnings: MigrationIssue[] = []
+  const lines = content.split('\n')
 
-  try {
-    const content = readFileSync(filePath, 'utf-8')
-    const lines = content.split('\n')
+  const allPatterns: Array<{
+    pattern: RegExp
+    type: MigrationIssue['type']
+    code?: MigrationLintErrorCode
+    message: string
+    suggestion: string
+  }> = [...BLOCKING_PATTERNS, ...LONG_RUNNING_PATTERNS, ...UNSAFE_PATTERNS]
 
-    // Check each pattern against the migration content
-    const allPatterns: Array<{ pattern: RegExp; type: MigrationIssue['type']; message: string; suggestion: string }> = [...BLOCKING_PATTERNS, ...LONG_RUNNING_PATTERNS, ...UNSAFE_PATTERNS]
+  lines.forEach((line, index) => {
+    // Skip comment-only lines so pattern source / docs in tooling files don't self-hit.
+    const trimmed = line.trim()
+    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+      return
+    }
 
-    lines.forEach((line, index) => {
-      allPatterns.forEach(({ pattern, type, message, suggestion }) => {
-        if (pattern.test(line)) {
-          const issue: MigrationIssue = {
-            type,
-            message,
-            suggestion,
-            line: index + 1,
-            migration: filePath
-          }
-
-          if (type === 'warning') {
-            warnings.push(issue)
-          } else {
-            issues.push(issue)
-          }
+    allPatterns.forEach(({ pattern, type, code, message, suggestion }) => {
+      if (pattern.test(line)) {
+        const issue: MigrationIssue = {
+          type,
+          code,
+          message,
+          suggestion,
+          line: index + 1,
+          migration: filePath,
         }
-      })
-    })
 
-    // Additional checks for migration structure
-    checkMigrationStructure(content, filePath, issues, warnings)
-
-  } catch (error) {
-    issues.push({
-      type: 'unsafe',
-      message: `Failed to read migration file: ${error}`,
-      suggestion: 'Ensure file exists and is readable',
-      migration: filePath
+        if (type === 'warning') {
+          warnings.push(issue)
+        } else {
+          issues.push(issue)
+        }
+      }
     })
+  })
+
+  // Multi-line / API-form checks for the two CI-gated blocking patterns.
+  for (const issue of collectPgmBlockingIssues(content, filePath)) {
+    if (!issues.some((i) => i.code === issue.code)) {
+      issues.push(issue)
+    }
   }
+
+  checkMigrationStructure(content, filePath, issues, warnings)
 
   return {
     passed: issues.length === 0,
     issues,
-    warnings
+    warnings,
   }
 }
 
 /**
- * Check migration structure for best practices
+ * CI-focused gate: only the two patterns from issue #681.
+ * Returns a typed discriminated union so callers can branch on the failure code.
  */
-function checkMigrationStructure(
+export function lintCiBlockingPatterns(
   content: string,
-  filePath: string,
-  issues: MigrationIssue[],
-  warnings: MigrationIssue[]
-): void {
-  // Check for missing down migration
-  if (!content.includes('export async function down')) {
-    warnings.push({
-      type: 'warning',
-      message: 'Migration missing down function',
-      suggestion: 'Always provide a rollback strategy',
-      migration: filePath
-    })
+  filePath = '<memory>',
+): MigrationLintResult {
+  const result = analyzeMigrationContent(content, filePath)
+  const ciIssues = result.issues.filter(
+    (issue) =>
+      issue.code === 'ADD_COLUMN_NOT_NULL' || issue.code === 'CREATE_UNIQUE_INDEX',
+  )
+
+  if (ciIssues.length === 0) {
+    return { ok: true, issues: [], warnings: result.warnings }
   }
 
-  // Check for missing documentation
-  if (!content.includes('/**') || !content.includes('*/')) {
-    warnings.push({
-      type: 'warning',
-      message: 'Migration missing documentation',
-      suggestion: 'Add JSDoc comments explaining the migration purpose, risk level, and estimated runtime',
-      migration: filePath
-    })
+  const primary = ciIssues[0]
+  return {
+    ok: false,
+    code: primary.code ?? 'ADD_COLUMN_NOT_NULL',
+    message: `${primary.code}: ${primary.message}${
+      primary.line ? ` (line ${primary.line})` : ''
+    } in ${filePath}`,
+    issues: ciIssues,
+    warnings: result.warnings,
   }
+}
 
-  // Check for hardcoded timeouts that might be too short
-  const timeoutMatch = content.match(/timeout:\s*(\d+)/i)
-  if (timeoutMatch && parseInt(timeoutMatch[1]) < 30000) {
-    warnings.push({
-      type: 'warning',
-      message: 'Timeout might be too short for large operations',
-      suggestion: 'Consider using longer timeouts for schema changes (30s+ for DDL, 5min+ for data)',
-      migration: filePath
-    })
+/**
+ * Analyze a single migration file for potential issues
+ */
+export function analyzeMigration(filePath: string): PreflightResult {
+  try {
+    const content = readFileSync(filePath, 'utf-8')
+    return analyzeMigrationContent(content, filePath)
+  } catch (error) {
+    return {
+      passed: false,
+      issues: [
+        {
+          type: 'unsafe',
+          code: 'READ_FAILURE',
+          message: `Failed to read migration file: ${error}`,
+          suggestion: 'Ensure file exists and is readable',
+          migration: filePath,
+        },
+      ],
+      warnings: [],
+    }
   }
+}
 
-  // Check for batching requirements
-  const largeUpdateMatch = content.match(/UPDATE.*SET.*WHERE/i)
-  if (largeUpdateMatch && !content.includes('LIMIT') && !content.includes('batch')) {
-    warnings.push({
-      type: 'warning',
-      message: 'Large UPDATE without batching detected',
-      suggestion: 'Add LIMIT clause or use batching utilities for operations affecting >10,000 rows',
-      migration: filePath
-    })
-  }
-
-  // Check for lock timeout configuration
-  if (!content.includes('statement_timeout') && content.includes('CONCURRENTLY')) {
-    warnings.push({
-      type: 'warning',
-      message: 'Index creation without explicit timeout',
-      suggestion: 'Set statement_timeout for CONCURRENTLY index operations',
-      migration: filePath
-    })
-  }
+/**
+ * True for numbered migration files (e.g. 001_initial_schema.ts).
+ * Excludes tooling, templates, and examples from directory scans.
+ */
+export function isNumberedMigrationFile(fileName: string): boolean {
+  return /^\d+_.+\.ts$/.test(fileName) && !fileName.endsWith('.test.ts')
 }
 
 /**
@@ -236,28 +328,88 @@ export function analyzeAllMigrations(migrationsDir: string): PreflightResult {
 
   try {
     const files = readdirSync(migrationsDir)
-      .filter(file => file.endsWith('.ts') && !file.endsWith('.test.ts'))
+      .filter(isNumberedMigrationFile)
       .sort() // Process in order
 
-    files.forEach(file => {
+    files.forEach((file) => {
       const filePath = join(migrationsDir, file)
       const result = analyzeMigration(filePath)
       allIssues.push(...result.issues)
       allWarnings.push(...result.warnings)
     })
-
   } catch (error) {
     allIssues.push({
       type: 'unsafe',
+      code: 'READ_FAILURE',
       message: `Failed to read migrations directory: ${error}`,
-      suggestion: 'Ensure migrations directory exists and is readable'
+      suggestion: 'Ensure migrations directory exists and is readable',
     })
   }
 
   return {
     passed: allIssues.length === 0,
     issues: allIssues,
-    warnings: allWarnings
+    warnings: allWarnings,
+  }
+}
+
+/**
+ * Check migration structure for best practices
+ */
+function checkMigrationStructure(
+  content: string,
+  filePath: string,
+  _issues: MigrationIssue[],
+  warnings: MigrationIssue[],
+): void {
+  if (!content.includes('export async function down')) {
+    warnings.push({
+      type: 'warning',
+      message: 'Migration missing down function',
+      suggestion: 'Always provide a rollback strategy',
+      migration: filePath,
+    })
+  }
+
+  if (!content.includes('/**') || !content.includes('*/')) {
+    warnings.push({
+      type: 'warning',
+      message: 'Migration missing documentation',
+      suggestion:
+        'Add JSDoc comments explaining the migration purpose, risk level, and estimated runtime',
+      migration: filePath,
+    })
+  }
+
+  const timeoutMatch = content.match(/timeout:\s*(\d+)/i)
+  if (timeoutMatch && parseInt(timeoutMatch[1]) < 30000) {
+    warnings.push({
+      type: 'warning',
+      message: 'Timeout might be too short for large operations',
+      suggestion:
+        'Consider using longer timeouts for schema changes (30s+ for DDL, 5min+ for data)',
+      migration: filePath,
+    })
+  }
+
+  const largeUpdateMatch = content.match(/UPDATE.*SET.*WHERE/i)
+  if (largeUpdateMatch && !content.includes('LIMIT') && !content.includes('batch')) {
+    warnings.push({
+      type: 'warning',
+      message: 'Large UPDATE without batching detected',
+      suggestion:
+        'Add LIMIT clause or use batching utilities for operations affecting >10,000 rows',
+      migration: filePath,
+    })
+  }
+
+  if (!content.includes('statement_timeout') && content.includes('CONCURRENTLY')) {
+    warnings.push({
+      type: 'warning',
+      message: 'Index creation without explicit timeout',
+      suggestion: 'Set statement_timeout for CONCURRENTLY index operations',
+      migration: filePath,
+    })
   }
 }
 
@@ -265,8 +417,8 @@ export function analyzeAllMigrations(migrationsDir: string): PreflightResult {
  * Check if migration is safe for online schema change
  */
 export function isOnlineSchemaChange(migrationContent: string): boolean {
-  const blockingPatterns = BLOCKING_PATTERNS.map(p => p.pattern)
-  const hasBlocking = blockingPatterns.some(pattern => pattern.test(migrationContent))
+  const blockingPatterns = BLOCKING_PATTERNS.map((p) => p.pattern)
+  const hasBlocking = blockingPatterns.some((pattern) => pattern.test(migrationContent))
   return !hasBlocking
 }
 


### PR DESCRIPTION
## Overview

This PR adds a **database migration linter CI gate** that blocks PRs introducing locking DDL — specifically `ADD COLUMN … NOT NULL` and non-concurrent `CREATE UNIQUE INDEX` — on numbered migration files changed in that PR.

**Threat mitigated:** without a merge gate, a PR can ship table-locking schema changes that take production tables offline under write load (`AccessExclusiveLock` / rewrite). Historical migrations already contain similar patterns, so the gate is **PR-diff scoped** (only changed numbered migrations), not a full-tree fail.

## Related Issue

Closes #681

## Changes

### 🔒 Migration Lint Gate

- **[MODIFY]** `src/migrations/guardrails.ts`
  - Typed error codes (`ADD_COLUMN_NOT_NULL`, `CREATE_UNIQUE_INDEX`, …) via a discriminated-union result.
  - Pure content analyzer + CI helper `lintCiBlockingPatterns`.
  - Allowlists `CREATE UNIQUE INDEX CONCURRENTLY`.
  - Detects equivalent `pgm.addColumn({ notNull: true })` / `pgm.createIndex({ unique: true })` forms.
  - Directory scans limited to numbered migration files.

- **[ADD]** `scripts/migration-lint-ci.ts`
  - PR-scoped gate: diffs against the PR base SHA and fails only on the two #681 blockers.

- **[ADD]** `npm run migrate:lint:ci`
  - Wired for GitHub Actions / local use with `MIGRATION_LINT_BASE_SHA`.

### 🧪 Tests

- **[ADD]** `src/migrations/__tests__/guardrails.blocking.test.ts`
  - Negative tests: SQL + pgm forms that must fail the gate.
  - Positive tests: nullable columns, `CONCURRENTLY`, `{ unique: true, concurrently: true }`.

### ⚙️ CI Workflow (follow-up push)

- Workflow YAML is ready at `.github/workflows/migration-lint.yml` locally; push of that file requires a GitHub token with the `workflow` scope (SINCEO2 PAT currently lacks it). Will be pushed in a follow-up commit once scope is granted, or maintainers can add the workflow from this PR discussion.

## Verification Results

```
npm test -- src/migrations/__tests__/guardrails.blocking.test.ts
✅ 10/10 passed

Negative path:
✅ ADD COLUMN … NOT NULL → ADD_COLUMN_NOT_NULL
✅ CREATE UNIQUE INDEX (non-concurrent) → CREATE_UNIQUE_INDEX

Positive path:
✅ nullable ADD COLUMN / CREATE UNIQUE INDEX CONCURRENTLY → pass

npm run migrate:lint:ci -- <upstream/main merge-base>
✅ no numbered migration files changed; OK
```

| Acceptance Criteria | Status |
| --- | --- |
| Blocks ADD COLUMN NOT NULL / CREATE UNIQUE INDEX in the PR that introduces them | ✅ PR-scoped `migrate:lint:ci` |
| Negative test exercises the new check | ✅ 10 tests including fail-before/pass-after cases |
| PR description names the threat being mitigated | ✅ Overview above |
| Lint / type-check / tests pass locally for changed surface | ✅ guardrails tests green |
| References this issue with `Closes #<issue>` | ✅ Closes #681 |