### PR TITLE
test: add tests for Link header pagination.

### DIFF
--- a/src/lib/pagination.property.test.ts
+++ b/src/lib/pagination.property.test.ts
@@ -21,10 +21,12 @@ import {
   DEFAULT_LIMIT,
   MAX_LIMIT,
   PaginationValidationError,
+  buildLinkHeader,
   decodeCursor,
   encodeCursor,
   parsePaginationParams,
 } from './pagination.js'
+
 
 const SEED = 0xc0ffee
 
@@ -223,3 +225,48 @@ describe('limit clamping: parsed limit always in [DEFAULT_LIMIT, MAX_LIMIT]', ()
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// 5. Link Header Pagination Invariants
+// ---------------------------------------------------------------------------
+
+describe('Link Header Pagination Invariants (RFC 5988)', () => {
+  it('first_page_has_no_prev_and_last_page_has_no_next', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 200 }),
+        fc.integer({ min: 1, max: MAX_LIMIT }),
+        fc.integer({ min: 1, max: 10000 }),
+        (page, limit, total) => {
+          const lastPage = Math.max(1, Math.ceil(total / limit))
+          const actualPage = Math.min(page, lastPage)
+          const header = buildLinkHeader({ baseUrl: '/api/test', page: actualPage, limit, total })
+
+          expect(header).not.toBeNull()
+
+          // Invariant 1: First page (page 1) MUST NOT contain prev link
+          if (actualPage === 1) {
+            expect(header).not.toContain('rel="prev"')
+          }
+
+          // Invariant 2: Last page MUST NOT contain next link
+          if (actualPage === lastPage) {
+            expect(header).not.toContain('rel="next"')
+          }
+
+          // Invariant 3: If page > 1, prev link MUST be present
+          if (actualPage > 1) {
+            expect(header).toContain('rel="prev"')
+          }
+
+          // Invariant 4: If page < lastPage, next link MUST be present
+          if (actualPage < lastPage) {
+            expect(header).toContain('rel="next"')
+          }
+        },
+      ),
+      { seed: SEED },
+    )
+  })
+})
+

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -4,6 +4,7 @@ import fc from 'fast-check'
 process.env.JWT_SECRET = 'test-jwt-secret-at-least-32-chars-long'
 
 import {
+  buildLinkHeader,
   buildPaginationMeta,
   decodeCursor,
   encodeCursor,
@@ -11,6 +12,7 @@ import {
   PaginationValidationError,
   parsePaginationParams,
 } from './pagination.js'
+
 
 describe('pagination helpers', () => {
   describe('parsePaginationParams', () => {
@@ -256,7 +258,59 @@ describe('pagination helpers', () => {
       )
     })
   })
+
+  describe('buildLinkHeader', () => {
+    const baseUrl = '/api/items'
+
+    it('returns_null_when_total_is_zero', () => {
+      const header = buildLinkHeader({ baseUrl, page: 1, limit: 10, total: 0 })
+      expect(header).toBeNull()
+    })
+
+    it('first_page_has_no_prev_link', () => {
+      const header = buildLinkHeader({ baseUrl, page: 1, limit: 10, total: 50 })
+      expect(header).not.toBeNull()
+      expect(header).not.toContain('rel="prev"')
+      expect(header).toContain('rel="first"')
+      expect(header).toContain('rel="next"')
+      expect(header).toContain('rel="last"')
+      expect(header).toBe(
+        '</api/items?page=1&limit=10>; rel="first", </api/items?page=2&limit=10>; rel="next", </api/items?page=5&limit=10>; rel="last"',
+      )
+    })
+
+    it('last_page_has_no_next_link', () => {
+      const header = buildLinkHeader({ baseUrl, page: 5, limit: 10, total: 50 })
+      expect(header).not.toBeNull()
+      expect(header).not.toContain('rel="next"')
+      expect(header).toContain('rel="first"')
+      expect(header).toContain('rel="prev"')
+      expect(header).toContain('rel="last"')
+      expect(header).toBe(
+        '</api/items?page=1&limit=10>; rel="first", </api/items?page=4&limit=10>; rel="prev", </api/items?page=5&limit=10>; rel="last"',
+      )
+    })
+
+    it('middle_page_has_both_prev_and_next_links', () => {
+      const header = buildLinkHeader({ baseUrl, page: 3, limit: 10, total: 50 })
+      expect(header).toBe(
+        '</api/items?page=1&limit=10>; rel="first", </api/items?page=2&limit=10>; rel="prev", </api/items?page=4&limit=10>; rel="next", </api/items?page=5&limit=10>; rel="last"',
+      )
+    })
+
+    it('single_page_has_neither_prev_nor_next_link', () => {
+      const header = buildLinkHeader({ baseUrl, page: 1, limit: 10, total: 5 })
+      expect(header).not.toContain('rel="prev"')
+      expect(header).not.toContain('rel="next"')
+      expect(header).toContain('rel="first"')
+      expect(header).toContain('rel="last"')
+      expect(header).toBe(
+        '</api/items?page=1&limit=10>; rel="first", </api/items?page=1&limit=10>; rel="last"',
+      )
+    })
+  })
 })
+
 
 function try_decode_base64url(s: string): boolean {
   try {

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -282,3 +282,64 @@ export function buildCursorEnvelope<T>(
     },
   }
 }
+
+export interface LinkHeaderOptions {
+  baseUrl: string
+  page: number
+  limit: number
+  total: number
+}
+
+/**
+ * Builds an RFC 5988 Link header string for page/limit based pagination.
+ *
+ * Rules:
+ * - First page (page <= 1) has NO 'prev' link.
+ * - Last page (page * limit >= total) has NO 'next' link.
+ * - 'first' and 'last' links are always included when total > 0.
+ *
+ * Example:
+ * `<http://api.example.com/items?page=1&limit=10>; rel="first", <http://api.example.com/items?page=3&limit=10>; rel="next", <http://api.example.com/items?page=5&limit=10>; rel="last"`
+ */
+export function buildLinkHeader(options: LinkHeaderOptions): string | null {
+  const { baseUrl, page, limit, total } = options
+
+  if (total <= 0) {
+    return null
+  }
+
+  const lastPage = Math.max(1, Math.ceil(total / limit))
+  const links: string[] = []
+
+  // Helper to format URL with page and limit
+  const formatUrl = (p: number) => {
+    const url = new URL(baseUrl, 'http://localhost')
+    url.searchParams.set('page', String(p))
+    url.searchParams.set('limit', String(limit))
+    // Return relative or full URL path + query string based on baseUrl input
+    if (baseUrl.startsWith('http://') || baseUrl.startsWith('https://')) {
+      return url.toString()
+    }
+    return `${url.pathname}${url.search}`
+  }
+
+  // 'first' link
+  links.push(`<${formatUrl(1)}>; rel="first"`)
+
+  // 'prev' link: only included if page > 1
+  if (page > 1) {
+    const prevPage = Math.min(page - 1, lastPage)
+    links.push(`<${formatUrl(prevPage)}>; rel="prev"`)
+  }
+
+  // 'next' link: only included if page < lastPage
+  if (page < lastPage) {
+    links.push(`<${formatUrl(page + 1)}>; rel="next"`)
+  }
+
+  // 'last' link
+  links.push(`<${formatUrl(lastPage)}>; rel="last"`)
+
+  return links.join(', ')
+}
+


### PR DESCRIPTION
Closes #819

### Summary of Actions Taken:
1. **New Branch**: Created and checked out dedicated branch `test/link-header-pagination`.
2. **Link Header Functionality**: Added `buildLinkHeader` to [`src/lib/pagination.ts`](Credence-Backend/src/lib/pagination.ts) enforcing RFC 5988 link pagination contracts:
   - First page (`page <= 1`) omits `prev`.
   - Last page (`page * limit >= total`) omits `next`.
   - Returns `null` when `total <= 0`.
3. **Unit & Property Tests**:
   - Added assertive unit tests in [`src/lib/pagination.test.ts`](Credence-Backend/src/lib/pagination.test.ts) testing boundary conditions (`first_page_has_no_prev_link`, `last_page_has_no_next_link`, `middle_page_has_both_prev_and_next_links`, `single_page_has_neither_prev_nor_next_link`).
   - Added fast-check property-based tests in [`src/lib/pagination.property.test.ts`](Credence-Backend/src/lib/pagination.property.test.ts) verifying link presence invariants across arbitrary page, limit, and total inputs.
4. **Verification**: Executed vitest suite and `sbom:check`.
5. **Git Commit**: Staged and committed changes with message `test: add tests for Link header pagination (Closes #819)`.