### PR TITLE
feat(db): add OpenTelemetry span for every database query (#676)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -351,6 +351,19 @@ const result = await txManager.withTransaction(
 
 The span is created via the `withSpan` utility and exported by the configured `SpanProcessor` (ConsoleSpanExporter in dev; OTLP in production).
 
+## Database Query Spans
+
+Every database query executed through the connection pools (`pool`, `workerPool`, `replicaPool`) generates an OpenTelemetry span named `db.query` with the following attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `db.system` | string | Set to `"postgresql"`. |
+| `db.statement` | string | The SQL query string executed. |
+| `db.pool` | string | Which pool ran the query (`"api"`, `"worker"`, or `"replica"`). |
+| `db.row_count` | number | The row count returned by the query (if successful). |
+
+If the query throws an exception, the span status is set to `ERROR`, and the exception is captured/recorded on the span.
+
 ## Slow Query Logging
 
 Every query issued through `pool`, `workerPool`, or `replicaPool` (`src/db/pool.ts`) is timed. Any query taking at least `SLOW_QUERY_THRESHOLD_MS` (default `1000`, i.e. 1 second; `0` disables the check) emits a `db:slow-query` structured log — `LogEventType.DB_SLOW_QUERY` — with the query's plan attached, and increments Prometheus metrics.

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -285,9 +285,55 @@ export function instrumentSlowQueryLogging(
   }) as unknown as Pool["query"];
 }
 
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+
+export function instrumentQueryTracing(target: Pool, poolName: PoolName): void {
+  const originalQuery = target.query.bind(target) as (...args: unknown[]) => unknown;
+
+  target.query = ((...args: unknown[]) => {
+    // Callback-style calls aren't used anywhere in this codebase; pass them
+    // through unmodified.
+    if (typeof args[args.length - 1] === "function") {
+      return originalQuery(...args);
+    }
+
+    const text = extractQueryText(args) || "unknown";
+    const tracer = trace.getTracer("credence-backend");
+
+    return tracer.startActiveSpan("db.query", async (span) => {
+      span.setAttribute("db.system", "postgresql");
+      span.setAttribute("db.statement", text);
+      span.setAttribute("db.pool", poolName);
+
+      try {
+        const result = await (originalQuery(...args) as Promise<QueryResult>);
+        if (result && typeof result.rowCount === "number") {
+          span.setAttribute("db.row_count", result.rowCount);
+        }
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+      } catch (err) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: err instanceof Error ? err.message : "Unknown error",
+        });
+        span.recordException(err as Error);
+        throw err;
+      } finally {
+        span.end();
+      }
+    });
+  }) as unknown as Pool["query"];
+}
+
 instrumentSlowQueryLogging(pool, "api");
+instrumentQueryTracing(pool, "api");
+
 instrumentSlowQueryLogging(workerPool, "worker");
+instrumentQueryTracing(workerPool, "worker");
+
 instrumentSlowQueryLogging(replicaPool, "replica");
+instrumentQueryTracing(replicaPool, "replica");
 
 /**
  * Helper to execute an operation on the replica, falling back to primary

--- a/src/db/queryTracing.test.ts
+++ b/src/db/queryTracing.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import type { Pool, QueryResult } from "pg";
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { instrumentQueryTracing } from "./pool.js";
+
+describe("instrumentQueryTracing (OpenTelemetry Spans)", () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new NodeTracerProvider();
+
+  beforeAll(() => {
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+  });
+
+  afterAll(async () => {
+    await provider.shutdown();
+    trace.disable();
+  });
+
+  it("creates a db.query span with SQL and rowcount attributes on success", async () => {
+    exporter.reset();
+
+    const mockResult = { rows: [{ id: 1 }], rowCount: 1 } as unknown as QueryResult;
+    const query = vi.fn().mockResolvedValue(mockResult);
+    const fakePool = { query } as unknown as Pool;
+
+    instrumentQueryTracing(fakePool, "api");
+
+    const result = await fakePool.query("SELECT * FROM users WHERE id = $1", [1]);
+    expect(result).toBe(mockResult);
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+
+    const span = spans[0];
+    expect(span.name).toBe("db.query");
+    expect(span.status.code).toBe(SpanStatusCode.OK);
+    expect(span.attributes["db.system"]).toBe("postgresql");
+    expect(span.attributes["db.statement"]).toBe("SELECT * FROM users WHERE id = $1");
+    expect(span.attributes["db.pool"]).toBe("api");
+    expect(span.attributes["db.row_count"]).toBe(1);
+  });
+
+  it("creates a db.query span and captures exceptions on failure", async () => {
+    exporter.reset();
+
+    const mockError = new Error("Unique constraint violation");
+    const query = vi.fn().mockRejectedValue(mockError);
+    const fakePool = { query } as unknown as Pool;
+
+    instrumentQueryTracing(fakePool, "worker");
+
+    await expect(fakePool.query("INSERT INTO users (id) VALUES ($1)", [1])).rejects.toThrow(
+      "Unique constraint violation"
+    );
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+
+    const span = spans[0];
+    expect(span.name).toBe("db.query");
+    expect(span.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span.status.message).toBe("Unique constraint violation");
+    expect(span.attributes["db.system"]).toBe("postgresql");
+    expect(span.attributes["db.statement"]).toBe("INSERT INTO users (id) VALUES ($1)");
+    expect(span.attributes["db.pool"]).toBe("worker");
+    expect(span.events.some((e) => e.name === "exception")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds OpenTelemetry span instrumentation for all database queries executed via connection pools (`pool`, `workerPool`, `replicaPool`).

## Changes
- Wrapped connection pools with `instrumentQueryTracing` in `src/db/pool.ts` to start a `"db.query"` span on every query.
- Attached `db.system`, `db.statement`, `db.pool`, and `db.row_count` attributes to the query spans.
- Added comprehensive unit tests in `src/db/queryTracing.test.ts` using `InMemorySpanExporter`.
- Updated observability documentation in `docs/observability.md`.

## Checklist
- [x] Acceptance criteria met.
- [x] Tests pass locally (`src/db/queryTracing.test.ts` & existing `src/db/pool.test.ts`, `src/db/slowQueryLogging.test.ts`).
- [x] Linting and typechecking pass on modified files.
- [x] Documentation updated.

Closes #676