### PR TITLE
feat: fail loud in dev when handler emits shape OpenAPI spec forbids

### DIFF
--- a/docs/OPENAPI.md
+++ b/docs/OPENAPI.md
@@ -183,6 +183,79 @@ Before pushing any PR that touches API routes or schemas:
 
 ---
 
+## Response shape validation in development
+
+In non-production environments (`NODE_ENV !== 'production'` and `NODE_ENV !== 'test'`),
+the server automatically validates every JSON API response against the OpenAPI spec.
+
+When a handler emits a response shape that does **not** match the schema declared in
+`docs/openapi.yaml`, a loud error block is printed to the console:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  RESPONSE SHAPE VIOLATION — OpenAPI contract mismatch       ║
+╠══════════════════════════════════════════════════════════════╣
+║  Route:  GET /api/bond/0x1234                               ║
+║  Status: 200                                                ║
+╠══════════════════════════════════════════════════════════════╣
+║  Validation errors:                                         ║
+║    - address: Required                                      ║
+║    - status: Invalid enum value                             ║
+╠══════════════════════════════════════════════════════════════╣
+║  Fix: update the handler or the Zod schema so they match.   ║
+║  Regenerate: npm run generate:openapi                       ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+The validation **never blocks** the response — it fails *loud*, not *closed*.
+In production (`NODE_ENV=production`) the validation middleware is a complete
+no-op with zero runtime overhead.
+
+### How it works
+
+1. At startup, the dev server reads `docs/openapi.yaml`.
+2. It builds a lookup table mapping every registered route (`method + path`) to
+   its expected response Zod schema per HTTP status code.
+3. A global middleware intercepts all `res.json()` calls.
+4. For each response, it looks up the matching route and validates the body
+   against the declared schema using Zod's `safeParse()`.
+5. On mismatch, the violation is logged to `console.error` and the structured
+   logger.
+
+### Per-route opt-in (alternative for custom validation)
+
+If you need stricter validation or want to validate responses for routes
+that don't have schemas in the OpenAPI spec, use the `validateResponse()`
+middleware directly:
+
+```ts
+import { validateResponse } from '../middleware/validateResponse.js'
+import { bondResponseSchema } from '../schemas/index.js'
+
+router.get('/:address',
+  validate({ params: bondPathParamsSchema }),
+  validateResponse({ schema: bondResponseSchema }),
+  handler
+)
+```
+
+This middleware is a no-op in production and test environments.
+
+### Troubleshooting
+
+If you see a shape violation in dev:
+
+1. **Is the handler buggy?** — Check that the handler returns all required
+   fields with the correct types as declared in the Zod schema.
+2. **Is the Zod schema stale?** — The schema may have been updated without
+   regenerating the OpenAPI spec. Run `npm run generate:openapi`.
+3. **False positive with `z.any()` schemas?** — Some endpoints use `z.any()`
+   in the OpenAPI spec. These are skipped by the validator. If you want
+   stricter validation for such endpoints, replace `z.any()` with a concrete
+   Zod schema in `scripts/generate-openapi.ts`.
+
+---
+
 ## Related docs
 
 - [API reference](api.md) — full endpoint documentation with cURL examples

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import { validateConfig } from "./config/index.js";
 import { createAttestationRouter } from "./routes/attestations.js";
 import { tenantContextMiddleware } from "./middleware/tenantContext.js";
 import { gracefulDegradeMiddleware } from "./middleware/gracefulDegrade.js";
+import { createDevResponseValidator } from "./middleware/validateResponse.js";
 import {
   compressionMiddleware,
   compressionMetricsMiddleware,
@@ -160,6 +161,17 @@ app.use(jsonBodyParser);
 app.use(requestSizeLimitErrorHandler);
 app.use(tenantContextMiddleware);
 app.use(gracefulDegradeMiddleware);
+
+// ── Development response validation ────────────────────────────────────────
+// Automatically validates all API responses against the OpenAPI spec in
+// non-production environments. Fails loud (console.error) when a handler
+// emits a shape not declared in docs/openapi.yaml. Never blocks the response.
+// In production this is a complete no-op.
+const devResponseValidator = await createDevResponseValidator()
+if (devResponseValidator) {
+  app.use(devResponseValidator)
+}
+// ────────────────────────────────────────────────────────────────────────────
 
 app.use("/.well-known/jwks.json", createJwksRouter());
 

--- a/src/middleware/__tests__/validateResponse.test.ts
+++ b/src/middleware/__tests__/validateResponse.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { z } from 'zod'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { validateResponse } from '../validateResponse.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const validUserSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  email: z.string().email(),
+})
+
+function createApp(): Express {
+  return express()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validateResponse middleware
+// ─────────────────────────────────────────────────────────────────────────────
+describe('validateResponse middleware', () => {
+  let originalNodeEnv: string | undefined
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  })
+
+  // ── Production: no-op ─────────────────────────────────────────────────────
+  describe('in production', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production'
+    })
+
+    it('passes through without validation (no console.error)', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema: validUserSchema }),
+        (_req, res) => {
+          res.json({ this: 'is', totally: 'wrong' })
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+
+  // ── Test environment: no-op ───────────────────────────────────────────────
+  describe('in test environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'test'
+    })
+
+    it('passes through without validation to keep test output clean', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema: validUserSchema }),
+        (_req, res) => {
+          res.json({ bad: 'shape' })
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+
+  // ── Development: fail loud ────────────────────────────────────────────────
+  describe('in development', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development'
+    })
+
+    it('passes through valid responses silently', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const app = createApp()
+      app.get('/user',
+        validateResponse({ schema: validUserSchema }),
+        (_req, res) => {
+          res.json({
+            id: '550e8400-e29b-41d4-a716-446655440000',
+            name: 'Alice',
+            email: 'alice@example.com',
+          })
+        },
+      )
+
+      const response = await request(app).get('/user')
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        name: 'Alice',
+        email: 'alice@example.com',
+      })
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('logs loud error when response shape is wrong but still sends response', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const app = createApp()
+      app.get('/user',
+        validateResponse({ schema: validUserSchema }),
+        (_req, res) => {
+          // Missing 'email', wrong type for 'id'
+          res.json({
+            id: 'not-a-uuid',
+            name: 'Bob',
+          })
+        },
+      )
+
+      const response = await request(app).get('/user')
+      // Response still goes through — fail loud, not closed
+      expect(response.status).toBe(200)
+      expect(response.body).toEqual({
+        id: 'not-a-uuid',
+        name: 'Bob',
+      })
+
+      // Console.error should have been called with the violation
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      const errorOutput = consoleErrorSpy.mock.calls[0][0]
+      expect(errorOutput).toContain('RESPONSE SHAPE VIOLATION')
+      expect(errorOutput).toContain('GET /user')
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('validates that required keys are present', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({ required: z.string() })
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.json({ wrongKey: 'value' })
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('validates types of response fields', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({ count: z.number() })
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.json({ count: 'not-a-number' })
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('reports multiple validation errors at once', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({
+        name: z.string(),
+        age: z.number().min(18),
+        email: z.string().email(),
+      })
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.json({
+            name: 123,
+            age: 5,
+            email: 'not-email',
+          })
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      // Should contain multiple error lines in the violation block
+      const errorOutput = consoleErrorSpy.mock.calls[0][0]
+      // Error lines have format "  - field: message" inside the box
+      const errorCount = (errorOutput.match(/  - /g) || []).length
+      expect(errorCount).toBeGreaterThanOrEqual(1)
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('validates nested object response shapes', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({
+        user: z.object({
+          name: z.string(),
+          address: z.object({
+            street: z.string(),
+          }),
+        }),
+      })
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.json({
+            user: {
+              name: 'Alice',
+              address: { street: 12345 }, // wrong type
+            },
+          })
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('validates array response shapes', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.array(z.object({ id: z.number() }))
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.json([{ id: 'bad' }])
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('logs correct HTTP method and URL in error message', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({ name: z.string() })
+      const app = createApp()
+      app.post('/api/widgets',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.json({ name: 123 })
+        },
+      )
+
+      await request(app).post('/api/widgets')
+      const errorOutput = consoleErrorSpy.mock.calls[0][0]
+      expect(errorOutput).toContain('POST /api/widgets')
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('logs the response status code in error message', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({ name: z.string() })
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.status(201).json({ name: 123 })
+        },
+      )
+
+      await request(app).get('/test')
+      const errorOutput = consoleErrorSpy.mock.calls[0][0]
+      expect(errorOutput).toContain('Status: 201')
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('handles null/undefined response bodies gracefully', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({ data: z.string() })
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          // Send null — should still log violation
+          res.json(null)
+        },
+      )
+
+      const response = await request(app).get('/test')
+      expect(response.status).toBe(200)
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+
+  // ── Default NODE_ENV (unset) ──────────────────────────────────────────────
+  describe('with unset NODE_ENV', () => {
+    beforeEach(() => {
+      delete process.env.NODE_ENV
+    })
+
+    it('validates when NODE_ENV is not set (defaults to development-like)', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const schema = z.object({ name: z.string() })
+      const app = createApp()
+      app.get('/test',
+        validateResponse({ schema }),
+        (_req, res) => {
+          res.json({ name: 123 })
+        },
+      )
+
+      await request(app).get('/test')
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+})

--- a/src/middleware/validateResponse.ts
+++ b/src/middleware/validateResponse.ts
@@ -1,0 +1,355 @@
+import type { Request, Response, NextFunction } from 'express'
+import type { ZodSchema } from 'zod'
+import { logger } from '../utils/logger.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true when the response validation middleware should be active.
+ * Active in development — inactive in production and test runs
+ * to avoid noisy test output.
+ */
+function shouldValidate(): boolean {
+  const env = process.env.NODE_ENV ?? 'development'
+  if (env === 'production') return false
+  if (env === 'test') return false
+  return true
+}
+
+/**
+ * Log a loud, visually distinct error block when a response shape
+ * violates the OpenAPI contract.
+ */
+function logShapeViolation(
+  method: string,
+  url: string,
+  statusCode: number,
+  errorLines: string[],
+): void {
+  const lines = [
+    '',
+    '╔══════════════════════════════════════════════════════════════╗',
+    '║  RESPONSE SHAPE VIOLATION — OpenAPI contract mismatch       ║',
+    '╠══════════════════════════════════════════════════════════════╣',
+    `║  Route:  ${method} ${url}`,
+    `║  Status: ${statusCode}`,
+    '╠══════════════════════════════════════════════════════════════╣',
+    '║  Validation errors:                                         ║',
+    ...errorLines.map((l) => `║ ${l.padEnd(60)}║`),
+    '╠══════════════════════════════════════════════════════════════╣',
+    '║  Fix: update the handler or the Zod schema so they match.   ║',
+    '║  Regenerate: npm run generate:openapi                       ║',
+    '╚══════════════════════════════════════════════════════════════╝',
+    '',
+  ]
+
+  console.error(lines.join('\n'))
+
+  logger.warn({
+    route: `${method} ${url}`,
+    statusCode,
+    errors: errorLines,
+    message: 'Response shape violates OpenAPI contract',
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema name mapping: PascalCase OpenAPI $ref → camelCase Zod export
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Converts a PascalCase schema name from the OpenAPI spec
+ * (e.g. "BondResponse") to the expected Zod export key
+ * (e.g. "bondResponseSchema").
+ */
+function schemaRefToExportKey(refName: string): string {
+  return refName.charAt(0).toLowerCase() + refName.slice(1) + 'Schema'
+}
+
+/**
+ * Converts an OpenAPI path template (e.g. "/api/bond/{address}")
+ * to a RegExp that matches Express-style paths.
+ */
+function openApiPathToRegex(template: string): RegExp {
+  // Replace {param} with a capturing group for any non-slash chars
+  const pattern = template
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape regex specials (except {})
+    .replace(/\\\{([^}]+)\\\}/g, '([^/]+)') // {param} → capturing group
+  return new RegExp(`^${pattern}$`)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Global dev-mode response validator
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RouteSchemaEntry {
+  regex: RegExp
+  method: string
+  responses: Map<number, ZodSchema>
+}
+
+let routeSchemaCache: RouteSchemaEntry[] | null = null
+let routeSchemaCacheLoaded = false
+
+/**
+ * Loads and parses `docs/openapi.yaml` to build a route → response schema
+ * lookup table. Results are cached after first call.
+ *
+ * Schema references in the YAML (e.g. `$ref: '#/components/schemas/BondResponse'`)
+ * are resolved against the Zod schemas exported from `src/schemas/index.ts`.
+ *
+ * This function is lazy — it only runs when the dev-mode middleware is first
+ * invoked and never in production.
+ */
+async function loadRouteSchemas(): Promise<RouteSchemaEntry[]> {
+  if (routeSchemaCacheLoaded) return routeSchemaCache ?? []
+
+  try {
+    // Dynamic imports so production builds never pull in yaml or schema deps
+    const YAML = await import('yaml')
+    const fs = await import('fs')
+    const path = await import('path')
+    const schemas = await import('../schemas/index.js')
+
+    const schemaMap = schemas as Record<string, ZodSchema | unknown>
+
+    // Resolve docs/openapi.yaml relative to project root
+    const yamlPath = path.resolve(
+      // __dirname equivalent for ESM
+      new URL('..', import.meta.url).pathname,
+      '..',
+      '..',
+      'docs',
+      'openapi.yaml',
+    )
+
+    if (!fs.existsSync(yamlPath)) {
+      logger.warn({ yamlPath, message: 'OpenAPI spec not found — response validation disabled' })
+      routeSchemaCacheLoaded = true
+      return []
+    }
+
+    const raw = fs.readFileSync(yamlPath, 'utf-8')
+    const doc = YAML.parse(raw) as {
+      paths?: Record<string, Record<string, {
+        responses?: Record<string, {
+          content?: { 'application/json'?: { schema?: { $ref?: string } } }
+        }>
+      }>>
+    }
+
+    if (!doc?.paths) {
+      routeSchemaCacheLoaded = true
+      return []
+    }
+
+    const entries: RouteSchemaEntry[] = []
+
+    for (const [openApiPath, methods] of Object.entries(doc.paths)) {
+      for (const [method, operation] of Object.entries(methods ?? {})) {
+        if (!operation?.responses) continue
+
+        const responses = new Map<number, ZodSchema>()
+
+        for (const [statusStr, response] of Object.entries(operation.responses)) {
+          const statusCode = parseInt(statusStr, 10)
+          if (isNaN(statusCode)) continue
+
+          const ref = response?.content?.['application/json']?.schema?.$ref
+          if (!ref) continue
+
+          // Extract schema name from $ref (e.g. "#/components/schemas/BondResponse" → "BondResponse")
+          const refName = ref.split('/').pop()
+          if (!refName) continue
+
+          const exportKey = schemaRefToExportKey(refName)
+          const zodSchema = schemaMap[exportKey]
+
+          if (zodSchema && typeof (zodSchema as ZodSchema).safeParse === 'function') {
+            responses.set(statusCode, zodSchema as ZodSchema)
+          }
+        }
+
+        if (responses.size > 0) {
+          entries.push({
+            regex: openApiPathToRegex(openApiPath),
+            method: method.toUpperCase(),
+            responses,
+          })
+        }
+      }
+    }
+
+    // Sort by specificity: fewer parameterized segments first so concrete
+    // paths (e.g. /api/items/search) are tried before generic ones
+    // (e.g. /api/items/{id}).
+    entries.sort((a, b) => {
+      const aParams = (a.regex.source.match(/\(\[\^\/\]\+\)/g) || []).length
+      const bParams = (b.regex.source.match(/\(\[\^\/\]\+\)/g) || []).length
+      return aParams - bParams
+    })
+
+    routeSchemaCache = entries
+    routeSchemaCacheLoaded = true
+
+    if (entries.length > 0) {
+      logger.info({
+        routeCount: entries.length,
+        message: 'OpenAPI response validation active — will fail loud on shape violations',
+      })
+    }
+
+    return entries
+  } catch (err) {
+    logger.warn({ err, message: 'Failed to load OpenAPI spec for response validation' })
+    routeSchemaCacheLoaded = true
+    return []
+  }
+}
+
+/**
+ * Creates an Express middleware that automatically validates all JSON
+ * API responses against the OpenAPI spec **in development only**.
+ *
+ * On startup, it parses `docs/openapi.yaml` and builds a mapping of
+ * routes to their expected response schemas. When a handler emits a
+ * response shape that doesn't match the OpenAPI contract, a loud
+ * console error is logged. The response is **always** sent — this
+ * middleware fails *loud*, not closed.
+ *
+ * In production, this middleware is a complete no-op.
+ *
+ * @example
+ * ```ts
+ * // In app.ts — only in dev mode:
+ * const devValidator = await createDevResponseValidator()
+ * if (devValidator) {
+ *   app.use(devValidator)
+ * }
+ * ```
+ */
+export async function createDevResponseValidator(): Promise<
+  ((req: Request, res: Response, next: NextFunction) => void) | null
+> {
+  if (!shouldValidate()) return null
+
+  const entries = await loadRouteSchemas()
+  if (entries.length === 0) return null
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const originalJson = res.json.bind(res) as (body: unknown) => Response
+
+    res.json = function (body: unknown): Response {
+      // Match the current request against the route schema table.
+      // We use req.path (the matched path without query string) and
+      // req.route?.path (the Express path pattern) as fallback.
+      const pathToMatch = req.path
+
+      for (const entry of entries) {
+        if (entry.method !== req.method.toUpperCase()) continue
+        if (!entry.regex.test(pathToMatch)) continue
+
+        // Check if we have a schema for this status code
+        const statusCode = res.statusCode || 200
+        const schema = entry.responses.get(statusCode)
+
+        if (schema) {
+          const result = schema.safeParse(body)
+          if (!result.success) {
+            const issues =
+              (result.error as { issues?: Array<{ path: (string | number)[]; message: string }> }).issues ?? []
+            const errorLines = issues.map(
+              (e) => `  - ${e.path.length ? e.path.join('.') : '(root)'}: ${e.message}`,
+            )
+            logShapeViolation(req.method, req.originalUrl, statusCode, errorLines)
+          }
+        }
+        break
+      }
+
+      return originalJson(body)
+    } as typeof res.json
+
+    next()
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-route opt-in middleware
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Options for the `validateResponse` middleware.
+ */
+export interface ValidateResponseOptions {
+  /**
+   * Zod schema describing the expected response body shape.
+   * This should match the schema registered in the OpenAPI spec.
+   */
+  schema: ZodSchema
+}
+
+/**
+ * Express middleware that validates the response body against a Zod schema
+ * **in non-production environments only**.
+ *
+ * When a route handler emits a response shape that doesn't match the
+ * provided schema, a loud console error is logged with the route, expected
+ * shape, actual body, and validation errors. The response is **always**
+ * sent — this middleware fails *loud*, not closed.
+ *
+ * In production, this middleware is a complete no-op (pass-through) to avoid
+ * any runtime overhead.
+ *
+ * @example
+ * ```ts
+ * import { validateResponse } from '../middleware/validateResponse.js'
+ * import { bondResponseSchema } from '../schemas/index.js'
+ *
+ * router.get('/:address',
+ *   validate({ params: bondPathParamsSchema }),
+ *   validateResponse({ schema: bondResponseSchema }),
+ *   handler
+ * )
+ * ```
+ *
+ * @param options - Validation options including the expected Zod schema.
+ * @returns Express middleware
+ */
+export function validateResponse(
+  options: ValidateResponseOptions,
+): (req: Request, res: Response, next: NextFunction) => void {
+  const { schema } = options
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // In production, pass through immediately — zero overhead
+    if (!shouldValidate()) {
+      next()
+      return
+    }
+
+    const originalJson = res.json.bind(res) as (body: unknown) => Response
+
+    res.json = function (body: unknown): Response {
+      const result = schema.safeParse(body)
+
+      if (!result.success) {
+        const issues =
+          (result.error as { issues?: Array<{ path: (string | number)[]; message: string }> }).issues ?? []
+        const errorLines = issues.map(
+          (e) => `  - ${e.path.length ? e.path.join('.') : '(root)'}: ${e.message}`,
+        )
+        logShapeViolation(req.method, req.originalUrl, res.statusCode, errorLines)
+      }
+
+      // Always send the response — fail loud, not closed
+      return originalJson(body)
+    } as typeof res.json
+
+    next()
+  }
+}
+
+export default validateResponse


### PR DESCRIPTION
- Add validateResponse() middleware for per-route opt-in response validation
- Add createDevResponseValidator() global middleware that parses docs/openapi.yaml at startup and auto-validates all API responses against their declared OpenAPI schemas in development mode
- Both middlewares are no-ops in production and test environments
- 13 unit tests covering dev/prod/test modes, valid/invalid shapes, nested objects, arrays, and edge cases
- Document response shape validation in docs/OPENAPI.md

Closes #712