### PR TITLE
feat: implement hash-chained audit log repository with secure append …

### DIFF
--- a/src/db/repositories/auditLogsRepository.test.ts
+++ b/src/db/repositories/auditLogsRepository.test.ts
@@ -337,3 +337,84 @@ describe('InMemoryAuditLogsRepository - Top Talkers', () => {
   })
 })
 
+describe('AuditLogsRepository - appendBatch & actor_id preservation', () => {
+  it('appends multiple entries in a batch while preserving actorId for each entry', async () => {
+    const repository = new InMemoryAuditLogsRepository()
+
+    const batchInputs = [
+      {
+        actorId: 'actor-101',
+        actorEmail: 'actor101@credence.org',
+        action: AuditAction.ASSIGN_ROLE,
+        resourceType: 'user',
+        resourceId: 'user-101',
+        tenantId: 'tenant-alpha',
+      },
+      {
+        actorId: 'actor-102',
+        actorEmail: 'actor102@credence.org',
+        action: AuditAction.REVOKE_API_KEY,
+        resourceType: 'user',
+        resourceId: 'user-102',
+        tenantId: 'tenant-beta',
+      },
+    ]
+
+    const result = await repository.appendBatch(batchInputs)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].actorId).toBe('actor-101')
+    expect(result[0].adminId).toBe('actor-101')
+    expect(result[0].seq).toBe(1)
+    expect(result[1].actorId).toBe('actor-102')
+    expect(result[1].adminId).toBe('actor-102')
+    expect(result[1].seq).toBe(2)
+    expect(result[1].prevHash).toBe(result[0].rowHash)
+
+    const all = await repository.getAll()
+    expect(all).toHaveLength(2)
+    expect(all[0].actorId).toBe('actor-101')
+    expect(all[1].actorId).toBe('actor-102')
+  })
+
+  it('preserves actor_id when passed via alternate property names (actor_id / adminId)', async () => {
+    const repository = new InMemoryAuditLogsRepository()
+
+    const mixedBatch: any[] = [
+      {
+        actor_id: 'actor-snake-case',
+        actor_email: 'snake@credence.org',
+        action: AuditAction.CREATE_API_KEY,
+        resourceType: 'user',
+        resourceId: 'user-snake',
+        tenantId: 'tenant-1',
+      },
+      {
+        adminId: 'admin-alias-id',
+        adminEmail: 'alias@credence.org',
+        action: AuditAction.DELETE_USER,
+        resourceType: 'user',
+        resourceId: 'user-alias',
+        tenantId: 'tenant-1',
+      },
+    ]
+
+    const result = await repository.appendBatch(mixedBatch)
+
+    expect(result).toHaveLength(2)
+    expect(result[0].actorId).toBe('actor-snake-case')
+    expect(result[1].actorId).toBe('admin-alias-id')
+
+    const queryResult = await repository.query({ tenantId: 'tenant-1' }, 10)
+    expect(queryResult.logs.map((l) => l.actorId)).toContain('actor-snake-case')
+    expect(queryResult.logs.map((l) => l.actorId)).toContain('admin-alias-id')
+  })
+
+  it('handles empty batch input gracefully', async () => {
+    const repository = new InMemoryAuditLogsRepository()
+    const result = await repository.appendBatch([])
+    expect(result).toEqual([])
+  })
+})
+
+

--- a/src/db/repositories/auditLogsRepository.ts
+++ b/src/db/repositories/auditLogsRepository.ts
@@ -150,8 +150,21 @@ export function computeRowHash(
   return createHash('sha256').update(input, 'utf8').digest('hex')
 }
 
+const resolveActorId = (input: AuditLogInput): string =>
+  input.actorId ??
+  (input as unknown as { actor_id?: string }).actor_id ??
+  (input as unknown as { adminId?: string }).adminId ??
+  'unknown'
+
+const resolveActorEmail = (input: AuditLogInput): string =>
+  input.actorEmail ??
+  (input as unknown as { actor_email?: string }).actor_email ??
+  (input as unknown as { adminEmail?: string }).adminEmail ??
+  'unknown@unknown'
+
 export interface AuditLogRepository {
   append(input: AuditLogInput): Promise<AuditLogEntry>
+  appendBatch(inputs: AuditLogInput[]): Promise<AuditLogEntry[]>
   query(filters?: AuditLogFilters, limit?: number, cursor?: string): Promise<{ logs: AuditLogEntry[]; hasNextPage: boolean; nextCursor?: string }>
   getTopTalkers(limit?: number, windowMinutes?: number, now?: Date): Promise<TopTalkersReport>
   getAll(): Promise<AuditLogEntry[]>
@@ -177,6 +190,8 @@ export class PostgresAuditLogsRepository implements AuditLogRepository {
    */
   async append(input: AuditLogInput): Promise<AuditLogEntry> {
     const id = randomUUID()
+    const actorId = resolveActorId(input)
+    const actorEmail = resolveActorEmail(input)
     const detailsStr = JSON.stringify(input.details ?? {})
     const statusVal = input.status ?? 'success'
 
@@ -257,8 +272,8 @@ export class PostgresAuditLogsRepository implements AuditLogRepository {
       `,
       [
         id,
-        input.actorId,
-        input.actorEmail,
+        actorId,
+        actorEmail,
         input.action,
         input.resourceType,
         input.resourceId,
@@ -272,6 +287,15 @@ export class PostgresAuditLogsRepository implements AuditLogRepository {
     )
 
     return mapAuditLog(result.rows[0])
+  }
+
+  async appendBatch(inputs: AuditLogInput[]): Promise<AuditLogEntry[]> {
+    const entries: AuditLogEntry[] = []
+    for (const input of inputs) {
+      const entry = await this.append(input)
+      entries.push(entry)
+    }
+    return entries
   }
 
   async query(filters?: AuditLogFilters, limit = 100, cursor?: string): Promise<{ logs: AuditLogEntry[]; hasNextPage: boolean; nextCursor?: string }> {
@@ -411,6 +435,8 @@ export class InMemoryAuditLogsRepository implements AuditLogRepository {
 
   async append(input: AuditLogInput): Promise<AuditLogEntry> {
     const id = randomUUID()
+    const actorId = resolveActorId(input)
+    const actorEmail = resolveActorEmail(input)
     const seq = ++this.seqCounter
     const occurredAt = new Date().toISOString()
     const detailsStr = JSON.stringify(input.details ?? {})
@@ -426,7 +452,7 @@ export class InMemoryAuditLogsRepository implements AuditLogRepository {
       prevHash,
       id,
       occurredAt,
-      input.actorId,
+      actorId,
       input.action as string,
       input.resourceType,
       input.resourceId,
@@ -439,10 +465,10 @@ export class InMemoryAuditLogsRepository implements AuditLogRepository {
     const entry: AuditLogEntry = {
       id,
       timestamp: occurredAt,
-      actorId: input.actorId,
-      actorEmail: input.actorEmail,
-      adminId: input.actorId,
-      adminEmail: input.actorEmail,
+      actorId,
+      actorEmail,
+      adminId: actorId,
+      adminEmail: actorEmail,
       action: input.action,
       resourceType: input.resourceType,
       resourceId: input.resourceId,
@@ -465,6 +491,15 @@ export class InMemoryAuditLogsRepository implements AuditLogRepository {
     const frozen = Object.freeze(cloneEntry(entry))
     this.logs.push(frozen)
     return cloneEntry(frozen)
+  }
+
+  async appendBatch(inputs: AuditLogInput[]): Promise<AuditLogEntry[]> {
+    const entries: AuditLogEntry[] = []
+    for (const input of inputs) {
+      const entry = await this.append(input)
+      entries.push(entry)
+    }
+    return entries
   }
 
   async query(filters?: AuditLogFilters, limit = 100, cursor?: string): Promise<{ logs: AuditLogEntry[]; hasNextPage: boolean; nextCursor?: string }> {

--- a/src/services/audit/index.ts
+++ b/src/services/audit/index.ts
@@ -97,6 +97,24 @@ export class AuditLogService {
   }
 
   /**
+   * Append a batch of audit log entries while maintaining actor_id integrity.
+   *
+   * @param inputs - Array of audit log input objects
+   * @returns Array of created audit log entries
+   */
+  async appendBatch(inputs: AuditLogInput[]): Promise<AuditLogEntry[]> {
+    return this.repository.appendBatch(inputs)
+  }
+
+  /**
+   * Log a batch of audit actions.
+   * Alias for appendBatch.
+   */
+  async logBatch(inputs: AuditLogInput[]): Promise<AuditLogEntry[]> {
+    return this.appendBatch(inputs)
+  }
+
+  /**
    * Get audit logs with optional filtering
    * 
    * SECURITY: Tenant scoping is DENY-BY-DEFAULT. Either tenantId or allowSuperScope must be provided.


### PR DESCRIPTION
closes #893 


## Summary
Fixes an issue where `actor_id` (`actorId`) was lost or defaulted to `'unknown'` during batched write operations in the audit logging layer.

## Changes Made
- **Repository Interface & Implementations**: Added `appendBatch(inputs: AuditLogInput[]): Promise<AuditLogEntry[]>` to `AuditLogRepository` in [`src/db/repositories/auditLogsRepository.ts`](file:///c:/Users/HP/Desktop/TechBroAfrica/Credence-Backend/src/db/repositories/auditLogsRepository.ts).
- **Actor ID Property Resolution**: Added helper resolvers (`resolveActorId` & `resolveActorEmail`) to normalize `actorId`, `actor_id`, and `adminId` property aliases so `actor_id` is strictly preserved across single and batched writes.
- **Service API**: Added `appendBatch` and `logBatch` to `AuditLogService` in [`src/services/audit/index.ts`](file:///c:/Users/HP/Desktop/TechBroAfrica/Credence-Backend/src/services/audit/index.ts).
- **Unit Tests**: Added comprehensive test coverage in [`src/db/repositories/auditLogsRepository.test.ts`](file:///c:/Users/HP/Desktop/TechBroAfrica/Credence-Backend/src/db/repositories/auditLogsRepository.test.ts):
  - **Happy Path**: Verifies `appendBatch` preserves distinct `actorId`s across entries with sequential `seq` allocation and unbroken hash-chain links (`prevHash` / `rowHash`).
  - **Failure / Edge Modes**: Tests property alias fallbacks (`actor_id`, `adminId`) and empty batch array handling.


