### PR TITLE
feat: add lint-on-save (ESLint auto-fix on save + lint:fix script)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.useFlatConfig": true,
+  "eslint.validate": ["typescript"],
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ All configuration is driven by environment variables. Copy `.env.example` to `.e
 | `npm run build`           | Compile TypeScript                         |
 | `npm start`               | Run compiled `dist/`                       |
 | `npm run lint`            | Run ESLint                                 |
+| `npm run lint:fix`        | Run ESLint and auto-fix violations         |
 | `npm test`                | Run test suite (vitest)                    |
 | `npm run test:watch`      | Run tests in watch mode                    |
 | `npm run test:coverage`   | Run tests with coverage                    |
@@ -148,6 +149,37 @@ All configuration is driven by environment variables. Copy `.env.example` to `.e
 | `npm run migrate`         | Run pending migrations (CI/production)     |
 | `npm run migrate:down`    | Rollback last migration                    |
 | `npm run migrate:dry-run` | Preview pending migrations without running |
+
+## Developer Setup
+
+### Lint on save (VS Code)
+
+The repository ships with `.vscode/settings.json` and `.vscode/extensions.json` so ESLint auto-fixes your code every time you save a TypeScript file — no extra configuration needed.
+
+**Prerequisites:** Install the recommended extension when VS Code prompts you, or run:
+
+```
+Extensions: Show Recommended Extensions   # Ctrl+Shift+P → type "Show Recommended"
+```
+
+The extension ID is `dbaeumer.vscode-eslint`.
+
+**How it works:**
+
+- `.vscode/settings.json` sets `editor.codeActionsOnSave` → `source.fixAll.eslint: "explicit"`, which triggers ESLint's `--fix` pass on every explicit save (`Ctrl+S` / `⌘S`).
+- `eslint.useFlatConfig: true` tells the extension to use the project's `eslint.config.js` flat-config format.
+- `[typescript].editor.defaultFormatter` is set to the ESLint extension so format-on-save routes through ESLint rather than a separate formatter.
+
+**CLI equivalent** (safe to re-run, idempotent):
+
+```bash
+npm run lint        # check only — exits non-zero if there are errors
+npm run lint:fix    # check and auto-fix — writes changes in place
+```
+
+Both commands target `src/` and respect the ignore patterns in `eslint.config.js` (e.g. `dist/`, `**/*.test.ts`).
+
+---
 
 ## API (current)
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/index.js",
     "prepare": "husky install",
     "lint": "node --import tsx ./node_modules/eslint/bin/eslint.js src",
+    "lint:fix": "node --import tsx ./node_modules/eslint/bin/eslint.js src --fix",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:chaos": "vitest run tests/chaos --sequence",

--- a/src/__tests__/lintOnSave.test.ts
+++ b/src/__tests__/lintOnSave.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the `npm run lint` and `npm run lint:fix` scripts.
+ *
+ * Temp files are written inside `src/` so that ESLint's flat-config lookup
+ * finds `eslint.config.js` at the project root — the same behaviour as when a
+ * developer saves a real source file in VS Code.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { spawnSync } from "child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Project root: src/__tests__/ is two directories below the repo root
+// ---------------------------------------------------------------------------
+const PROJECT_ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../..",
+);
+
+const ESLINT_BIN = path.join(
+  PROJECT_ROOT,
+  "node_modules",
+  "eslint",
+  "bin",
+  "eslint.js",
+);
+
+// ---------------------------------------------------------------------------
+// Helper: run ESLint on a specific file using the same invocation as the npm
+// scripts (`node --import tsx ./node_modules/eslint/bin/eslint.js`).
+// ---------------------------------------------------------------------------
+function runEslintOn(
+  target: string,
+  fix = false,
+): { exitCode: number; stdout: string; stderr: string } {
+  const args = [
+    "--import",
+    "tsx",
+    ESLINT_BIN,
+    target,
+    ...(fix ? ["--fix"] : []),
+  ];
+  const result = spawnSync(process.execPath, args, {
+    cwd: PROJECT_ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Temp file management — files live inside src/ so ESLint finds the config
+// ---------------------------------------------------------------------------
+const tmpFiles: string[] = [];
+
+function writeTempSrc(name: string, content: string): string {
+  const filePath = path.join(PROJECT_ROOT, "src", name);
+  fs.writeFileSync(filePath, content, "utf8");
+  tmpFiles.push(filePath);
+  return filePath;
+}
+
+afterAll(() => {
+  for (const f of tmpFiles) {
+    try {
+      fs.unlinkSync(f);
+    } catch {
+      /* already deleted */
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("lint:fix npm script", () => {
+  it("package.json declares the lint:fix script with --fix flag", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(PROJECT_ROOT, "package.json"), "utf8"),
+    ) as { scripts?: Record<string, string> };
+
+    expect(pkg.scripts?.["lint:fix"]).toBeDefined();
+    expect(pkg.scripts!["lint:fix"]).toMatch(/--fix/);
+  });
+
+  it("happy path: exits 0 on a TypeScript file with no lint violations", () => {
+    const cleanFile = writeTempSrc(
+      "__tmp_lint_clean.ts",
+      [
+        "// Lint-clean TypeScript file",
+        "export const add = (a: number, b: number): number => a + b;",
+        "",
+      ].join("\n"),
+    );
+
+    const { exitCode } = runEslintOn(cleanFile);
+    expect(exitCode).toBe(0);
+  });
+
+  it("happy path: --fix (lint:fix) is idempotent on a clean file and exits 0", () => {
+    const cleanFile = writeTempSrc(
+      "__tmp_lint_idempotent.ts",
+      [
+        "// File with no violations — --fix must be idempotent",
+        "export const greet = (name: string): string => `Hello, ${name}!`;",
+        "",
+      ].join("\n"),
+    );
+
+    const before = fs.readFileSync(cleanFile, "utf8");
+    const { exitCode } = runEslintOn(cleanFile, /* fix */ true);
+    const after = fs.readFileSync(cleanFile, "utf8");
+
+    expect(exitCode).toBe(0);
+    expect(after).toBe(before); // idempotent: no change to a clean file
+  });
+
+  it("failure mode: exits non-zero on an unfixable lint error, even with --fix", () => {
+    // no-console is "error" in eslint.config.js and is not auto-fixable.
+    const violatingFile = writeTempSrc(
+      "__tmp_lint_violating.ts",
+      [
+        "// File with an unfixable lint error (no-console)",
+        "export function logIt(msg: string): void {",
+        "  console.log(msg);",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    const { exitCode, stdout, stderr } = runEslintOn(violatingFile, /* fix */ true);
+
+    expect(exitCode).not.toBe(0);
+    const combined = stdout + stderr;
+    expect(combined).toMatch(/no-console|console/i);
+  });
+
+  it("check-only mode: exits non-zero on a violation without modifying the file", () => {
+    const originalContent = [
+      "export function bad(msg: string): void {",
+      "  console.error(msg);",
+      "}",
+      "",
+    ].join("\n");
+    const violatingFile = writeTempSrc("__tmp_lint_checkonly.ts", originalContent);
+
+    const { exitCode } = runEslintOn(violatingFile, /* fix */ false);
+
+    expect(exitCode).not.toBe(0);
+    // File must be unchanged in check-only mode
+    expect(fs.readFileSync(violatingFile, "utf8")).toBe(originalContent);
+  });
+});
+
+describe(".vscode configuration", () => {
+  it("settings.json exists and enables ESLint fix-on-save", () => {
+    const settingsPath = path.join(PROJECT_ROOT, ".vscode", "settings.json");
+    expect(fs.existsSync(settingsPath)).toBe(true);
+
+    const settings = JSON.parse(
+      fs.readFileSync(settingsPath, "utf8"),
+    ) as Record<string, unknown>;
+
+    const codeActions = settings["editor.codeActionsOnSave"] as
+      | Record<string, string>
+      | undefined;
+    expect(codeActions?.["source.fixAll.eslint"]).toBe("explicit");
+  });
+
+  it("settings.json enables flat-config mode", () => {
+    const settingsPath = path.join(PROJECT_ROOT, ".vscode", "settings.json");
+    const settings = JSON.parse(
+      fs.readFileSync(settingsPath, "utf8"),
+    ) as Record<string, unknown>;
+
+    expect(settings["eslint.useFlatConfig"]).toBe(true);
+  });
+
+  it("extensions.json recommends the ESLint VS Code extension", () => {
+    const extPath = path.join(PROJECT_ROOT, ".vscode", "extensions.json");
+    expect(fs.existsSync(extPath)).toBe(true);
+
+    const ext = JSON.parse(fs.readFileSync(extPath, "utf8")) as {
+      recommendations?: string[];
+    };
+    expect(ext.recommendations).toContain("dbaeumer.vscode-eslint");
+  });
+});


### PR DESCRIPTION
What changed
  
  - .vscode/settings.json — enables source.fixAll.eslint: "explicit" so ESLint auto-fixes every TypeScript file on Ctrl+S
  / ⌘S in VS Code. Also sets eslint.useFlatConfig: true (matches the project's eslint.config.js) and routes format-on-save
  through ESLint rather than a separate formatter.
  - .vscode/extensions.json — recommends dbaeumer.vscode-eslint so VS Code prompts new contributors to install the right
  extension automatically.
  - package.json — adds npm run lint:fix (eslint src --fix). Idempotent, no new dependencies.
  - README.md — new Developer Setup / Lint on save section explains how it works and documents the CLI equivalents (npm
  run lint / npm run lint:fix). Also adds lint:fix to the Scripts table.
  - src/__tests__/lintOnSave.test.ts — 8 tests covering:
    - package.json declares lint:fix with --fix
    - Happy path: clean file exits 0
    - --fix is idempotent on a clean file
    - Failure mode: unfixable no-console error exits non-zero even with --fix
    - Check-only mode leaves file content unchanged
    - .vscode/settings.json correctness assertions
    - eslint.useFlatConfig is enabled
    - extensions.json recommends the ESLint extension
  
  Testing
  
  npm run lint        # check only
  npm run lint:fix    # auto-fix
  npx vitest run src/__tests__/lintOnSave.test.ts  # 8/8 pass
  
  Out of scope
  
  Pre-existing no-console and logger-schema lint violations in src/ are not touched — those are tracked separately.
Closes #883 