### PR TITLE
perf: cache JWKS response for 10 minutes

### DIFF
--- a/src/routes/jwks.test.ts
+++ b/src/routes/jwks.test.ts
@@ -72,9 +72,9 @@ describe('GET /.well-known/jwks.json', () => {
     }
   })
 
-  it('sets Cache-Control header with max-age=300', async () => {
+  it('sets Cache-Control header with max-age=600', async () => {
     const res = await request(app).get('/.well-known/jwks.json')
-    expect(res.headers['cache-control']).toContain('max-age=300')
+    expect(res.headers['cache-control']).toContain('max-age=600')
   })
 
   it('returns 503 if keyManager.getPublicJwks throws', async () => {

--- a/src/routes/jwks.ts
+++ b/src/routes/jwks.ts
@@ -24,7 +24,7 @@ import { keyManager } from '../services/keyManager/index.js'
  * tokens whose `exp` or `iat` values differ slightly due to clock drift.
  *
  * ## Caching
- * The response includes `Cache-Control: public, max-age=300, stale-while-revalidate=60`.
+ * The response includes `Cache-Control: public, max-age=600, stale-while-revalidate=60`.
  * Consumers caching this response should re-fetch when they encounter an unknown
  * `kid` in a JWT header, as a rotation may have occurred.
  */
@@ -36,7 +36,7 @@ export function createJwksRouter(): Router {
       const jwks = await keyManager.getPublicJwks()
       res
         .status(200)
-        .set('Cache-Control', 'public, max-age=300, stale-while-revalidate=60')
+        .set('Cache-Control', 'public, max-age=600, stale-while-revalidate=60')
         .json(jwks)
     } catch {
       res.status(503).json({ error: 'Key manager not initialized' })

--- a/src/services/keyManager/index.ts
+++ b/src/services/keyManager/index.ts
@@ -13,6 +13,7 @@ import type {
 } from './types.js'
 
 const ALG = 'PS256'
+const JWKS_CACHE_TTL_MS = 10 * 60 * 1000
 
 /**
  * Manages RSA signing key pairs for JWT issuance and verification.
@@ -36,6 +37,9 @@ export class KeyManager {
   private activeKid: string | null = null
   private readonly config: KeyManagerConfig
   private readonly auditLog: KeyAuditEvent[] = []
+  private jwksCache: JwksResponse | null = null
+  private jwksCacheExpiresAt = 0
+  private jwksCacheVersion = 0
 
   constructor(config: KeyManagerConfig) {
     this.config = config
@@ -54,6 +58,7 @@ export class KeyManager {
       ? await this._importKey(this.config.privateKeyPem, this.config.initialKid)
       : await this._generateKey()
     this._emitAudit({ timestamp: new Date().toISOString(), event: 'KEY_CREATED', kid: key.kid })
+    this._invalidateJwksCache()
   }
 
   // ── Key Accessors ────────────────────────────────────────────────────────
@@ -118,6 +123,7 @@ export class KeyManager {
     })
 
     this.pruneExpiredKeys()
+    this._invalidateJwksCache()
 
     return { newKid: newKey.kid, retiredKid }
   }
@@ -148,6 +154,10 @@ export class KeyManager {
       }
     }
 
+    if (pruned.length > 0) {
+      this._invalidateJwksCache()
+    }
+
     return pruned
   }
 
@@ -159,6 +169,11 @@ export class KeyManager {
    * Private key material (`d`, `p`, `q`, `dp`, `dq`, `qi`) is never included.
    */
   async getPublicJwks(): Promise<JwksResponse> {
+    const now = Date.now()
+    if (this.jwksCache !== null && now < this.jwksCacheExpiresAt) {
+      return this.jwksCache
+    }
+
     const verificationKeys = this.getAllVerificationKeys()
     const jwkEntries = await Promise.all(
       verificationKeys.map(async (k) => {
@@ -172,7 +187,10 @@ export class KeyManager {
         } as JsonWebKey
       }),
     )
-    return { keys: jwkEntries }
+
+    this.jwksCache = { keys: jwkEntries }
+    this.jwksCacheExpiresAt = now + JWKS_CACHE_TTL_MS
+    return this.jwksCache
   }
 
   // ── JWT Operations ────────────────────────────────────────────────────────
@@ -252,6 +270,7 @@ export class KeyManager {
     this.keys.clear()
     this.activeKid = null
     this.auditLog.length = 0
+    this._invalidateJwksCache()
   }
 
   // ── Private Helpers ──────────────────────────────────────────────────────
@@ -294,6 +313,11 @@ export class KeyManager {
   private _emitAudit(event: KeyAuditEvent): void {
     this.auditLog.push(event)
     console.log(JSON.stringify(event))
+  }
+
+  private _invalidateJwksCache(): void {
+    this.jwksCache = null
+    this.jwksCacheExpiresAt = 0
   }
 }
 

--- a/src/services/keyManager/keyManager.test.ts
+++ b/src/services/keyManager/keyManager.test.ts
@@ -130,6 +130,27 @@ describe('KeyManager (singleton)', () => {
       expect(keys).toHaveLength(1)
     })
 
+    it('reuses the cached JWKS response while the key set is unchanged', async () => {
+      await keyManager.initialize()
+      const first = await keyManager.getPublicJwks()
+      const second = await keyManager.getPublicJwks()
+
+      expect(second).toBe(first)
+      expect(second.keys).toEqual(first.keys)
+    })
+
+    it('invalidates the cached JWKS response after rotation', async () => {
+      await keyManager.initialize()
+      const beforeRotation = await keyManager.getPublicJwks()
+
+      await keyManager.rotate()
+
+      const afterRotation = await keyManager.getPublicJwks()
+      expect(afterRotation).not.toBe(beforeRotation)
+      expect(afterRotation.keys).toHaveLength(2)
+      expect(afterRotation.keys.some((key) => key.kid === beforeRotation.keys[0].kid)).toBe(true)
+    })
+
     it('returns two entries immediately after rotation', async () => {
       await keyManager.initialize()
       await keyManager.rotate()


### PR DESCRIPTION
Closes #891

## Summary
Cache the JWKS response for 10 minutes to reduce repeated key-set generation and avoid unnecessary work for public JWKS consumers.

## Changes
- Added an in-memory JWKS cache in the key manager with a 10-minute TTL.
- Invalidated the cache on initialization, rotation, pruning, and reset so the response stays consistent with the current signing keys.
- Updated the JWKS route to advertise `Cache-Control: public, max-age=600, stale-while-revalidate=60`.
- Added regression tests covering repeated reads and cache invalidation after rotation.

## Verification
- `npx vitest run src/services/keyManager/keyManager.test.ts src/routes/jwks.test.ts`

Closes #891