### PR TITLE
test(auth): add permission gate audit tests for signing key rotation

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,8 +10,6 @@ export const DEFAULT_TOP_TALKERS_LIMIT = 10
 export const MAX_TOP_TALKERS_LIMIT = 100
 
 /** Default time window in minutes for top talkers request aggregation (1 hour). */
- feat/request-attempt-header
-export const DEFAULT_TOP_TALKERS_WINDOW_MINUTES = 60
 export const DEFAULT_TOP_TALKERS_WINDOW_MINUTES = 60
 
 /** Header name used to trigger graceful degradation / read-only mode */
@@ -38,4 +36,3 @@ export const PG_STAT_ACTIVITY_SNAPSHOT_RETENTION_HOURS = 24
  * thundering herd against a just-recovered provider.
  */
 export const PROVIDER_RECOVERY_BUFFER_MS = 5_000
- main

--- a/src/routes/admin/webhooks.ts
+++ b/src/routes/admin/webhooks.ts
@@ -2,8 +2,8 @@ import { Router, Request, Response } from 'express'
 import { WebhookService } from '../../services/webhooks/service.js'
 import { PostgresWebhookRepository } from '../../db/repositories/webhookRepository.js'
 import { pool } from '../../db/pool.js'
-import { AuthenticatedRequest, requireUserAuth, requireAdminRole, requireApiKey, ApiScope } from '../../middleware/auth.js'
-import { auditLogService } from '../../services/audit/index.js'
+import { AuthenticatedRequest, requireUserAuth, requireAdminRole, UserRole } from '../../middleware/auth.js'
+import { auditLogService, AuditAction } from '../../services/audit/index.js'
 
 /**
  * Create the webhook admin router.
@@ -26,12 +26,30 @@ export function createWebhookAdminRouter(): Router {
    *
    * @requires webhooks:admin scope OR admin role
    */
-  router.post('/:id/rotate', requireUserAuth, requireAdminRole, async (req: Request, res: Response) => {
+  router.post('/:id/rotate', requireUserAuth, async (req: Request, res: Response) => {
     try {
       const { id } = req.params
       const admin = (req as AuthenticatedRequest).user!
       const requestId = (req as any).requestId
       
+      if (admin.role !== UserRole.ADMIN && admin.role !== UserRole.SUPER_ADMIN && (admin.role as string) !== 'super-admin') {
+        void auditLogService.logAction(
+          admin.tenantId || 'default-tenant',
+          admin.id,
+          admin.email,
+          AuditAction.ROTATE_WEBHOOK_SECRET,
+          id,
+          'webhook',
+          { id, reason: 'insufficient_permissions' },
+          'failure',
+          'Admin role required',
+          req.ip,
+          requestId
+        )
+        res.status(403).json({ error: 'Forbidden', message: 'Admin role required' })
+        return
+      }
+
       const webhook = await webhookService.rotateSecret(id, { id: admin.id, email: admin.email, tenantId: admin.tenantId }, requestId)
       
       res.json({

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express'
-import { AuthenticatedRequest, requireUserAuth, requireAdminRole } from '../middleware/auth.js'
+import { AuthenticatedRequest, requireUserAuth, UserRole } from '../middleware/auth.js'
 import { WebhookRotationService, WebhookNotFoundError } from '../services/webhooks/rotationService.js'
 import type { WebhookStore } from '../services/webhooks/types.js'
-import type { AuditLogService } from '../services/audit/index.js'
+import { AuditAction, type AuditLogService } from '../services/audit/index.js'
 import { getTenantId, setTenantId } from '../utils/tenantContext.js'
 
 /**
@@ -39,7 +39,6 @@ export function createWebhookRouter(store: WebhookStore, audit: AuditLogService)
   router.post(
     '/:webhookId/rotate-secret',
     requireUserAuth,
-    requireAdminRole,
     async (req: Request, res: Response): Promise<void> => {
       // Set tenant context from request header
       const tenantId = req.headers['x-tenant-id'] as string || 'default-tenant'
@@ -53,6 +52,26 @@ export function createWebhookRouter(store: WebhookStore, audit: AuditLogService)
         const authReq = req as AuthenticatedRequest
         const actor = authReq.user!
         const ipAddress = req.ip ?? req.socket.remoteAddress
+
+        if (actor.role !== UserRole.ADMIN && actor.role !== UserRole.SUPER_ADMIN && (actor.role as string) !== 'super-admin') {
+          void audit.logAction({
+            tenantId: actor.tenantId || tenantId,
+            actorId: actor.id,
+            actorEmail: actor.email,
+            action: AuditAction.ROTATE_WEBHOOK_SECRET,
+            resourceType: 'webhook',
+            resourceId: webhookId,
+            details: { webhookId, reason: 'insufficient_permissions' },
+            status: 'failure',
+            errorMessage: 'Admin role required',
+            ipAddress,
+          })
+          res.status(403).json({
+            error: 'Forbidden',
+            message: 'Admin role required',
+          })
+          return
+        }
 
         const result = await rotationService.rotateSecret(
           webhookId,

--- a/tests/routes/webhooks.test.ts
+++ b/tests/routes/webhooks.test.ts
@@ -273,7 +273,7 @@ describe('Webhook Routes', () => {
       expect((body as { error: string }).error).toBe('Unauthorized')
     })
 
-    it('returns 403 when caller has verifier role (not admin)', async () => {
+    it('returns 403 when caller has verifier role (not admin) and writes audit entry', async () => {
       const { status, body } = await request(
         app,
         'POST',
@@ -283,6 +283,13 @@ describe('Webhook Routes', () => {
 
       expect(status).toBe(403)
       expect((body as { error: string }).error).toBe('Forbidden')
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(mockAuditLogs).toHaveLength(1)
+      expect(mockAuditLogs[0].action).toBe('ROTATE_WEBHOOK_SECRET')
+      expect(mockAuditLogs[0].status).toBe('failure')
+      expect(mockAuditLogs[0].resourceId).toBe(SEED_WEBHOOK.id)
     })
   })
 })


### PR DESCRIPTION
Closes #810

## Summary
Locks in the permission gate contract for the `POST /:webhookId/rotate-secret` endpoint:
- Non-admin callers receive `403 Forbidden`
- Every rejection writes a `ROTATE_WEBHOOK_SECRET` audit entry with `status: 'failure'`

## Changes
- `src/routes/webhooks.ts` — explicit role check with failure audit log before returning 403
- `src/routes/admin/webhooks.ts` — matching audit log on non-admin rejection
- `tests/routes/webhooks.test.ts` — asserts both the 403 response and the audit entry
- `src/config/constants.ts` — fixed stray merge markers (syntax error that broke the test suite)

## Acceptance Criteria

- [x] Non-admin rejected with 403 Forbidden
- [x] Immutable audit log failure entry written on non-admin rejection
- [x] All 11 tests in `tests/routes/webhooks.test.ts` pass
- [x] TypeScript type-check (`npx tsc --noEmit`) clean
- [x] `npm run sbom:check` passes
- [x] Tests run on every CI matrix entry via standard `npm test` / vitest suite

## Test Output
```
✓ tests/routes/webhooks.test.ts (11 tests) 381ms
  ✓ POST /:webhookId/rotate-secret (11)
    ✓ rotates the secret and returns rotation metadata
    ✓ new secret is a 64-char hex string
    ✓ updates the store — old secret is preserved as previousSecret
    ✓ previousSecretExpiresAt is ~24 h in the future
    ✓ writes an audit log entry on success
    ✓ two consecutive rotations produce different secrets
    ✓ returns 404 when webhook does not exist
    ✓ writes a failure audit log entry when webhook is not found
    ✓ returns 401 when no Authorization header is provided
    ✓ returns 401 for an invalid Bearer token
    ✓ returns 403 when caller has verifier role (not admin) and writes audit entry
```