### PR TITLE
feat: add x-cache header on responses indicating HIT/MISS/STALE

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ The service includes a Redis-based caching layer with:
 - **TTL support** - Set expiration times on cached values
 - **Health checks** - Built-in Redis health monitoring
 - **Graceful fallback** - Continues working when Redis is unavailable
+- **Cache response header** - Appends `x-cache` header (`HIT`, `MISS`, or `STALE`) to responses for transparency
 
 See [docs/caching.md](./docs/caching.md) for detailed documentation.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,6 +31,14 @@ To help clients debug their retry loops, you may optionally provide an `x-reques
 x-request-attempt: 3
 ```
 
+## Cache Status Response Header
+
+For endpoints that utilize caching (such as analytics summaries), the response will include an `x-cache` header indicating the cache transaction status:
+
+* `HIT` — The request was fully served from the cache.
+* `MISS` — The cache did not contain the requested data, and it was fetched from the database or origin server.
+* `STALE` — The request was served from the cache, but the cached data was determined to be stale.
+
 ---
 
 ## Authentication

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -321,6 +321,15 @@ const result = await singleflight.do('my-operation-key', async () => {
 })
 ```
 
+## Response Cache Headers (X-Cache)
+
+To aid debugging and provide client-side reasoning about cache performance, responses from cached endpoints will contain an `x-cache` header indicating the cache status:
+- `HIT` — The data was served entirely from the cache.
+- `MISS` — The data was not in the cache and had to be computed or fetched from the database.
+- `STALE` — The data was retrieved from the cache but was determined to be stale based on its age or timestamp indicators.
+
+This tracking is automatically managed by `cacheHeaderMiddleware` using asynchronous local storage context during request processing.
+
 ## Best Practices
 
 1. **Always set TTL** - Prevent memory leaks

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,59 +32,9 @@ import {
 import { metricsMiddleware, register } from "./middleware/metrics.js";
 import { createCidrWhitelistMiddleware } from "./middleware/cidrWhitelist.js";
 import { createSafeRedirectMiddleware } from "./middleware/safeRedirect.js";
- feat/request-attempt-header
-import {
-  bondPathParamsSchema,
-  attestationsPathParamsSchema,
-  createAttestationBodySchema,
-} from './schemas/index.js'
-import { compressionMiddleware, compressionMetricsMiddleware } from './middleware/compression.js'
-import { metricsMiddleware, register } from './middleware/metrics.js'
-import { createMembersRouter } from './routes/admin/member.ts'
-import { clientVersionEchoMiddleware } from './middleware/clientVersionEcho.js'
-import { requestAttemptEchoMiddleware } from './middleware/requestAttemptEcho.js'
-
-const app = express()
-
-// Request context and correlation IDs
-app.use(requestIdMiddleware)
-
-// Debugging echo
-app.use(clientVersionEchoMiddleware)
-app.use(requestAttemptEchoMiddleware)
-
-// Metrics endpoint for Prometheus
-app.get('/metrics', async (_req, res) => {
-  res.set('Content-Type', register.contentType)
-  res.end(await register.metrics())
-})
-
-app.use(metricsMiddleware)
-app.use(compressionMetricsMiddleware)
-app.use(compressionMiddleware)
-app.use(express.json())
-
-// JWT public key set — unauthenticated, per RFC 8414 / OIDC Discovery conventions
-app.use('/.well-known/jwks.json', createJwksRouter())
-
-// Health – full readiness check with per-dependency status
-const healthProbes = createDefaultProbes()
-
-// If Redis is configured, wire up a client for the worker-health endpoint
-let redisClient: import('./cache/redis.js').RedisClient | undefined
-if (process.env.REDIS_URL) {
-  try {
-    const conn = RedisConnection.getInstance()
-    // Best-effort connect — the endpoint degrades gracefully if Redis is down
-    conn.connect().catch(() => {})
-    redisClient = conn.getClient()
-  } catch {
-    // Redis may not be reachable at startup; worker-health will degrade gracefully
-  }
-}
-
-app.use('/api/health', createHealthRouter({ ...healthProbes, redisClient }))
- main
+import { clientVersionEchoMiddleware } from "./middleware/clientVersionEcho.js";
+import { requestAttemptEchoMiddleware } from "./middleware/requestAttemptEcho.js";
+import { cacheHeaderMiddleware } from "./middleware/cacheHeader.js";
 
 // Add missing imports used in the router
 import {
@@ -134,6 +84,9 @@ try {
 const timeoutBudgetMiddleware = createTimeoutBudgetMiddleware(globalTimeoutMs);
 
 app.use(requestIdMiddleware);
+app.use(cacheHeaderMiddleware);
+app.use(clientVersionEchoMiddleware);
+app.use(requestAttemptEchoMiddleware);
 app.use(timeoutBudgetMiddleware);
 
 const metricsCidrs = process.env.METRICS_ALLOWED_CIDRS

--- a/src/cache/redis.ts
+++ b/src/cache/redis.ts
@@ -4,6 +4,7 @@ import { executeCacheOperation, createMetricsAdapter } from '../lib/timeoutExecu
 import { createDefaultMetricsCollector } from '../observability/timeoutMetrics.js'
 import { logger } from '../utils/logger.js'
 import { singleflight } from '../lib/singleflight.js'
+import { recordCacheHit, recordCacheMiss, isObjectStale } from '../utils/cacheContext.js'
 
 export type RedisClient = RedisClientType
 
@@ -146,6 +147,11 @@ export class CacheService {
     // Check L1 cache first
     const l1Value = this.l1Cache.get(namespacedKey)
     if (l1Value !== undefined) {
+      if (l1Value === null) {
+        recordCacheMiss()
+      } else {
+        recordCacheHit(isObjectStale(l1Value))
+      }
       return l1Value as T
     }
     
@@ -156,6 +162,7 @@ export class CacheService {
         const value = await this.redis.getClient().get(namespacedKey)
         
         if (value === null) {
+          recordCacheMiss()
           return null
         }
 
@@ -169,11 +176,13 @@ export class CacheService {
 
         // Store in L1
         this.l1Cache.set(namespacedKey, parsedValue)
+        recordCacheHit(isObjectStale(parsedValue))
         return parsedValue
       },
       { metrics: this.metrics }
     ).catch(error => {
       logger.error(`Cache get failed for key ${namespacedKey}:`, error)
+      recordCacheMiss()
       return null
     })
   }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,8 +10,6 @@ export const DEFAULT_TOP_TALKERS_LIMIT = 10
 export const MAX_TOP_TALKERS_LIMIT = 100
 
 /** Default time window in minutes for top talkers request aggregation (1 hour). */
- feat/request-attempt-header
-export const DEFAULT_TOP_TALKERS_WINDOW_MINUTES = 60
 export const DEFAULT_TOP_TALKERS_WINDOW_MINUTES = 60
 
 /** Header name used to trigger graceful degradation / read-only mode */
@@ -38,4 +36,6 @@ export const PG_STAT_ACTIVITY_SNAPSHOT_RETENTION_HOURS = 24
  * thundering herd against a just-recovered provider.
  */
 export const PROVIDER_RECOVERY_BUFFER_MS = 5_000
- main
+
+/** Header indicating Cache HIT/MISS/STALE status on response. */
+export const HEADER_X_CACHE = 'x-cache'

--- a/src/middleware/__tests__/cacheHeader.test.ts
+++ b/src/middleware/__tests__/cacheHeader.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import express, { Express } from 'express'
+import request from 'supertest'
+import { cacheHeaderMiddleware } from '../cacheHeader.js'
+import { cache } from '../../cache/redis.js'
+import { HEADER_X_CACHE } from '../../config/constants.js'
+import { recordCacheHit, recordCacheMiss } from '../../utils/cacheContext.js'
+
+describe('cacheHeaderMiddleware', () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = express()
+    app.use(cacheHeaderMiddleware)
+    vi.restoreAllMocks()
+  })
+
+  it('should not set x-cache header if no cache operations occur', async () => {
+    app.get('/no-cache', (_req, res) => {
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/no-cache')
+    expect(response.headers[HEADER_X_CACHE]).toBeUndefined()
+  })
+
+  it('should set x-cache header when hit/miss is called directly', async () => {
+    app.get('/direct-hit', (_req, res) => {
+      recordCacheHit()
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/direct-hit')
+    expect(response.headers[HEADER_X_CACHE]).toBe('HIT')
+  })
+
+  it('should set x-cache: HIT when cache get hits L1 cache with fresh data', async () => {
+    vi.spyOn(cache['l1Cache'], 'get').mockReturnValue({ data: 'some-data', staleness: { fresh: true, refreshStatus: 'ok' } })
+
+    app.get('/cache-hit', async (_req, res) => {
+      await cache.get('test-ns', 'test-key')
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/cache-hit')
+    expect(response.headers[HEADER_X_CACHE]).toBe('HIT')
+  })
+
+  it('should set x-cache: MISS when cache get misses L1 and L2 (Redis)', async () => {
+    vi.spyOn(cache['l1Cache'], 'get').mockReturnValue(undefined)
+    vi.spyOn(cache['redis'], 'connect').mockResolvedValue(undefined)
+    vi.spyOn(cache['redis'], 'getClient').mockReturnValue({
+      get: vi.fn().mockResolvedValue(null)
+    } as any)
+
+    app.get('/cache-miss', async (_req, res) => {
+      await cache.get('test-ns', 'test-key')
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/cache-miss')
+    expect(response.headers[HEADER_X_CACHE]).toBe('MISS')
+  })
+
+  it('should set x-cache: STALE when cache hit returned is stale', async () => {
+    vi.spyOn(cache['l1Cache'], 'get').mockReturnValue({ data: 'stale-data', staleness: { fresh: false, refreshStatus: 'stale' } })
+
+    app.get('/cache-stale', async (_req, res) => {
+      await cache.get('test-ns', 'test-key')
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/cache-stale')
+    expect(response.headers[HEADER_X_CACHE]).toBe('STALE')
+  })
+
+  it('should set x-cache: STALE when nested or plain object is stale', async () => {
+    vi.spyOn(cache['l1Cache'], 'get').mockReturnValue({ data: 'stale-data', refreshStatus: 'stale' })
+
+    app.get('/cache-stale-nested', async (_req, res) => {
+      await cache.get('test-ns', 'test-key')
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/cache-stale-nested')
+    expect(response.headers[HEADER_X_CACHE]).toBe('STALE')
+  })
+
+  it('should prioritize STALE over MISS and HIT', async () => {
+    app.get('/cache-mixed', (_req, res) => {
+      recordCacheHit()
+      recordCacheMiss()
+      recordCacheHit(true) // stale
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/cache-mixed')
+    expect(response.headers[HEADER_X_CACHE]).toBe('STALE')
+  })
+
+  it('should prioritize MISS over HIT when no stale exists', async () => {
+    app.get('/cache-mixed-miss', (_req, res) => {
+      recordCacheHit()
+      recordCacheMiss()
+      res.json({ message: 'ok' })
+    })
+
+    const response = await request(app).get('/cache-mixed-miss')
+    expect(response.headers[HEADER_X_CACHE]).toBe('MISS')
+  })
+})

--- a/src/middleware/cacheHeader.ts
+++ b/src/middleware/cacheHeader.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express'
+import { cacheContext } from '../utils/cacheContext.js'
+import { HEADER_X_CACHE } from '../config/constants.js'
+
+/**
+ * Middleware that initializes the cache status context for the request
+ * and appends the x-cache header to the response if any cache operations occurred.
+ */
+export function cacheHeaderMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const store = { status: null }
+
+  const originalEnd = res.end.bind(res)
+
+  ;(res as any).end = function patchedEnd(...args: unknown[]) {
+    if (!res.headersSent && store.status) {
+      res.setHeader(HEADER_X_CACHE, store.status)
+    }
+    return (originalEnd as (...a: unknown[]) => Response)(...args)
+  }
+
+  cacheContext.run(store, () => {
+    next()
+  })
+}

--- a/src/utils/cacheContext.ts
+++ b/src/utils/cacheContext.ts
@@ -1,0 +1,40 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+export interface CacheContextState {
+  status: 'HIT' | 'MISS' | 'STALE' | null
+}
+
+export const cacheContext = new AsyncLocalStorage<CacheContextState>()
+
+export function recordCacheHit(isStale = false): void {
+  const store = cacheContext.getStore()
+  if (!store) return
+
+  if (isStale) {
+    store.status = 'STALE'
+  } else if (store.status !== 'STALE' && store.status !== 'MISS') {
+    store.status = 'HIT'
+  }
+}
+
+export function recordCacheMiss(): void {
+  const store = cacheContext.getStore()
+  if (!store) return
+
+  if (store.status !== 'STALE') {
+    store.status = 'MISS'
+  }
+}
+
+export function isObjectStale(value: any): boolean {
+  if (!value || typeof value !== 'object') return false
+
+  // Check common staleness indicator fields
+  if (value.staleness?.fresh === false) return true
+  if (value.staleness?.refreshStatus === 'stale') return true
+  if (value.refreshStatus === 'stale') return true
+  if (value.stale === true) return true
+  if (value.status === 'stale') return true
+
+  return false
+}


### PR DESCRIPTION
  Closes #816
    
    ## Changes
    - Created `cacheContext` utilizing `AsyncLocalStorage` to track
  the overall cache status within the request lifecycle.
    - Integrated tracking into `CacheService.get` to update the
  context state dynamically.
    - Added `cacheHeaderMiddleware` to capture the recorded cache
  state and append the `x-cache` header onto Express responses.
    - Added unit tests covering HIT, MISS, STALE, mixed lookups, and
  no-cache operations.
    - Updated documentation in README, `docs/api.md`, and
  `docs/caching.md`.
    - Cleaned up broken/invalid git merge markers pre-existing in
  `src/app.ts` and `src/config/constants.ts`.
    
    ## Design Decisions
    - **AsyncLocalStorage Isolation**: Used `AsyncLocalStorage` to
  store context, avoiding modification of internal Express Request or
  routing signatures, thereby keeping API changes highly backward-
  compatible.
    - **Priority Rules**: If a request makes multiple cache lookups,
  the overall status is resolved as:
      1. `STALE` if any lookup was stale.
      2. `MISS` if any lookup was a miss (and no stale lookup
  occurred).
      3. `HIT` only if all lookups were hits and fresh.
      4. Header is omitted if no cache gets were executed.

    ## Checklist
    - [x] Matches the summary of issue #816.
    - [x] No regressions in existing test suite.
    - [x] Documented in README.md, docs/api.md, and docs/caching.md.
    - [x] Lint, type-check, and tests all pass locally for changed
  files.