### PR TITLE
docs: add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Credence Backend
 
+[![codecov](https://codecov.io/gh/CredenceOrg/Credence-Backend/branch/main/graph/badge.svg)](https://codecov.io/gh/CredenceOrg/Credence-Backend)
+
 API and services for the Credence economic trust protocol. Provides health checks, trust score and bond status endpoints (to be wired to Horizon and a reputation engine).
 
 ## About


### PR DESCRIPTION
## Summary
- Adds a Codecov coverage badge to the top of README.md, linking to the project's Codecov page.

## Why this badge
CI (`.github/workflows/test.yml`) already runs `npm run coverage` and uploads `coverage/lcov.info` to Codecov on every push/PR to `main`/`develop`. The badge surfaces that existing signal in the README instead of introducing a new tool or dependency.

## Scope
Docs-only change (no application code touched). Per the issue's "Out of scope" section, no unrelated refactors or stylistic changes were made.

## Test plan
- [x] `README.md` renders correctly (badge markdown verified locally)
- [x] No source files changed — `npm run lint` / `npm test` behavior unaffected

Closes #885