### PR TITLE
Config: central config module for cache TTLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,6 +191,12 @@ COMPRESSION_THRESHOLD=1024
 # Set to 0 to disable. Default: 5000 ms (5 seconds).
 # SOROBAN_STATE_CACHE_TTL_MS=5000
 
+# ── Bond / Attestation Caches ────────────────────────────────────────────────
+# Redis cache TTL (seconds) for bond lookups by id/identity. Default: 300 (5 min).
+# BOND_CACHE_TTL_SECONDS=300
+# Redis cache TTL (seconds) for attestation lookups by id/subject/bond. Default: 300 (5 min).
+# ATTESTATION_CACHE_TTL_SECONDS=300
+
 # Version identifier for the scoring model (recorded in score snapshots)
 REPUTATION_MODEL_VERSION=1.0.0
 # Maximum points for bond amount component (default: 50, achieved at ≥ 1 ETH)

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -305,3 +305,36 @@ describe('envSchema', () => {
     expect(result.success).toBe(true)
   })
 })
+
+// ─── Bond / attestation cache TTL ────────────────────────────────────────────
+
+describe('validateConfig – bond/attestation cache TTL', () => {
+  it('defaults bondCache.ttl and attestationCache.ttl to 300 seconds', () => {
+    const config = validateConfig(validEnv())
+
+    expect(config.bondCache.ttl).toBe(300)
+    expect(config.attestationCache.ttl).toBe(300)
+  })
+
+  it('applies BOND_CACHE_TTL_SECONDS and ATTESTATION_CACHE_TTL_SECONDS overrides', () => {
+    const config = validateConfig(validEnv({
+      BOND_CACHE_TTL_SECONDS: '900',
+      ATTESTATION_CACHE_TTL_SECONDS: '120',
+    }))
+
+    expect(config.bondCache.ttl).toBe(900)
+    expect(config.attestationCache.ttl).toBe(120)
+  })
+
+  it('rejects a non-numeric BOND_CACHE_TTL_SECONDS', () => {
+    expect(() =>
+      validateConfig(validEnv({ BOND_CACHE_TTL_SECONDS: 'not-a-number' })),
+    ).toThrow(ConfigValidationError)
+  })
+
+  it('rejects an out-of-range ATTESTATION_CACHE_TTL_SECONDS', () => {
+    expect(() =>
+      validateConfig(validEnv({ ATTESTATION_CACHE_TTL_SECONDS: '999999' })),
+    ).toThrow(ConfigValidationError)
+  })
+})

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,6 +18,18 @@ export const envSchema = z.object({
       .default('600') // 10 minutes
       .transform(Number)
       .pipe(z.number().int().min(60).max(86400)),
+    // Bond cache TTL (seconds)
+    BOND_CACHE_TTL_SECONDS: z
+      .string()
+      .default('300') // 5 minutes
+      .transform(Number)
+      .pipe(z.number().int().min(1).max(86400)),
+    // Attestation cache TTL (seconds)
+    ATTESTATION_CACHE_TTL_SECONDS: z
+      .string()
+      .default('300') // 5 minutes
+      .transform(Number)
+      .pipe(z.number().int().min(1).max(86400)),
     // Webhook payload size cap in bytes
     WEBHOOK_PAYLOAD_SIZE_CAP: z
       .string()
@@ -448,6 +460,12 @@ export interface Config {
   trustScoreCache: {
     ttl: number
   }
+  bondCache: {
+    ttl: number
+  }
+  attestationCache: {
+    ttl: number
+  }
   port: number
   nodeEnv: 'development' | 'production' | 'test'
   logLevel: 'debug' | 'info' | 'warn' | 'error'
@@ -759,6 +777,12 @@ function mapEnvToConfig(env: Env): Config {
     },
     trustScoreCache: {
       ttl: env.TRUST_SCORE_CACHE_TTL,
+    },
+    bondCache: {
+      ttl: env.BOND_CACHE_TTL_SECONDS,
+    },
+    attestationCache: {
+      ttl: env.ATTESTATION_CACHE_TTL_SECONDS,
     },
     sorobanCircuitBreaker: {
       failureThreshold: env.SOROBAN_CIRCUIT_BREAKER_FAILURE_THRESHOLD,

--- a/src/services/__tests__/attestationCacheService.test.ts
+++ b/src/services/__tests__/attestationCacheService.test.ts
@@ -25,6 +25,14 @@ vi.mock('../../cache/invalidation.js', async () => {
   }
 })
 
+vi.mock('../../config/index.js', () => ({
+  loadConfig: () => ({
+    attestationCache: {
+      ttl: 120,
+    },
+  }),
+}))
+
 describe('AttestationCacheService', () => {
   let service: AttestationCacheService
   let mockRepository: AttestationsRepository
@@ -70,7 +78,7 @@ describe('AttestationCacheService', () => {
       const result = await service.getAttestationById(1)
 
       expect(mockRepository.findById).toHaveBeenCalledWith(1)
-      expect(cache.set).toHaveBeenCalledWith('attestation', 'id:1', mockAttestation, 300)
+      expect(cache.set).toHaveBeenCalledWith('attestation', 'id:1', mockAttestation, 120)
       expect(result).toEqual(mockAttestation)
     })
   })
@@ -93,7 +101,7 @@ describe('AttestationCacheService', () => {
       const result = await service.getAttestationsBySubject('0x123')
 
       expect(mockRepository.listBySubject).toHaveBeenCalledWith('0x123')
-      expect(cache.set).toHaveBeenCalledWith('attestation', 'subject:0x123', [mockAttestation], 300)
+      expect(cache.set).toHaveBeenCalledWith('attestation', 'subject:0x123', [mockAttestation], 120)
       expect(result).toEqual([mockAttestation])
     })
   })

--- a/src/services/__tests__/bondCacheService.test.ts
+++ b/src/services/__tests__/bondCacheService.test.ts
@@ -24,6 +24,14 @@ vi.mock('../../cache/invalidation.js', async () => {
   }
 })
 
+vi.mock('../../config/index.js', () => ({
+  loadConfig: () => ({
+    bondCache: {
+      ttl: 900,
+    },
+  }),
+}))
+
 describe('BondCacheService', () => {
   let service: BondCacheService
   let mockRepository: BondsRepository
@@ -70,7 +78,7 @@ describe('BondCacheService', () => {
 
       expect(cache.get).toHaveBeenCalledWith('bond', 'id:1')
       expect(mockRepository.findById).toHaveBeenCalledWith(1)
-      expect(cache.set).toHaveBeenCalledWith('bond', 'id:1', mockBond, 300)
+      expect(cache.set).toHaveBeenCalledWith('bond', 'id:1', mockBond, 900)
       expect(result).toEqual(mockBond)
     })
 
@@ -104,7 +112,7 @@ describe('BondCacheService', () => {
       const result = await service.getBondsByIdentity('0x123')
 
       expect(mockRepository.listByIdentity).toHaveBeenCalledWith('0x123')
-      expect(cache.set).toHaveBeenCalledWith('bond', 'identity:0x123', [mockBond], 300)
+      expect(cache.set).toHaveBeenCalledWith('bond', 'identity:0x123', [mockBond], 900)
       expect(result).toEqual([mockBond])
     })
   })

--- a/src/services/attestationCacheService.ts
+++ b/src/services/attestationCacheService.ts
@@ -6,8 +6,7 @@
 import { AttestationsRepository, Attestation, type AttestationPage, type ListAttestationsPageOptions, type CursorPaginationOptions, type AttestationCursorPage } from '../db/repositories/attestationsRepository.js'
 import { cache } from '../cache/redis.js'
 import { createCacheKey, invalidateCache } from '../cache/invalidation.js'
-
-const ATTESTATION_CACHE_TTL = 300 // 5 minutes
+import { loadConfig } from '../config/index.js'
 
 export class AttestationCacheService {
   constructor(private readonly repository: AttestationsRepository) {}
@@ -29,7 +28,7 @@ export class AttestationCacheService {
     
     const attestation = await this.repository.findById(id)
     if (attestation) {
-      await cache.set('attestation', cacheKey, attestation, ATTESTATION_CACHE_TTL)
+      await cache.set('attestation', cacheKey, attestation, loadConfig().attestationCache.ttl)
     }
     
     return attestation
@@ -52,7 +51,7 @@ export class AttestationCacheService {
     
     const attestations = await this.repository.listBySubject(subjectAddress)
     if (attestations.length > 0) {
-      await cache.set('attestation', cacheKey, attestations, ATTESTATION_CACHE_TTL)
+      await cache.set('attestation', cacheKey, attestations, loadConfig().attestationCache.ttl)
     }
     
     return attestations
@@ -79,7 +78,7 @@ export class AttestationCacheService {
     }
 
     const page = await this.repository.listBySubjectPage(subjectAddress, options)
-    await cache.set('attestation', cacheKey, page, ATTESTATION_CACHE_TTL)
+    await cache.set('attestation', cacheKey, page, loadConfig().attestationCache.ttl)
 
     return page
   }
@@ -123,7 +122,7 @@ export class AttestationCacheService {
     
     const attestations = await this.repository.listByBond(bondId)
     if (attestations.length > 0) {
-      await cache.set('attestation', cacheKey, attestations, ATTESTATION_CACHE_TTL)
+      await cache.set('attestation', cacheKey, attestations, loadConfig().attestationCache.ttl)
     }
     
     return attestations

--- a/src/services/bondCacheService.ts
+++ b/src/services/bondCacheService.ts
@@ -6,8 +6,7 @@
 import { BondsRepository, Bond, BondStatus } from '../db/repositories/bondsRepository.js'
 import { cache } from '../cache/redis.js'
 import { invalidateCache, createCacheKey } from '../cache/invalidation.js'
-
-const BOND_CACHE_TTL = 300 // 5 minutes
+import { loadConfig } from '../config/index.js'
 
 export class BondCacheService {
   constructor(private readonly repository: BondsRepository) {}
@@ -30,7 +29,7 @@ export class BondCacheService {
     
     const bond = await this.repository.findById(id)
     if (bond) {
-      await cache.set('bond', cacheKey, bond, BOND_CACHE_TTL)
+      await cache.set('bond', cacheKey, bond, loadConfig().bondCache.ttl)
     }
     
     return bond
@@ -54,7 +53,7 @@ export class BondCacheService {
     
     const bonds = await this.repository.listByIdentity(identityAddress)
     if (bonds.length > 0) {
-      await cache.set('bond', cacheKey, bonds, BOND_CACHE_TTL)
+      await cache.set('bond', cacheKey, bonds, loadConfig().bondCache.ttl)
     }
     
     return bonds


### PR DESCRIPTION
## Summary

`BondCacheService` and `AttestationCacheService` each hardcoded a local
`300`-second TTL constant (`BOND_CACHE_TTL`, `ATTESTATION_CACHE_TTL`)
instead of going through the app's existing central config module.
Other caches in the codebase (trust score, Soroban state) already read
their TTL from `loadConfig()` — this brings bond/attestation caches in
line with that established pattern.

## Changes

- `src/config/index.ts`: add `BOND_CACHE_TTL_SECONDS` and
  `ATTESTATION_CACHE_TTL_SECONDS` env vars (zod-validated, default
  `300`s, matching prior hardcoded behavior) exposed as
  `config.bondCache.ttl` / `config.attestationCache.ttl`.
- `src/services/bondCacheService.ts`, `src/services/attestationCacheService.ts`:
  removed the hardcoded module-level TTL constants; each cache write
  now reads `loadConfig().bondCache.ttl` / `loadConfig().attestationCache.ttl`
  at the point of use (same idiom as `reputationService.ts`'s trust
  score cache).
- `.env.example`: documented both new env vars.
- Tests: added config validation tests (defaults, env override,
  invalid/out-of-range value) in `src/config/__tests__/config.test.ts`;
  updated `bondCacheService.test.ts` / `attestationCacheService.test.ts`
  to mock config with distinct TTL values, proving the TTL is actually
  sourced from config rather than a coincidental hardcoded match.

## Test plan

- [x] `npx vitest run src/config/__tests__/config.test.ts src/services/__tests__/bondCacheService.test.ts src/services/__tests__/attestationCacheService.test.ts src/services/__tests__/trustScoreCacheService.test.ts` — all passing except one pre-existing, unrelated failure (`rejects wildcard CORS origin (*) when NODE_ENV is production`), confirmed present on `main` before this change too.
- [x] `npx tsc --noEmit` — same 56 pre-existing errors as on `main` (unrelated Express route-typing issue), zero new errors introduced.
- [x] `npm run lint` — same 177 pre-existing problems as on `main` (unrelated files), zero new errors/warnings in changed files.

Closes #886