### PR TITLE
feat(audit): add tenant_id to audit log lines

### DIFF
--- a/src/observability/logSchemas.ts
+++ b/src/observability/logSchemas.ts
@@ -52,6 +52,9 @@ export enum LogEventType {
   // ── Audit Chain Verifier Events ──
   AUDIT_CHAIN_VERIFICATION = "audit-chain:verification",
 
+  // ── Audit Log Events ──
+  AUDIT_LOG_RECORDED = "audit:log-recorded",
+
   // ── Database Events ──
   DB_SLOW_QUERY = "db:slow-query",
 
@@ -239,6 +242,14 @@ export const LOG_SCHEMAS: Record<LogEventType, Record<string, FieldSchema>> = {
     lastCheckedSeq: { type: "number" },
     firstViolationSeq: { type: "number" },
     checkedAt: { type: "string" },
+  },
+
+  [LogEventType.AUDIT_LOG_RECORDED]: {
+    tenantId: { type: "string" },
+    action: { type: "string" },
+    resourceType: { type: "string" },
+    status: { type: "string" },
+    requestId: { type: "string" },
   },
 
   // ── Database ──

--- a/src/services/audit/index.test.ts
+++ b/src/services/audit/index.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AuditLogService, AuditAction } from './index.js'
+import { InMemoryAuditLogsRepository } from '../../db/repositories/auditLogsRepository.js'
+import { logger } from '../../utils/logger.js'
+
+describe('AuditLogService audit log lines', () => {
+  let service: AuditLogService
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    service = new AuditLogService(new InMemoryAuditLogsRepository())
+    vi.spyOn(logger, 'info').mockImplementation(() => undefined)
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined)
+  })
+
+  it('emits an INFO log line carrying tenantId on a successful audit action', async () => {
+    await service.logAction(
+      'tenant-happy-path',
+      'admin-1',
+      'admin@example.com',
+      AuditAction.ASSIGN_ROLE,
+      'user-2',
+      'user@example.com',
+      { role: 'reviewer' },
+      'success',
+    )
+
+    expect(logger.info).toHaveBeenCalledTimes(1)
+    expect(logger.warn).not.toHaveBeenCalled()
+
+    const [loggedPayload] = vi.mocked(logger.info).mock.calls[0]
+    expect(loggedPayload).toMatchObject({
+      tenantId: 'tenant-happy-path',
+      action: AuditAction.ASSIGN_ROLE,
+      status: 'success',
+    })
+  })
+
+  it('emits a WARN log line carrying tenantId when the audit action failed', async () => {
+    await service.logAction(
+      'tenant-failure-path',
+      'admin-1',
+      'admin@example.com',
+      AuditAction.REVOKE_API_KEY,
+      'user-3',
+      undefined,
+      undefined,
+      'failure',
+      'target key not found',
+    )
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.info).not.toHaveBeenCalled()
+
+    const [loggedPayload] = vi.mocked(logger.warn).mock.calls[0]
+    expect(loggedPayload).toMatchObject({
+      tenantId: 'tenant-failure-path',
+      action: AuditAction.REVOKE_API_KEY,
+      status: 'failure',
+    })
+  })
+
+  it('never leaks actor/target email addresses into the audit log line', async () => {
+    await service.logAction(
+      'tenant-redaction-check',
+      'admin-1',
+      'admin@example.com',
+      AuditAction.DELETE_USER,
+      'user-4',
+      'target@example.com',
+      { note: 'cleanup' },
+      'success',
+    )
+
+    const [loggedPayload] = vi.mocked(logger.info).mock.calls[0]
+    expect(loggedPayload).not.toHaveProperty('actorEmail')
+    expect(loggedPayload).not.toHaveProperty('targetUserEmail')
+    expect(loggedPayload).not.toHaveProperty('details')
+    expect(JSON.stringify(loggedPayload)).not.toContain('example.com')
+  })
+})

--- a/src/services/audit/index.ts
+++ b/src/services/audit/index.ts
@@ -10,6 +10,9 @@ import {
   type AuditChainVerificationRepository,
 } from '../../db/repositories/auditChainVerificationRepository.js'
 import { toChainVerificationState } from './chainStatus.js'
+import { logger } from '../../utils/logger.js'
+import { redact } from '../../observability/redaction.js'
+import { LogEventType } from '../../observability/logSchemas.js'
 import type {
   AuditChainVerificationState,
   AuditLogEntry,
@@ -66,7 +69,9 @@ export class AuditLogService {
     requestId?: string,
   ): Promise<AuditLogEntry> {
     if (typeof inputOrTenantId !== 'string') {
-      return this.repository.append(inputOrTenantId)
+      const entry = await this.repository.append(inputOrTenantId)
+      this.logAuditEvent(entry)
+      return entry
     }
 
     const tenantId = inputOrTenantId
@@ -81,7 +86,7 @@ export class AuditLogService {
       ...(targetUserEmail ? { targetUserEmail } : {}),
     }
 
-    return this.repository.append({
+    const entry = await this.repository.append({
       tenantId,
       actorId: actorId ?? 'unknown',
       actorEmail: actorEmail ?? 'unknown@unknown',
@@ -94,6 +99,33 @@ export class AuditLogService {
       ipAddress,
       requestId,
     })
+    this.logAuditEvent(entry)
+    return entry
+  }
+
+  /**
+   * Emit a schema-validated structured log line for a recorded audit entry.
+   *
+   * Every audit log line must carry tenantId so log aggregation can be
+   * scoped per tenant; the allowlist schema for AUDIT_LOG_RECORDED drops
+   * anything else (e.g. actorEmail, details) that isn't explicitly listed.
+   */
+  private logAuditEvent(entry: AuditLogEntry): void {
+    const payload = {
+      eventType: LogEventType.AUDIT_LOG_RECORDED,
+      tenantId: entry.tenantId,
+      action: entry.action,
+      resourceType: entry.resourceType,
+      status: entry.status,
+      requestId: entry.requestId,
+    }
+    const redacted = redact(payload, { eventType: LogEventType.AUDIT_LOG_RECORDED })
+
+    if (entry.status === 'failure') {
+      logger.warn(redacted)
+    } else {
+      logger.info(redacted)
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Admin/credential-issuance actions recorded via `AuditLogService.logAction()` were persisted to the `audit_logs` table (which already has a `tenant_id` column) but never emitted a corresponding structured log line — so log aggregation had zero visibility into audit events, tenant-scoped or otherwise.

This adds a schema-validated `audit:log-recorded` log line, emitted on every audit action, that always carries `tenantId`.

## Changes

- `src/observability/logSchemas.ts`: new `LogEventType.AUDIT_LOG_RECORDED` with an allowlist schema (`tenantId`, `action`, `resourceType`, `status`, `requestId`).
- `src/services/audit/index.ts`: `AuditLogService.logAction()` now emits this log line (INFO on success, WARN on failure) via the existing `redact()` allowlist, after the entry is persisted.
- `src/services/audit/index.test.ts`: new tests covering the happy path, a failure-status path, and that PII (actor/target emails, details) never leaks into the log line.

## Notes

- Structured logs only, no free-form strings; no secrets/tokens/request bodies are logged.
- Uses the existing schema-based redaction (`redact()` + `LOG_SCHEMAS`) as the project's "RedactedLogger" mechanism — unlisted fields (emails, details) are dropped fail-secure.
- Scoped to this change only; did not touch unrelated files.

Closes #882