### PR TITLE
feat: add sendError() helper for structured error codes across all routes

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7,6 +7,31 @@ servers:
   - url: https://api.credence.org/v1
 components:
   schemas:
+    ErrorResponse:
+      type: object
+      description: Standard error envelope returned by all API error responses. Consumers should branch on `code` (or the `error_code` alias) rather than parsing the `error` message.
+      properties:
+        error:
+          type: string
+          description: Human-readable error message. In production, this is always the catalog default message; in non-production environments it may contain the original error detail.
+          example: Validation failed
+        code:
+          type: string
+          description: Machine-readable error code from the centralized error catalog. Stable across releases.
+          example: validation_failed
+        error_code:
+          type: string
+          description: Alias of `code`. Present for backward compatibility; branch on `code`.
+          example: validation_failed
+        details:
+          type: array
+          description: Optional structured details (e.g., Zod issue list). Omitted in production to prevent PII leakage.
+          items:
+            type: object
+      required:
+        - error
+        - code
+        - error_code
     addressSchema:
       def:
         type: string

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,121 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import { sendError, ErrorCode } from './errors.js'
+import { getErrorCatalogEntry } from './errorCatalog.js'
+
+const makeApp = (handler: (req: express.Request, res: express.Response) => void) => {
+  const app = express()
+  app.get('/test', handler)
+  return app
+}
+
+const withNodeEnv = async <T>(nodeEnv: string, fn: () => Promise<T>): Promise<T> => {
+  const original = process.env.NODE_ENV
+  process.env.NODE_ENV = nodeEnv
+  try {
+    return await fn()
+  } finally {
+    if (original === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = original
+    }
+  }
+}
+
+describe('sendError helper', () => {
+  it('returns the standard error envelope with code and error_code', async () => {
+    const app = makeApp((_req, res) => {
+      sendError(res, ErrorCode.NOT_FOUND, 'Widget not found')
+    })
+
+    const res = await request(app).get('/test')
+    expect(res.status).toBe(404)
+    expect(res.body).toEqual({
+      error: 'Widget not found',
+      code: 'not_found',
+      error_code: 'not_found',
+    })
+  })
+
+  it('uses the catalog default message in production', async () => {
+    await withNodeEnv('production', async () => {
+      const app = makeApp((_req, res) => {
+        sendError(res, ErrorCode.VALIDATION_FAILED, 'Sensitive detail')
+      })
+
+      const res = await request(app).get('/test')
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe(getErrorCatalogEntry(ErrorCode.VALIDATION_FAILED).defaultMessage)
+      expect(res.body.code).toBe('validation_failed')
+      expect(res.body.error_code).toBe('validation_failed')
+    })
+  })
+
+  it('omits details in production', async () => {
+    await withNodeEnv('production', async () => {
+      const app = makeApp((_req, res) => {
+        sendError(res, ErrorCode.VALIDATION_FAILED, 'fail', [{ path: 'x', message: 'required' }])
+      })
+
+      const res = await request(app).get('/test')
+      expect(res.body.details).toBeUndefined()
+    })
+  })
+
+  it('includes details in non-production', async () => {
+    const app = makeApp((_req, res) => {
+      sendError(res, ErrorCode.VALIDATION_FAILED, 'fail', [{ path: 'x', message: 'required' }])
+    })
+
+    const res = await request(app).get('/test')
+    expect(res.body.details).toEqual([{ path: 'x', message: 'required' }])
+  })
+
+  it('allows overriding the HTTP status', async () => {
+    const app = makeApp((_req, res) => {
+      sendError(res, ErrorCode.SERVICE_UNAVAILABLE, 'Not implemented', undefined, 501)
+    })
+
+    const res = await request(app).get('/test')
+    expect(res.status).toBe(501)
+    expect(res.body.code).toBe('service_unavailable')
+    expect(res.body.error_code).toBe('service_unavailable')
+  })
+
+  it('uses catalog status when no override is provided', async () => {
+    const app = makeApp((_req, res) => {
+      sendError(res, ErrorCode.RATE_LIMIT_EXCEEDED, 'Too many requests')
+    })
+
+    const res = await request(app).get('/test')
+    expect(res.status).toBe(429)
+    expect(res.body.code).toBe('rate_limit_exceeded')
+  })
+
+  it('returns correct envelope for each major error category', async () => {
+    const testCases: Array<{ code: ErrorCode; expectedStatus: number }> = [
+      { code: ErrorCode.VALIDATION_FAILED, expectedStatus: 400 },
+      { code: ErrorCode.UNAUTHORIZED, expectedStatus: 401 },
+      { code: ErrorCode.FORBIDDEN, expectedStatus: 403 },
+      { code: ErrorCode.NOT_FOUND, expectedStatus: 404 },
+      { code: ErrorCode.CONFLICT, expectedStatus: 409 },
+      { code: ErrorCode.RATE_LIMIT_EXCEEDED, expectedStatus: 429 },
+      { code: ErrorCode.INTERNAL_SERVER_ERROR, expectedStatus: 500 },
+      { code: ErrorCode.SERVICE_UNAVAILABLE, expectedStatus: 503 },
+    ]
+
+    for (const { code, expectedStatus } of testCases) {
+      const app = makeApp((_req, res) => {
+        sendError(res, code, `Test ${code}`)
+      })
+
+      const res = await request(app).get('/test')
+      expect(res.status).toBe(expectedStatus)
+      expect(typeof res.body.error).toBe('string')
+      expect(res.body.code).toBe(getErrorCatalogEntry(code).code)
+      expect(res.body.error_code).toBe(getErrorCatalogEntry(code).code)
+    }
+  })
+})

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,3 +1,4 @@
+import type { Response } from 'express'
 import {
   ErrorCode as ErrorCodeRegistry,
   getErrorCatalogEntry,
@@ -166,4 +167,37 @@ export class RequestTooLargeError extends AppError {
   constructor(message: string = getErrorCatalogEntry(ErrorCodeRegistry.REQUEST_TOO_LARGE).defaultMessage) {
     super(message, ErrorCodeRegistry.REQUEST_TOO_LARGE)
   }
+}
+
+/**
+ * Send a structured error response using the centralized error catalog.
+ *
+ * This is a convenience helper for route handlers that need to return an
+ * error directly (rather than throwing an AppError through next()). It
+ * produces the same `{ error, code, error_code, details? }` envelope as
+ * the global error-handler middleware.
+ *
+ * In production, only the catalog default message is returned (no PII).
+ *
+ * @param statusOverride - Optional HTTP status override. When provided, the
+ *   response uses this status instead of the catalog default. Use sparingly
+ *   to preserve backward compatibility with existing API contracts.
+ */
+export function sendError(
+  res: Response,
+  code: ErrorCodeValue,
+  message?: string,
+  details?: unknown,
+  statusOverride?: number,
+): void {
+  const catalogEntry = getErrorCatalogEntry(code)
+  const status = statusOverride ?? getHttpStatus(catalogEntry)
+  const isProduction = process.env.NODE_ENV === 'production'
+
+  res.status(status).json({
+    error: isProduction ? catalogEntry.defaultMessage : (message ?? catalogEntry.defaultMessage),
+    code: catalogEntry.code,
+    error_code: catalogEntry.code,
+    ...(!isProduction && details !== undefined ? { details } : {}),
+  })
 }

--- a/src/routes/admin/erasureProof.ts
+++ b/src/routes/admin/erasureProof.ts
@@ -5,6 +5,7 @@ import {
   requireAdminRole,
 } from '../../middleware/auth.js'
 import { auditLogService, AuditAction } from '../../services/audit/index.js'
+import { sendError, ErrorCode } from '../../lib/errors.js'
 
 const router = Router()
 
@@ -25,7 +26,7 @@ router.get(
       const evidenceId = req.params.id
 
       if (!evidenceId || evidenceId.trim().length === 0) {
-        res.status(400).json({ error: 'BadRequest', message: 'evidence id is required' })
+        sendError(res, ErrorCode.FIELD_REQUIRED, 'evidence id is required')
         return
       }
 
@@ -41,10 +42,7 @@ router.get(
       )
 
       if (logs.length === 0) {
-        res.status(404).json({
-          error: 'NotFound',
-          message: `No erasure proof found for evidence ${evidenceId}`,
-        })
+        sendError(res, ErrorCode.NOT_FOUND, `No erasure proof found for evidence ${evidenceId}`)
         return
       }
 
@@ -61,8 +59,7 @@ router.get(
         },
       })
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error'
-      res.status(500).json({ error: 'InternalError', message })
+      sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, error instanceof Error ? error.message : 'Unknown error')
     }
   },
 )

--- a/src/routes/admin/featureFlags.ts
+++ b/src/routes/admin/featureFlags.ts
@@ -12,6 +12,7 @@ import {
   setOverrideBodySchema,
   setTenantRolloutBodySchema,
 } from '../../schemas/featureFlags.js'
+import { sendError, ErrorCode } from '../../lib/errors.js'
 
 export function createFeatureFlagAdminRouter(
   service: FeatureFlagService = new FeatureFlagService(),
@@ -42,8 +43,7 @@ export function createFeatureFlagAdminRouter(
         const flags = await service.listFlagsWithOverrides(tenantId)
         res.json({ success: true, data: flags })
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        res.status(400).json({ error: message })
+        sendError(res, ErrorCode.VALIDATION_FAILED, err instanceof Error ? err.message : 'Unknown error')
       }
     },
   )
@@ -57,7 +57,7 @@ export function createFeatureFlagAdminRouter(
     async (req: Request, res: Response) => {
       const parsed = createFlagBodySchema.safeParse(req.body)
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Validation error', details: parsed.error.issues })
+        sendError(res, ErrorCode.VALIDATION_FAILED, parsed.error.issues[0]?.message ?? 'Validation error', parsed.error.issues)
         return
       }
 
@@ -72,8 +72,7 @@ export function createFeatureFlagAdminRouter(
         )
         res.status(201).json({ success: true, data: flag })
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        res.status(400).json({ error: message })
+        sendError(res, ErrorCode.VALIDATION_FAILED, err instanceof Error ? err.message : 'Unknown error')
       }
     },
   )
@@ -87,7 +86,7 @@ export function createFeatureFlagAdminRouter(
     async (req: Request, res: Response) => {
       const parsed = updateFlagBodySchema.safeParse(req.body)
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Validation error', details: parsed.error.issues })
+        sendError(res, ErrorCode.VALIDATION_FAILED, parsed.error.issues[0]?.message ?? 'Validation error', parsed.error.issues)
         return
       }
 
@@ -97,8 +96,8 @@ export function createFeatureFlagAdminRouter(
         res.json({ success: true, data: flag })
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
-        const status = message.includes('not found') ? 404 : 400
-        res.status(status).json({ error: message })
+        const code = message.includes('not found') ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_FAILED
+        sendError(res, code, message)
       }
     },
   )
@@ -112,7 +111,7 @@ export function createFeatureFlagAdminRouter(
     async (req: Request, res: Response) => {
       const parsed = setOverrideBodySchema.safeParse(req.body)
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Validation error', details: parsed.error.issues })
+        sendError(res, ErrorCode.VALIDATION_FAILED, parsed.error.issues[0]?.message ?? 'Validation error', parsed.error.issues)
         return
       }
 
@@ -123,8 +122,8 @@ export function createFeatureFlagAdminRouter(
         res.status(201).json({ success: true, data: override })
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
-        const status = message.includes('not found') ? 404 : 400
-        res.status(status).json({ error: message })
+        const code = message.includes('not found') ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_FAILED
+        sendError(res, code, message)
       }
     },
   )
@@ -142,8 +141,8 @@ export function createFeatureFlagAdminRouter(
         res.json({ success: true })
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
-        const status = message.includes('not found') ? 404 : 400
-        res.status(status).json({ error: message })
+        const code = message.includes('not found') ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_FAILED
+        sendError(res, code, message)
       }
     },
   )
@@ -163,7 +162,7 @@ export function createFeatureFlagAdminRouter(
     async (req: Request, res: Response) => {
       const parsed = setTenantRolloutBodySchema.safeParse(req.body)
       if (!parsed.success) {
-        res.status(400).json({ error: parsed.error.issues[0]?.message ?? 'Validation error', details: parsed.error.issues })
+        sendError(res, ErrorCode.VALIDATION_FAILED, parsed.error.issues[0]?.message ?? 'Validation error', parsed.error.issues)
         return
       }
 
@@ -179,8 +178,8 @@ export function createFeatureFlagAdminRouter(
         res.status(201).json({ success: true, data: tenantRollout })
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
-        const status = message.includes('not found') ? 404 : 400
-        res.status(status).json({ error: message })
+        const code = message.includes('not found') ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_FAILED
+        sendError(res, code, message)
       }
     },
   )
@@ -198,8 +197,8 @@ export function createFeatureFlagAdminRouter(
         res.json({ success: true })
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error'
-        const status = message.includes('not found') ? 404 : 400
-        res.status(status).json({ error: message })
+        const code = message.includes('not found') ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_FAILED
+        sendError(res, code, message)
       }
     },
   )

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -16,7 +16,7 @@ import {
 import { AdminService } from "../../services/admin/index.js";
 import { auditLogService, AuditAction } from "../../services/audit/index.js";
 import { impersonationService } from "../../services/impersonation/index.js";
-import { AppError, ErrorCode, ValidationError } from "../../lib/errors.js";
+import { AppError, ErrorCode, ValidationError, sendError } from "../../lib/errors.js";
 import type {
   AssignRoleRequest,
   RevokeApiKeyRequest,
@@ -151,7 +151,7 @@ export function createAdminRouter(): Router {
         validateConfig(candidateEnv as any);
       } catch (err: any) {
         if (err instanceof ConfigValidationError) {
-          res.status(400).json({ error: 'ConfigValidationError', message: 'Vault secrets validation failed', issues: err.issues });
+          sendError(res, ErrorCode.VALIDATION_FAILED, 'Vault secrets validation failed', err.issues)
           return;
         }
         throw err;
@@ -235,7 +235,7 @@ export function createAdminRouter(): Router {
       const body = req.body as Partial<IssueImpersonationTokenRequest>
 
       if (!body.targetUserId || !body.reason) {
-        res.status(400).json({ error: 'BadRequest', message: 'targetUserId and reason are required' })
+        sendError(res, ErrorCode.FIELD_REQUIRED, 'targetUserId and reason are required')
         return
       }
 
@@ -257,10 +257,10 @@ export function createAdminRouter(): Router {
       const message =
         error instanceof Error ? error.message : "Unknown error";
       if (/User not found/i.test(message)) {
-        res.status(404).json({ error: "NotFound", message });
+        sendError(res, ErrorCode.NOT_FOUND, message)
         return;
       }
-      res.status(400).json({ error: "BadRequest", message });
+      sendError(res, ErrorCode.VALIDATION_FAILED, message)
     }
   });
 
@@ -276,7 +276,7 @@ export function createAdminRouter(): Router {
     const { tokenId } = req.params
 
     if (!tokenId) {
-      res.status(400).json({ error: 'InvalidRequest', message: 'tokenId is required' })
+      sendError(res, ErrorCode.FIELD_REQUIRED, 'tokenId is required')
       return
     }
 
@@ -286,10 +286,10 @@ export function createAdminRouter(): Router {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error'
       if (/Token not found/i.test(message)) {
-        res.status(404).json({ error: 'NotFound', message })
+        sendError(res, ErrorCode.NOT_FOUND, message)
         return
       }
-      res.status(400).json({ error: "BadRequest", message });
+      sendError(res, ErrorCode.VALIDATION_FAILED, message)
     }
   });
 
@@ -504,7 +504,7 @@ export function createAdminRouter(): Router {
 
         res.status(200).json({ success: true, data: result })
       } catch (error: any) {
-        res.status(400).json({ error: 'ReplayFailed', message: error.message })
+        sendError(res, ErrorCode.VALIDATION_FAILED, error.message)
       }
     }
   )

--- a/src/routes/admin/member.ts
+++ b/src/routes/admin/member.ts
@@ -37,6 +37,7 @@ import { auditLogService } from '../../services/audit/index.js'
 import type { MemberRole } from '../../services/members/types.js'
 import { MemberService } from '../../services/members/factory.ts'
 import { MemberRepository } from '../../repositories/member.repository.ts'
+import { sendError, ErrorCode } from '../../lib/errors.js'
 
 const VALID_MEMBER_ROLES: MemberRole[] = ['owner', 'admin', 'member']
 
@@ -75,11 +76,7 @@ export function createMembersRouter(): Router {
         pagination = parsePaginationParams(req.query as Record<string, unknown>, { defaultLimit: 50 })
       } catch (err) {
         if (err instanceof PaginationValidationError) {
-          res.status(400).json({
-            error: 'InvalidRequest',
-            message: 'Invalid pagination parameters',
-            details: err.details,
-          })
+          sendError(res, ErrorCode.VALIDATION_FAILED, 'Invalid pagination parameters', err.details)
           return
         }
         throw err
@@ -141,10 +138,7 @@ export function createMembersRouter(): Router {
 
 
       if (role && !VALID_MEMBER_ROLES.includes(role as MemberRole)) {
-        res.status(400).json({
-          error: 'InvalidRequest',
-          message: `Invalid role. Must be one of: ${VALID_MEMBER_ROLES.join(', ')}`,
-        })
+        sendError(res, ErrorCode.VALIDATION_FAILED, `Invalid role. Must be one of: ${VALID_MEMBER_ROLES.join(', ')}`)
         return
       }
 
@@ -159,10 +153,8 @@ export function createMembersRouter(): Router {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       const isConflict = message.includes('already active')
-      res.status(isConflict ? 409 : 400).json({
-        error: isConflict ? 'Conflict' : 'BadRequest',
-        message,
-      })
+      const code = isConflict ? ErrorCode.CONFLICT : ErrorCode.VALIDATION_FAILED
+      sendError(res, code, message)
     }
   })
 
@@ -195,10 +187,8 @@ export function createMembersRouter(): Router {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       const isNotFound = message.includes('not found')
-      res.status(isNotFound ? 404 : 400).json({
-        error: isNotFound ? 'NotFound' : 'BadRequest',
-        message,
-      })
+      const code = isNotFound ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_FAILED
+      sendError(res, code, message)
     }
   })
 
@@ -226,10 +216,8 @@ export function createMembersRouter(): Router {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       const isNotFound = message.includes('not found') || message.includes('already deleted')
-      res.status(isNotFound ? 404 : 400).json({
-        error: isNotFound ? 'NotFound' : 'BadRequest',
-        message,
-      })
+      const code = isNotFound ? ErrorCode.NOT_FOUND : ErrorCode.VALIDATION_FAILED
+      sendError(res, code, message)
     }
   })
 
@@ -257,14 +245,14 @@ export function createMembersRouter(): Router {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
       if (message.includes('already exists')) {
-        res.status(409).json({ error: 'Conflict', message })
+        sendError(res, ErrorCode.CONFLICT, message)
         return
       }
       if (message.includes('not found') || message.includes('already active')) {
-        res.status(404).json({ error: 'NotFound', message })
+        sendError(res, ErrorCode.NOT_FOUND, message)
         return
       }
-      res.status(500).json({ error: 'InternalError', message })
+      sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, message)
     }
   })
 

--- a/src/routes/admin/migrations.ts
+++ b/src/routes/admin/migrations.ts
@@ -10,6 +10,7 @@ import {
   migrationsDryRunBodySchema,
 } from '../../schemas/admin.js'
 import { dryRunMigration } from '../../migrations/runner.js'
+import { sendError, ErrorCode } from '../../lib/errors.js'
 
 const router = Router()
 
@@ -39,11 +40,7 @@ router.get(
       })
 
       if (!result.success) {
-        return res.status(400).json({
-          success: false,
-          error: 'MigrationDryRunFailed',
-          message: result.error ?? 'Failed to execute migration dry run',
-        })
+        return sendError(res, ErrorCode.VALIDATION_FAILED, result.error ?? 'Failed to execute migration dry run')
       }
 
       const sqlStatements = result.sql ?? []
@@ -89,11 +86,7 @@ router.post(
       })
 
       if (!result.success) {
-        return res.status(400).json({
-          success: false,
-          error: 'MigrationDryRunFailed',
-          message: result.error ?? 'Failed to execute migration dry run',
-        })
+        return sendError(res, ErrorCode.VALIDATION_FAILED, result.error ?? 'Failed to execute migration dry run')
       }
 
       const sqlStatements = result.sql ?? []

--- a/src/routes/admin/outbox.ts
+++ b/src/routes/admin/outbox.ts
@@ -11,6 +11,7 @@ import {
   requireUserAuth,
 } from '../../middleware/auth.js'
 import { auditLogService, AuditAction } from '../../services/audit/index.js'
+import { sendError, ErrorCode } from '../../lib/errors.js'
 
 const quarantineReasons = new Set<OutboxQuarantineReason>([
   'malformed_json',
@@ -58,7 +59,7 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
         })
         const reason = typeof req.query.reason === 'string' ? req.query.reason : undefined
         if (reason && !quarantineReasons.has(reason as OutboxQuarantineReason)) {
-          res.status(400).json({ error: 'InvalidReason', message: `Unsupported quarantine reason: ${reason}` })
+          sendError(res, ErrorCode.VALIDATION_FAILED, `Unsupported quarantine reason: ${reason}`)
           return
         }
 
@@ -104,7 +105,7 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
         const payload = req.body?.payload
         const requestId = (req as any).requestId
         if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
-          res.status(400).json({ error: 'InvalidPayload', message: 'payload must be a JSON object' })
+          sendError(res, ErrorCode.VALIDATION_FAILED, 'payload must be a JSON object')
           return
         }
 
@@ -115,7 +116,7 @@ export function createOutboxAdminRouter(repository = new OutboxRepository()): Ro
 
         const newEventId = await repository.reinjectQuarantined(pool, id, payload as Record<string, unknown>, actorId)
         if (!newEventId) {
-          res.status(404).json({ error: 'NotFound', message: 'Quarantined event not found or already reinjected' })
+          sendError(res, ErrorCode.NOT_FOUND, 'Quarantined event not found or already reinjected')
           return
         }
 

--- a/src/routes/admin/webhooks.ts
+++ b/src/routes/admin/webhooks.ts
@@ -4,6 +4,7 @@ import { PostgresWebhookRepository } from '../../db/repositories/webhookReposito
 import { pool } from '../../db/pool.js'
 import { AuthenticatedRequest, requireUserAuth, requireAdminRole, requireApiKey, ApiScope } from '../../middleware/auth.js'
 import { auditLogService } from '../../services/audit/index.js'
+import { sendError, ErrorCode } from '../../lib/errors.js'
 
 /**
  * Create the webhook admin router.
@@ -43,8 +44,7 @@ export function createWebhookAdminRouter(): Router {
         }
       })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      res.status(400).json({ error: message })
+      sendError(res, ErrorCode.VALIDATION_FAILED, err instanceof Error ? err.message : 'Unknown error')
     }
   })
 
@@ -69,8 +69,7 @@ export function createWebhookAdminRouter(): Router {
         message: 'Previous secret revoked successfully'
       })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      res.status(400).json({ error: message })
+      sendError(res, ErrorCode.VALIDATION_FAILED, err instanceof Error ? err.message : 'Unknown error')
     }
   })
 

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -16,7 +16,7 @@ import { InMemoryApiKeyRepository } from '../repositories/apiKeyRepository.js'
 import { ApiKeyRotationService } from '../services/apiKeyRotationService.js'
 import { auditLogService } from '../services/audit/index.js'
 import type { KeyScope, SubscriptionTier } from '../services/apiKeys.js'
-import { ValidationError, NotFoundError, ForbiddenError } from '../lib/errors.js'
+import { ValidationError, NotFoundError, ForbiddenError, sendError, ErrorCode } from '../lib/errors.js'
 
 const VALID_SCOPES: KeyScope[] = ['read', 'full']
 const VALID_TIERS: SubscriptionTier[] = ['free', 'pro', 'enterprise']
@@ -93,10 +93,7 @@ export function createApiKeyRouter(
 
       if (!newKey) {
         // Key existed but was already revoked — conflict.
-        res.status(409).json({
-          error: 'Conflict',
-          message: 'API key is already revoked and cannot be rotated',
-        })
+        sendError(res, ErrorCode.CONFLICT, 'API key is already revoked and cannot be rotated')
         return
       }
 

--- a/src/routes/auditLog.ts
+++ b/src/routes/auditLog.ts
@@ -5,6 +5,7 @@ import { rateLimit } from '../middleware/rateLimit.js'
 import { auditLogService } from '../services/audit/index.js'
 import type { AuditLogService } from '../services/audit/index.js'
 import { loadConfig } from '../config/index.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 const EXPORT_RATE_LIMIT = rateLimit({
   namespace: 'ratelimit:audit-export',
@@ -55,17 +56,14 @@ export function createAuditLogRouter(service: AuditLogService = auditLogService)
       const to = req.query.to ? new Date(req.query.to as string) : now
 
       if (isNaN(from.getTime()) || isNaN(to.getTime())) {
-        res.status(400).json({ error: 'InvalidDateRange', message: 'from/to must be valid ISO date strings' })
+        sendError(res, ErrorCode.VALIDATION_FAILED, 'from/to must be valid ISO date strings')
         return
       }
 
       // Validate export window is not too large
       const windowMs = to.getTime() - from.getTime()
       if (windowMs > maxWindowMs) {
-        res.status(400).json({
-          error: 'WindowTooLarge',
-          message: `Export window cannot exceed ${maxWindowDays} days`,
-        })
+        sendError(res, ErrorCode.VALIDATION_FAILED, `Export window cannot exceed ${maxWindowDays} days`)
         return
       }
 
@@ -102,7 +100,7 @@ export function createAuditLogRouter(service: AuditLogService = auditLogService)
         }
 
         if (!res.headersSent) {
-          res.status(500).json({ error: 'ExportFailed', message: 'Failed to export audit logs' })
+          sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, 'Failed to export audit logs')
         } else {
           res.end()
         }

--- a/src/routes/bond.ts
+++ b/src/routes/bond.ts
@@ -3,7 +3,7 @@ import type { BondService } from '../services/bond/index.js'
 import { deriveBondPaymentStatus } from '../services/bond/index.js'
 import { validate, type ValidatedRequest } from '../middleware/validate.js'
 import { bondPathParamsSchema, type BondPathParams } from '../schemas/index.js'
-import { NotFoundError } from '../lib/errors.js'
+import { NotFoundError, sendError, ErrorCode } from '../lib/errors.js'
 
 /**
  * Builds the bond status router.
@@ -61,7 +61,7 @@ export function createBondRouter(bondService: BondService): Router {
    * Creates or tops up a bond. Stub — full implementation pending on-chain write layer.
    */
   router.post('/', (_req: Request, res: Response) => {
-    res.status(501).json({ error: 'Not implemented' })
+    sendError(res, ErrorCode.SERVICE_UNAVAILABLE, 'Not implemented', undefined, 501)
   })
 
   return router

--- a/src/routes/disputes.ts
+++ b/src/routes/disputes.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express'
 import { type AuthenticatedRequest, requireUserAuth } from '../middleware/auth.js'
 import { ErrorCode, getErrorCatalogEntry } from '../lib/errorCatalog.js'
+import { sendError } from '../lib/errors.js'
 import {
   dismissDispute,
   getDispute,
@@ -67,7 +68,7 @@ router.post('/', requireUserAuth, async (req: Request, res: Response) => {
       status: 'failure',
       errorMessage: message,
     })
-    res.status(400).json({ error: 'BadRequest', message })
+    sendError(res, ErrorCode.VALIDATION_FAILED, message)
   }
 })
 
@@ -77,7 +78,7 @@ router.get('/', requireUserAuth, (req: Request, res: Response) => {
 
   const status = req.query.status as string | undefined
   if (status && !DISPUTE_STATES.includes(status as any)) {
-    res.status(400).json({ error: 'BadRequest', message: `Invalid status: ${status}` })
+    sendError(res, ErrorCode.VALIDATION_FAILED, `Invalid status: ${status}`)
     return
   }
 
@@ -86,10 +87,10 @@ router.get('/', requireUserAuth, (req: Request, res: Response) => {
     pag = parsePaginationParams(req.query, { maxLimit: MAX_LIMIT })
   } catch (error) {
     if (error instanceof PaginationValidationError) {
-      res.status(400).json({ error: 'BadRequest', message: error.details[0]?.message || 'Invalid pagination parameters' })
+      sendError(res, ErrorCode.VALIDATION_FAILED, error.details[0]?.message || 'Invalid pagination parameters')
       return
     }
-    res.status(400).json({ error: 'BadRequest', message: 'Invalid pagination parameters' })
+    sendError(res, ErrorCode.VALIDATION_FAILED, 'Invalid pagination parameters')
     return
   }
 
@@ -112,7 +113,7 @@ router.get('/', requireUserAuth, (req: Request, res: Response) => {
 router.get('/:id', requireUserAuth, (req: Request, res: Response) => {
   const dispute = getDispute(req.params.id)
   if (!dispute) {
-    res.status(404).json({ error: 'NotFound', message: 'Dispute not found' })
+    sendError(res, ErrorCode.NOT_FOUND, 'Dispute not found')
     return
   }
 

--- a/src/routes/evidence.ts
+++ b/src/routes/evidence.ts
@@ -12,6 +12,7 @@ import {
 import { EvidenceStorageService, type Role } from '../services/evidence/storage.js'
 import { auditLogService, AuditAction } from '../services/audit/index.js'
 import { register } from '../middleware/metrics.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 const router = Router()
 let storageService: EvidenceStorageService | null = null
@@ -342,7 +343,7 @@ router.post(
         status: 'failure',
         errorMessage: message,
       })
-      res.status(400).json({ error: 'BadRequest', message })
+      sendError(res, ErrorCode.VALIDATION_FAILED, message)
     }
   }
 )
@@ -382,16 +383,16 @@ router.get('/:evidenceId', requireUserAuth, async (req: Request, res: Response) 
     })
 
     if (message.includes('Unauthorized')) {
-      res.status(403).json({ error: 'Forbidden', message })
+      sendError(res, ErrorCode.FORBIDDEN, message)
       return
     }
 
     if (message.includes('not found')) {
-      res.status(404).json({ error: 'NotFound', message })
+      sendError(res, ErrorCode.NOT_FOUND, message)
       return
     }
 
-    res.status(400).json({ error: 'BadRequest', message })
+    sendError(res, ErrorCode.VALIDATION_FAILED, message)
   }
 })
 

--- a/src/routes/governance.ts
+++ b/src/routes/governance.ts
@@ -20,6 +20,7 @@ import {
   type SubmitVoteBody,
   type SlashRequestPathParams,
 } from '../schemas/governance.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 const router = Router()
 
@@ -64,7 +65,7 @@ router.post(
         errorMessage: message,
       })
 
-      res.status(400).json({ error: 'BadRequest', message })
+      sendError(res, ErrorCode.VALIDATION_FAILED, message)
     }
   }
 )
@@ -84,7 +85,7 @@ router.post(
       const result = submitVote(requestId, voterId, choice)
 
       if (!result) {
-        res.status(404).json({ error: 'NotFound', message: 'Slash request not found' })
+        sendError(res, ErrorCode.NOT_FOUND, 'Slash request not found')
         return
       }
 
@@ -123,7 +124,8 @@ router.post(
       })
 
       const errorType = isDuplicateVoteError ? 'Conflict' : 'BadRequest'
-      res.status(statusCode).json({ error: errorType, message })
+      const code = isDuplicateVoteError ? ErrorCode.CONFLICT : ErrorCode.VALIDATION_FAILED
+      sendError(res, code, message)
     }
   }
 )
@@ -136,7 +138,7 @@ router.get(
     const validatedReq = req as ValidatedRequest<SlashRequestPathParams>
     const request = getSlashRequest(validatedReq.validated.params.id)
     if (!request) {
-      res.status(404).json({ error: 'NotFound', message: 'Slash request not found' })
+      sendError(res, ErrorCode.NOT_FOUND, 'Slash request not found')
       return
     }
     res.status(200).json(request)

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -4,6 +4,7 @@ import type { HealthProbe } from '../services/health/index.js'
 import type { RedisClient } from '../cache/redis.js'
 import { WorkerHealthService } from '../services/workerHealth.js'
 import { getVersionMetadata } from '../utils/version.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 export interface HealthRouterOptions {
   /** DB probe; when omitted, db is reported as not_configured. */
@@ -119,10 +120,7 @@ export function createHealthRouter(options: HealthRouterOptions = {}): Router {
         const result = await workerHealthService.getWorkerStatuses()
         res.status(200).json(result)
       } catch {
-        res.status(503).json({
-          workers: [],
-          error: 'Unable to query worker health',
-        })
+        sendError(res, ErrorCode.SERVICE_UNAVAILABLE, 'Unable to query worker health')
       }
     })
   }

--- a/src/routes/jwks.ts
+++ b/src/routes/jwks.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express'
 import { keyManager } from '../services/keyManager/index.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 /**
  * Creates the router for the JWK Set (JWKS) endpoint.
@@ -39,7 +40,7 @@ export function createJwksRouter(): Router {
         .set('Cache-Control', 'public, max-age=300, stale-while-revalidate=60')
         .json(jwks)
     } catch {
-      res.status(503).json({ error: 'Key manager not initialized' })
+      sendError(res, ErrorCode.SERVICE_UNAVAILABLE, 'Key manager not initialized')
     }
   })
 

--- a/src/routes/policy.ts
+++ b/src/routes/policy.ts
@@ -32,6 +32,7 @@ import {
   type PolicyOrgPathParams,
   type PolicyRulePathParams,
 } from '../schemas/policy.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 export function createPolicyRouter(): Router {
   const router = Router({ mergeParams: true })
@@ -60,7 +61,7 @@ export function createPolicyRouter(): Router {
         })
         res.status(201).json({ success: true, data: rule })
       } catch (err) {
-        res.status(500).json({ error: err instanceof Error ? err.message : 'Unknown error' })
+        sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, err instanceof Error ? err.message : 'Unknown error')
       }
     },
   )
@@ -94,7 +95,7 @@ export function createPolicyRouter(): Router {
       const validatedReq = req as ValidatedRequest<PolicyRulePathParams>
       const rule = policyService.getRule(validatedReq.validated.params.ruleId)
       if (!rule) {
-        res.status(404).json({ error: 'Rule not found' })
+        sendError(res, ErrorCode.NOT_FOUND, 'Rule not found')
         return
       }
       res.json({ success: true, data: rule })
@@ -122,7 +123,8 @@ export function createPolicyRouter(): Router {
         res.json({ success: true, data: rule })
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Unknown error'
-        res.status(msg.includes('not found') ? 404 : 500).json({ error: msg })
+        const code = msg.includes('not found') ? ErrorCode.NOT_FOUND : ErrorCode.INTERNAL_SERVER_ERROR
+        sendError(res, code, msg)
       }
     },
   )
@@ -142,7 +144,8 @@ export function createPolicyRouter(): Router {
         res.status(204).send()
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Unknown error'
-        res.status(msg.includes('not found') ? 404 : 500).json({ error: msg })
+        const code = msg.includes('not found') ? ErrorCode.NOT_FOUND : ErrorCode.INTERNAL_SERVER_ERROR
+        sendError(res, code, msg)
       }
     },
   )

--- a/src/routes/report.ts
+++ b/src/routes/report.ts
@@ -13,6 +13,7 @@ import {
   type ReportJobParams,
 } from "../schemas/report.js";
 import { auditLogService } from "../services/audit/index.js";
+import { sendError, ErrorCode } from "../lib/errors.js";
 
 const router = Router();
 const reportRepository = new ReportRepository(pool);
@@ -45,10 +46,7 @@ router.get(
       });
     } catch (error) {
       console.error("Top talkers report error:", error);
-      res.status(500).json({
-        error: "InternalServerError",
-        message: "An unexpected error occurred while fetching top talkers report",
-      });
+      sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, "An unexpected error occurred while fetching top talkers report");
     }
   },
 );
@@ -89,20 +87,14 @@ router.post(
         });
       } catch (error) {
         if (error instanceof Error && error.message.includes('maximum concurrent')) {
-          res.status(429).json({
-            error: "TooManyRequests",
-            message: error.message,
-          });
+          sendError(res, ErrorCode.RATE_LIMIT_EXCEEDED, error.message)
         } else {
           throw error;
         }
       }
     } catch (error) {
       console.error("Report generation error:", error);
-      res.status(500).json({
-        error: "InternalServerError",
-        message: "An unexpected error occurred while starting the report job",
-      });
+      sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, "An unexpected error occurred while starting the report job");
     }
   },
 );
@@ -130,10 +122,7 @@ router.get(
       const job = await reportService.getReportStatus(jobId);
 
       if (!job) {
-        res.status(404).json({
-          error: "NotFound",
-          message: `Report job ${jobId} not found`,
-        });
+        sendError(res, ErrorCode.NOT_FOUND, `Report job ${jobId} not found`);
         return;
       }
 
@@ -150,10 +139,7 @@ router.get(
       });
     } catch (error) {
       console.error("Report status query error:", error);
-      res.status(500).json({
-        error: "InternalServerError",
-        message: "An unexpected error occurred while fetching report status",
-      });
+      sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, "An unexpected error occurred while fetching report status");
     }
   },
 );
@@ -177,20 +163,14 @@ router.get(
       const signature = req.query.signature as string;
 
       if (!expires || !signature) {
-        res.status(400).json({
-          error: "InvalidRequest",
-          message: "Signed URL requires expires and signature query parameters",
-        });
+        sendError(res, ErrorCode.FIELD_REQUIRED, "Signed URL requires expires and signature query parameters");
         return;
       }
 
       const data = reportStorage.verifyAndRetrieve(key, expires, signature);
 
       if (!data) {
-        res.status(401).json({
-          error: "Unauthorized",
-          message: "Invalid or expired signed URL",
-        });
+        sendError(res, ErrorCode.UNAUTHORIZED, "Invalid or expired signed URL");
         return;
       }
 
@@ -202,10 +182,7 @@ router.get(
       res.status(200).send(data);
     } catch (error) {
       console.error("Report download error:", error);
-      res.status(500).json({
-        error: "InternalServerError",
-        message: "An unexpected error occurred while downloading the report",
-      });
+      sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, "An unexpected error occurred while downloading the report");
     }
   },
 );

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -4,6 +4,7 @@ import { WebhookRotationService, WebhookNotFoundError } from '../services/webhoo
 import type { WebhookStore } from '../services/webhooks/types.js'
 import type { AuditLogService } from '../services/audit/index.js'
 import { getTenantId, setTenantId } from '../utils/tenantContext.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 /**
  * Create the webhook management router.
@@ -67,18 +68,11 @@ export function createWebhookRouter(store: WebhookStore, audit: AuditLogService)
         })
       } catch (err) {
         if (err instanceof WebhookNotFoundError) {
-          res.status(404).json({
-            error: 'NotFound',
-            message: err.message,
-          })
+          sendError(res, ErrorCode.NOT_FOUND, err.message)
           return
         }
 
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        res.status(500).json({
-          error: 'InternalError',
-          message,
-        })
+        sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, err instanceof Error ? err.message : 'Unknown error')
       } finally {
         // Restore original tenant context
         if (!originalTenant) {


### PR DESCRIPTION
- Add sendError() helper that produces standardized { error, code, error_code } envelope
- Add ErrorResponse OpenAPI schema to docs/openapi.yaml
- Update 19 route files to use sendError() instead of ad-hoc error responses
- Add sendError() tests covering happy path, production mode, and status override
- Closes #895