### PR TITLE
Feat/887 expose db pool size config #Closes 887

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,12 @@ DB_POOL_CONNECTION_TIMEOUT_MS=5000
 DB_STATEMENT_TIMEOUT_MS=30000
 # Maximum connections in the worker pool for background jobs (default: 5)
 DB_WORKER_POOL_MAX=5
+# Maximum connections in the read-replica pool. Optional — falls back to
+# DB_POOL_MAX when unset, so most setups don't need to touch this.
+# DB_REPLICA_POOL_MAX=20
+# Maximum acceptable replication lag (ms) before reads fall back to the
+# primary pool (default: 1000)
+MAX_REPLICA_LAG_MS=1000
 # Minimum query duration (ms) that triggers a slow-query log entry with the
 # query's EXPLAIN plan attached. Set to 0 to disable. (default: 1000)
 SLOW_QUERY_THRESHOLD_MS=1000

--- a/README.md
+++ b/README.md
@@ -383,8 +383,10 @@ try {
 | `ANALYTICS_REFRESH_CRON`      | No       | `*/5 * * * *` | Refresh cadence for analytics materialized view        |
 | `ANALYTICS_STALENESS_SECONDS` | No       | `300`         | Max acceptable analytics staleness before marked stale |
 | `DB_POOL_IDLE_TIMEOUT_MS`     | No       | `300000`      | Milliseconds a pooled connection may stay idle before being closed. Kills idle connections to keep pool counts predictable. |
-| `DB_POOL_MAX`                 | No       | `20`          | Maximum connections in the primary / replica pools     |
+| `DB_POOL_MAX`                 | No       | `20`          | Maximum connections in the primary pool                |
 | `DB_WORKER_POOL_MAX`          | No       | `5`           | Maximum connections in the background-worker pool      |
+| `DB_REPLICA_POOL_MAX`         | No       | `DB_POOL_MAX` | Maximum connections in the read-replica pool; falls back to `DB_POOL_MAX` when unset |
+| `MAX_REPLICA_LAG_MS`          | No       | `1000`        | Max replication lag (ms) before reads fall back to the primary pool |
 | `DB_POOL_CONNECTION_TIMEOUT_MS` | No     | `5000`        | Milliseconds to wait for an available connection       |
 | `DB_STATEMENT_TIMEOUT_MS`     | No       | `30000`       | Per-statement timeout; kills runaway queries           |
 

--- a/docs/CONFIG_TEMPLATE.md
+++ b/docs/CONFIG_TEMPLATE.md
@@ -55,6 +55,8 @@ At startup the app parses `process.env` through a Zod schema (`envSchema` in
 | `DB_POOL_CONNECTION_TIMEOUT_MS` | `5000` | 1000–30000 | Wait for a free connection before erroring. |
 | `DB_STATEMENT_TIMEOUT_MS` | `30000` | ≥ 0 | Per-statement timeout; kills runaway queries. |
 | `DB_WORKER_POOL_MAX` | `5` | 1–50 | Separate pool for background jobs. |
+| `DB_REPLICA_POOL_MAX` | `DB_POOL_MAX` | 1–200 (optional) | Max connections in the read-replica pool; falls back to `DB_POOL_MAX` when unset. |
+| `MAX_REPLICA_LAG_MS` | `1000` | ≥ 0 | Max replication lag before `withReplica()` falls back to the primary pool. |
 | `DB_LOCK_TIMEOUT_READONLY_MS` | `1000` | 100–30000 | Lock timeout for read-only queries. See [lock-timeout-configuration.md](lock-timeout-configuration.md). |
 | `DB_LOCK_TIMEOUT_DEFAULT_MS` | `2000` | 100–30000 | Standard read-modify-write operations. |
 | `DB_LOCK_TIMEOUT_CRITICAL_MS` | `10000` | 100–60000 | Critical flows that may wait longer. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,7 @@ The application requires the following key environment variables, validated at s
 |----------|-------------|----------|
 | `DATABASE_URL` | PostgreSQL connection string | **Yes** |
 | `DB_REPLICA_URL` | PostgreSQL connection string for the read replica | No (Falls back to primary) |
+| `DB_REPLICA_POOL_MAX` | Max connections in the read-replica pool | No (Falls back to `DB_POOL_MAX`) |
 | `MAX_REPLICA_LAG_MS` | Max acceptable lag for replica reads | No (Default: 1000) |
 | `REDIS_URL` | Redis connection string | **Yes** |
 | `JWT_SECRET` | Secret for signing/verifying JWTs | **Yes** |

--- a/src/config/__tests__/config.test.ts
+++ b/src/config/__tests__/config.test.ts
@@ -269,6 +269,36 @@ describe('validateConfig – invalid values', () => {
   })
 })
 
+// ─── Database replica pool config (#887) ─────────────────────────────────────
+
+describe('validateConfig – database replica pool', () => {
+  it('falls back replicaPool.max to DB_POOL_MAX when DB_REPLICA_POOL_MAX is unset', () => {
+    const config = validateConfig(validEnv({ DB_POOL_MAX: '35' }))
+    expect(config.db.replicaPool.max).toBe(35)
+  })
+
+  it('uses DB_REPLICA_POOL_MAX when explicitly set, independent of DB_POOL_MAX', () => {
+    const config = validateConfig(validEnv({ DB_POOL_MAX: '20', DB_REPLICA_POOL_MAX: '8' }))
+    expect(config.db.pool.max).toBe(20)
+    expect(config.db.replicaPool.max).toBe(8)
+  })
+
+  it('rejects a DB_REPLICA_POOL_MAX outside the 1-200 range (failure mode)', () => {
+    expect(() => validateConfig(validEnv({ DB_REPLICA_POOL_MAX: '0' }))).toThrow(ConfigValidationError)
+    expect(() => validateConfig(validEnv({ DB_REPLICA_POOL_MAX: '500' }))).toThrow(ConfigValidationError)
+  })
+
+  it('defaults maxReplicaLagMs to 1000ms when MAX_REPLICA_LAG_MS is unset', () => {
+    const config = validateConfig(validEnv())
+    expect(config.db.maxReplicaLagMs).toBe(1000)
+  })
+
+  it('honors an explicit MAX_REPLICA_LAG_MS override', () => {
+    const config = validateConfig(validEnv({ MAX_REPLICA_LAG_MS: '2500' }))
+    expect(config.db.maxReplicaLagMs).toBe(2500)
+  })
+})
+
 // ─── ConfigValidationError ───────────────────────────────────────────────────
 
 describe('ConfigValidationError', () => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -75,6 +75,30 @@ export const envSchema = z.object({
     .default('5')
     .transform(Number)
     .pipe(z.number().int().min(1).max(50)),
+  /**
+   * Maximum connections in the read-replica pool. Falls back to DB_POOL_MAX
+   * when unset, so a single knob resizes the primary pool and the replica
+   * pool together by default. Set explicitly if the replica node should run
+   * with a different connection budget than the primary (#887).
+   */
+  DB_REPLICA_POOL_MAX: z
+    .string()
+    .optional()
+    .transform((val) => (val !== undefined && val !== '' ? Number(val) : undefined))
+    .pipe(z.union([z.undefined(), z.number().int().min(1).max(200)])),
+  /**
+   * Maximum acceptable replication lag (ms) before withReplica() falls back
+   * to the primary pool. Default: 1000 ms.
+   *
+   * Deliberately kept without a DB_ prefix to match the existing documented
+   * name in docs/architecture.md — renaming would silently break any
+   * deployment that already sets this variable.
+   */
+  MAX_REPLICA_LAG_MS: z
+    .string()
+    .default('1000')
+    .transform(Number)
+    .pipe(z.number().int().min(0)),
   DB_LOCK_TIMEOUT_READONLY_MS: z
     .string()
     .default('1000')
@@ -470,6 +494,12 @@ export interface Config {
     workerPool: {
       max: number
     }
+    replicaPool: {
+      /** Maximum connections in the read-replica pool. Defaults to db.pool.max when DB_REPLICA_POOL_MAX is unset. */
+      max: number
+    }
+    /** Maximum acceptable replica lag (ms) before withReplica() falls back to the primary pool. */
+    maxReplicaLagMs: number
     /** Minimum query duration (ms) that triggers a slow-query log entry. 0 disables. */
     slowQueryThresholdMs: number
   }
@@ -683,6 +713,11 @@ function mapEnvToConfig(env: Env): Config {
       workerPool: {
         max: env.DB_WORKER_POOL_MAX,
       },
+      replicaPool: {
+        // Fall back to the primary pool size when not explicitly configured.
+        max: env.DB_REPLICA_POOL_MAX ?? env.DB_POOL_MAX,
+      },
+      maxReplicaLagMs: env.MAX_REPLICA_LAG_MS,
       slowQueryThresholdMs: env.SLOW_QUERY_THRESHOLD_MS,
     },
     redis: {

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Pool } from 'pg'
 
+// pool.ts now sources its settings from loadConfig() (see #887), which
+// validates the *entire* app config, not just DB settings. These are the
+// minimal required vars for that validation to succeed in isolation.
+const REQUIRED_ENV: Record<string, string> = {
+  DB_URL: 'postgresql://user:pass@localhost:5432/credence',
+  REDIS_URL: 'redis://localhost:6379',
+  JWT_SECRET: 'a]r$8kL!qZ3wX#mN9pT&vB6yD0fH2jU4',
+}
+
 describe('DB Pool configuration', () => {
   let envSnapshot: NodeJS.ProcessEnv
 
   beforeEach(() => {
     envSnapshot = { ...process.env }
+    Object.assign(process.env, REQUIRED_ENV)
   })
 
   afterEach(() => {
@@ -75,6 +85,30 @@ describe('DB Pool configuration', () => {
     const { pool, replicaPool } = await import('./pool.js')
     expect(replicaPool).toBeInstanceOf(Pool)
     expect(replicaPool).not.toBe(pool)
+  })
+
+  it('replicaPool.options.max defaults to DB_POOL_MAX when DB_REPLICA_POOL_MAX is unset (#887)', async () => {
+    process.env.DB_POOL_MAX = '17'
+    delete process.env.DB_REPLICA_POOL_MAX
+    vi.resetModules()
+    const { pool, replicaPool } = await import('./pool.js')
+    expect(pool.options.max).toBe(17)
+    expect(replicaPool.options.max).toBe(17)
+  })
+
+  it('replicaPool.options.max honors DB_REPLICA_POOL_MAX independently of DB_POOL_MAX (#887)', async () => {
+    process.env.DB_POOL_MAX = '20'
+    process.env.DB_REPLICA_POOL_MAX = '6'
+    vi.resetModules()
+    const { pool, replicaPool } = await import('./pool.js')
+    expect(pool.options.max).toBe(20)
+    expect(replicaPool.options.max).toBe(6)
+  })
+
+  it('falls back to loadConfig() default replica pool max when the app fails to start with a bad value (failure mode, #887)', async () => {
+    process.env.DB_REPLICA_POOL_MAX = 'not-a-number'
+    vi.resetModules()
+    await expect(import('./pool.js')).rejects.toThrow(/DB_REPLICA_POOL_MAX/)
   })
 
   it('rejects a tenant that exceeds its connection budget', async () => {

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,17 +1,20 @@
 import { Pool, type PoolClient, type QueryResult } from "pg";
-import dotenv from "dotenv";
 import { AppError, ErrorCode } from "../lib/errors.js";
 import { logger } from "../utils/logger.js";
 import { getTenantId } from "../utils/tenantContext.js";
 import { redact } from "../observability/redaction.js";
 import { LogEventType } from "../observability/logSchemas.js";
-
-dotenv.config();
+import { loadConfig } from "../config/index.js";
 
 /**
  * Parse a numeric environment variable with a fallback default.
  * Returns the fallback if the variable is missing or non-numeric.
  * @internal Exported for testing only.
+ * @deprecated Pool configuration is now sourced from the validated config
+ * module (DB_POOL_MAX, DB_WORKER_POOL_MAX, DB_REPLICA_POOL_MAX, etc. — see
+ * src/config/index.ts). Kept only for DB_TENANT_CONNECTION_BUDGET, which has
+ * no fixed default and is derived from POOL_MAX below. New pool settings
+ * should be added to the config module instead (#887).
  */
 export function envInt(key: string, fallback: number): number {
   const raw = process.env[key];
@@ -20,22 +23,28 @@ export function envInt(key: string, fallback: number): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
-const DB_URL = process.env.DB_URL;
-const POOL_MAX = envInt("DB_POOL_MAX", 20);
-const IDLE_TIMEOUT = envInt("DB_POOL_IDLE_TIMEOUT_MS", 300_000); // 5 minutes: kills idle connections to keep pool counts predictable
-const CONN_TIMEOUT = envInt("DB_POOL_CONNECTION_TIMEOUT_MS", 5_000);
-const STMT_TIMEOUT = envInt("DB_STATEMENT_TIMEOUT_MS", 30_000);
-const WORKER_MAX = envInt("DB_WORKER_POOL_MAX", 5);
+// Single source of truth for every pool tuning knob — validated once at
+// startup by src/config/index.ts rather than read ad hoc via process.env
+// throughout this module. See issue #887.
+const cfg = loadConfig();
+
+const DB_URL = cfg.db.url;
+const POOL_MAX = cfg.db.pool.max;
+const IDLE_TIMEOUT = cfg.db.pool.idleTimeoutMillis;
+const CONN_TIMEOUT = cfg.db.pool.connectionTimeoutMillis;
+const STMT_TIMEOUT = cfg.db.pool.statementTimeoutMs;
+const WORKER_MAX = cfg.db.workerPool.max;
+const REPLICA_MAX = cfg.db.replicaPool.max;
 
 /**
  * Minimum query duration (ms) that triggers a slow-query log entry with the
  * query's EXPLAIN plan attached. 0 disables slow-query logging entirely.
  * See docs/observability.md#slow-query-logging.
  */
-const SLOW_QUERY_THRESHOLD_MS = envInt("SLOW_QUERY_THRESHOLD_MS", 1_000);
+const SLOW_QUERY_THRESHOLD_MS = cfg.db.slowQueryThresholdMs;
 
 const DB_REPLICA_URL = process.env.DB_REPLICA_URL || DB_URL;
-const MAX_REPLICA_LAG_MS = envInt("MAX_REPLICA_LAG_MS", 1000);
+const MAX_REPLICA_LAG_MS = cfg.db.maxReplicaLagMs;
 const TENANT_CONNECTION_BUDGET = Math.max(1, Math.min(envInt("DB_TENANT_CONNECTION_BUDGET", Math.max(1, Math.floor(POOL_MAX / 4))), POOL_MAX));
 const tenantConnectionCounts = new Map<string, number>();
 
@@ -136,7 +145,7 @@ workerPool.on("error", (err) => {
  */
 export const replicaPool = withTenantConnectionBudget(new Pool({
   connectionString: DB_REPLICA_URL,
-  max: POOL_MAX,
+  max: REPLICA_MAX,
   idleTimeoutMillis: IDLE_TIMEOUT,
   connectionTimeoutMillis: CONN_TIMEOUT,
   options: `-c statement_timeout=${STMT_TIMEOUT}`,

--- a/tests/setup/reportTestEnv.ts
+++ b/tests/setup/reportTestEnv.ts
@@ -8,3 +8,21 @@
 if (!process.env.REPORT_STORAGE_SIGNING_SECRET) {
   process.env.REPORT_STORAGE_SIGNING_SECRET = 'test-secret-32chr-1234567890123456';
 }
+
+/**
+ * src/db/pool.ts now sources its settings from loadConfig() (#887), which
+ * validates the entire app config — not just DB vars. Any test that imports
+ * pool.ts, even indirectly (repositories, workers, the outbox publisher),
+ * needs these three required vars present or module load throws
+ * ConfigValidationError before a single test runs. Set only if unset, so a
+ * test file that already defines its own values isn't overridden.
+ */
+if (!process.env.DB_URL) {
+  process.env.DB_URL = 'postgresql://user:pass@localhost:5432/credence_test';
+}
+if (!process.env.REDIS_URL) {
+  process.env.REDIS_URL = 'redis://localhost:6379';
+}
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = 'test-jwt-secret-32-characters-long!';
+}


### PR DESCRIPTION
Summary

Expose the DB replica pool size as config.

Closes #887

Note on the issue text: this codebase uses raw pg (not Prisma) and Express (not NestJS), so the implementation hints don't literally apply. DB_POOL_MAX for the primary pool was already validated through the config module. The actual gap was narrower but real: the replica pool silently reused the primary pool's size instead of being independently configurable, and MAX_REPLICA_LAG_MS was still read via a raw envInt() call, bypassing the "inject through a config module, not deep in business logic" pattern this repo otherwise follows.

Changes
src/config/index.ts
Added DB_REPLICA_POOL_MAX — optional, falls back to DB_POOL_MAX when unset so nobody's forced to tune a new knob.
Brought the existing (previously raw-envInt) MAX_REPLICA_LAG_MS under the same zod validation as everything else.
src/db/pool.ts
All pool tuning now sourced from loadConfig() instead of scattered envInt() calls.
Fixed replicaPool to actually use its own configured max — it was previously hardcoded to the primary pool's POOL_MAX.
Kept MAX_REPLICA_LAG_MS un-prefixed (not renamed to DB_MAX_REPLICA_LAG_MS) since it's already documented in docs/architecture.md; renaming would have silently broken any deployment that already sets it.
Docs: .env.example, README.md, docs/CONFIG_TEMPLATE.md, docs/architecture.md. Also corrected a now-inaccurate README.md line that described DB_POOL_MAX as sizing "the primary / replica pools" — no longer true now that the replica pool has its own setting.
Tests
src/config/__tests__/config.test.ts: fallback-to-primary default, explicit independent override, and out-of-range rejection (1–200) for DB_REPLICA_POOL_MAX; default and override for MAX_REPLICA_LAG_MS.
src/db/pool.test.ts: confirms replicaPool.options.max actually follows DB_REPLICA_POOL_MAX (and falls back correctly when unset), plus an explicit failure-mode test for an invalid value.
tests/setup/reportTestEnv.ts: since pool.ts now validates the full app config at import time (not just DB vars), this seeds DB_URL, REDIS_URL, and JWT_SECRET globally when unset — following the same pattern already used there for REPORT_STORAGE_SIGNING_SECRET. Without this, any test importing pool.ts indirectly (repositories, the outbox publisher, slow-query logging) would fail with ConfigValidationError even though it never touched DB pooling.
Checklist
 Change matches the issue summary (DB pool size exposed as config, including the replica pool that wasn't yet covered).
 Tests cover happy path + explicit failure mode.
 npm run lint, tsc --noEmit, and the affected vitest suites all pass locally.
 Verified the one pre-existing failure in config.test.ts (CORS_ORIGIN production check) predates this branch and is untouched by this change.
Unrelated issue found during verification (not fixed here, out of scope)

src/config/constants.ts on main has an unresolved merge-conflict artifact — DEFAULT_TOP_TALKERS_WINDOW_MINUTES is declared twice, with a stray branch-name string in between, which breaks the file's parse and fails src/db/repositories/auditLogsRepository.test.ts regardless of this PR. Flagging separately rather than fixing here to keep this PR scoped to #887.