### PR TITLE
test: assert rate-limit headers match Free/Pro/Enterprise config

### DIFF
--- a/src/middleware/__tests__/rateLimit.test.ts
+++ b/src/middleware/__tests__/rateLimit.test.ts
@@ -434,6 +434,61 @@ describe('per-tier overrides', () => {
     expect(blocked.body.details).toMatchObject({ limit: 1 })
   })
 
+  it('x_ratelimit_limit_header_matches_config_across_free_pro_enterprise', async () => {
+    // Free vs Pro vs Enterprise X-RateLimit-Limit values must mirror config
+    // (production defaults and arbitrary overrides).
+    const defaultCfg = { maxFree: 100, maxPro: 1000, maxEnterprise: 10000 }
+    const customCfg = { maxFree: 9, maxPro: 42, maxEnterprise: 777 }
+
+    const cases: Array<{
+      tier: SubscriptionTier
+      config: typeof defaultCfg
+      expected: number
+      ns: string
+    }> = [
+      { tier: 'free', config: defaultCfg, expected: 100, ns: 'unit:hdr:def:free' },
+      { tier: 'pro', config: defaultCfg, expected: 1000, ns: 'unit:hdr:def:pro' },
+      { tier: 'enterprise', config: defaultCfg, expected: 10000, ns: 'unit:hdr:def:ent' },
+      { tier: 'free', config: customCfg, expected: 9, ns: 'unit:hdr:cus:free' },
+      { tier: 'pro', config: customCfg, expected: 42, ns: 'unit:hdr:cus:pro' },
+      { tier: 'enterprise', config: customCfg, expected: 777, ns: 'unit:hdr:cus:ent' },
+    ]
+
+    for (const { tier, config, expected, ns } of cases) {
+      fakeRedis.flush()
+      const app = buildApp({
+        namespace: ns,
+        config,
+        tier,
+        keyId: `key-${ns}`,
+        ownerId: `owner-${ns}`,
+      })
+      const res = await request(app).get('/api/ping')
+      expect(res.status).toBe(200)
+      expect(res.headers['x-ratelimit-limit']).toBe(String(expected))
+      expect(res.headers['x-ratelimit-remaining']).toBe(String(expected - 1))
+    }
+  })
+
+  it('x_ratelimit_limit_on_429_matches_tier_config_not_higher_tiers', async () => {
+    const cfg = { maxFree: 1, maxPro: 50, maxEnterprise: 200 }
+    const app = buildApp({
+      namespace: 'unit:hdr:sad:free',
+      config: cfg,
+      tier: 'free',
+      keyId: 'key-hdr-sad',
+      ownerId: 'owner-hdr-sad',
+    })
+
+    expect((await request(app).get('/api/ping')).status).toBe(200)
+    const blocked = await request(app).get('/api/ping')
+    expect(blocked.status).toBe(429)
+    expect(blocked.headers['x-ratelimit-limit']).toBe(String(cfg.maxFree))
+    expect(blocked.headers['x-ratelimit-remaining']).toBe('0')
+    expect(blocked.headers['retry-after']).toBeDefined()
+    expect(blocked.body.details).toMatchObject({ limit: cfg.maxFree })
+  })
+
   it('different_tiers_operate_independently_on_separate_tenant_buckets', async () => {
     // Two separate apps, same config, different tiers — each exhausts its
     // own bucket without affecting the other.

--- a/tests/routes/rateLimit.test.ts
+++ b/tests/routes/rateLimit.test.ts
@@ -344,6 +344,106 @@ describe('Rate Limit Middleware', () => {
       }
       expect((await request(app).get('/api/ping')).status).toBe(429)
     })
+
+    it('x_ratelimit_limit_header_matches_config_for_free_pro_and_enterprise_tiers', async () => {
+      // Lock Free / Pro / Enterprise header values to whatever the active
+      // config says — defaults (100 / 1000 / 10000) and custom overrides alike.
+      const cases: Array<{
+        tier: SubscriptionTier
+        config: Config['rateLimit']
+        expectedLimit: number
+        namespace: string
+      }> = [
+        {
+          tier: 'free',
+          config: baseConfig({ maxFree: 100, maxPro: 1000, maxEnterprise: 10000 }),
+          expectedLimit: 100,
+          namespace: 'ratelimit:hdr:defaults:free',
+        },
+        {
+          tier: 'pro',
+          config: baseConfig({ maxFree: 100, maxPro: 1000, maxEnterprise: 10000 }),
+          expectedLimit: 1000,
+          namespace: 'ratelimit:hdr:defaults:pro',
+        },
+        {
+          tier: 'enterprise',
+          config: baseConfig({ maxFree: 100, maxPro: 1000, maxEnterprise: 10000 }),
+          expectedLimit: 10000,
+          namespace: 'ratelimit:hdr:defaults:enterprise',
+        },
+        {
+          tier: 'free',
+          config: baseConfig({ maxFree: 17, maxPro: 53, maxEnterprise: 211 }),
+          expectedLimit: 17,
+          namespace: 'ratelimit:hdr:custom:free',
+        },
+        {
+          tier: 'pro',
+          config: baseConfig({ maxFree: 17, maxPro: 53, maxEnterprise: 211 }),
+          expectedLimit: 53,
+          namespace: 'ratelimit:hdr:custom:pro',
+        },
+        {
+          tier: 'enterprise',
+          config: baseConfig({ maxFree: 17, maxPro: 53, maxEnterprise: 211 }),
+          expectedLimit: 211,
+          namespace: 'ratelimit:hdr:custom:enterprise',
+        },
+      ]
+
+      for (const { tier, config, expectedLimit, namespace } of cases) {
+        const app = express()
+        app.use(express.json())
+        app.use((req, _res, next) => {
+          ;(req as any).apiKeyRecord = {
+            id: `key-${tier}-${expectedLimit}`,
+            ownerId: `owner-${tier}-${expectedLimit}`,
+            tier,
+          }
+          next()
+        })
+        app.use('/api', createRateLimitMiddleware(config, { namespace }))
+        app.get('/api/ping', (_req, res) => res.json({ ok: true }))
+
+        const res = await request(app).get('/api/ping')
+        expect(res.status).toBe(200)
+        expect(res.headers['x-ratelimit-limit']).toBe(String(expectedLimit))
+        expect(res.headers['x-ratelimit-remaining']).toBe(String(expectedLimit - 1))
+        expect(res.headers['x-ratelimit-reset']).toBeDefined()
+      }
+    })
+
+    it('x_ratelimit_limit_on_429_still_matches_the_callers_tier_config', async () => {
+      // Sad path: once a free-tier caller is blocked, the Limit header must
+      // still report maxFree — not maxPro / maxEnterprise.
+      const config = baseConfig({ maxFree: 1, maxPro: 50, maxEnterprise: 200 })
+      const app = buildApp({
+        config,
+        apiKeyRecord: { id: 'key-free-sad', ownerId: 'owner-free-sad', tier: 'free' },
+      })
+
+      expect((await request(app).get('/api/ping')).status).toBe(200)
+      const blocked = await request(app).get('/api/ping')
+      expect(blocked.status).toBe(429)
+      expect(blocked.headers['x-ratelimit-limit']).toBe(String(config.maxFree))
+      expect(blocked.headers['x-ratelimit-remaining']).toBe('0')
+      expect(blocked.headers['retry-after']).toBeDefined()
+      expect(blocked.body.details).toMatchObject({ limit: config.maxFree })
+    })
+
+    it('unauthenticated_request_uses_free_tier_limit_in_header', async () => {
+      const config = baseConfig({ maxFree: 100, maxPro: 1000, maxEnterprise: 10000 })
+      const app = express()
+      app.use(express.json())
+      app.use('/api', createRateLimitMiddleware(config, { namespace: 'ratelimit:hdr:anon' }))
+      app.get('/api/ping', (_req, res) => res.json({ ok: true }))
+
+      const res = await request(app).get('/api/ping')
+      expect(res.status).toBe(200)
+      expect(res.headers['x-ratelimit-limit']).toBe(String(config.maxFree))
+      expect(res.headers['x-ratelimit-remaining']).toBe(String(config.maxFree - 1))
+    })
   })
 
   // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Overview

This PR adds deterministic tests that lock **`X-RateLimit-Limit` / `X-RateLimit-Remaining` / 429 headers** to the active Free / Pro / Enterprise config values (defaults **100 / 1000 / 10000** and custom overrides), so tier-header regressions fail CI.

## Related Issue

Closes #741

## Changes

### ✅ Rate-limit header contract tests

* **[MODIFY]** `tests/routes/rateLimit.test.ts`
  * Asserts `x-ratelimit-limit` matches config for free / pro / enterprise (defaults + custom overrides).
  * Asserts 429 responses still report the caller's tier limit (not a higher tier).
  * Asserts unauthenticated requests use the free-tier limit in the header.

* **[MODIFY]** `src/middleware/__tests__/rateLimit.test.ts`
  * Unit coverage that Free / Pro / Enterprise header values mirror `maxFree` / `maxPro` / `maxEnterprise`.
  * Sad-path coverage: on 429, limit header stays at the caller's tier config.

## Verification Results

```
npx vitest run tests/routes/rateLimit.test.ts src/middleware/__tests__/rateLimit.test.ts
✅ 71/71 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Free vs Pro vs Enterprise numbers must match config | ✅ Header assertions for defaults + custom config |
| Happy path + explicit sad path | ✅ 200 header match + 429 still reports tier limit |
| Tests run via standard vitest suite / CI includes | ✅ Under `tests/routes/**` and `src/**/__tests__/**` |
| PR references issue | ✅ `Closes #741` |

## Timeline

- neezzha committed

Made with [Cursor](https://cursor.com)