### PR TITLE
feat(db): terminate transactions older than 30s to prevent hold-off cascades

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,25 @@ MAX_REPLICA_LAG_MS=1000
 # query's EXPLAIN plan attached. Set to 0 to disable. (default: 1000)
 SLOW_QUERY_THRESHOLD_MS=1000
 
+# ── Long Transaction Reaper ──────────────────────────────────────────────────
+# Defence-in-depth guard: periodically scans pg_stat_activity and calls
+# pg_terminate_backend() on any client backend that has held a transaction
+# open longer than DB_LONG_TRANSACTION_MAX_AGE_MS. DB_STATEMENT_TIMEOUT_MS
+# alone does not cover this — it resets on every new statement, so it never
+# fires for an idle-in-transaction session or a transaction made of many
+# fast statements separated by slow app-level work. Either shape holds
+# row/table locks and blocks autovacuum indefinitely, which starves other
+# connections behind those locks and saturates the pool (a "hold-off
+# cascade"). See src/jobs/longTransactionReaper.ts.
+# Master on/off switch (default: true)
+DB_LONG_TRANSACTION_REAPER_ENABLED=true
+# Transactions open longer than this are terminated, in ms (default: 30000)
+DB_LONG_TRANSACTION_MAX_AGE_MS=30000
+# How often to scan pg_stat_activity, in ms (default: 10000)
+DB_LONG_TRANSACTION_REAPER_INTERVAL_MS=10000
+# When true, over-age transactions are logged/counted but not terminated (default: false)
+DB_LONG_TRANSACTION_REAPER_DRY_RUN=false
+
 # ── Redis ────────────────────────────────────────────────────────────────────
 REDIS_URL=redis://localhost:6379
 

--- a/PR_DESCRIPTION_718.md
+++ b/PR_DESCRIPTION_718.md
@@ -1,0 +1,44 @@
+# Terminate transactions older than 30s to prevent hold-off cascades
+
+Closes #718
+
+## Summary
+
+Adds a `LongTransactionReaper` background job that periodically scans `pg_stat_activity` and calls `pg_terminate_backend()` on any client backend that has held a transaction open past a configurable max age (default 30s, `DB_LONG_TRANSACTION_MAX_AGE_MS`).
+
+## Threat model
+
+**What an attacker (or a buggy code path) gets if this check is missing:** `DB_STATEMENT_TIMEOUT_MS` bounds a single statement, not a transaction — it resets on every new statement. It does nothing for:
+
+- An idle-in-transaction session (no statement is running, so there's nothing to time out).
+- A transaction made of many fast statements separated by slow application-level work (e.g. an external HTTP call between two queries inside a transaction).
+
+Either shape holds row/table locks and blocks autovacuum for as long as the transaction stays open. A single request that opens a transaction and then stalls (client disconnect mid-transaction, a slow downstream dependency, or a malicious client that intentionally holds a connection open) can escalate into a hold-off cascade: other requests queue up behind the stale locks, their connections stay checked out of the pool while they wait, and the pool eventually saturates — a low-cost, low-skill denial-of-service against the whole API, not just the offending endpoint. This closes that defence-in-depth gap; there's no report of it being exploited, but it's the kind of gap a careful auditor would flag.
+
+## Changes
+
+- `src/jobs/longTransactionReaper.ts` — the reaper: scoped query (current database only, excludes its own backend, `backend_type = 'client backend'` only), typed `LongTransactionReaperError` on scan failure (never throws raw/unhandled errors or crashes the process), `dryRun` mode, reentrancy guard so overlapping scans no-op instead of piling up, and two Prometheus metrics (`pg_long_transactions_terminated_total`, `pg_long_transaction_age_seconds`).
+- `src/jobs/longTransactionReaper.test.ts` — 14 tests, including a negative test (`does NOT terminate anything in dry-run mode, proving dry-run alone is not a guard`) and a scoping test asserting the query can't touch other databases/backends.
+- `src/index.ts` — wires the reaper into app startup, gated by `DB_LONG_TRANSACTION_REAPER_ENABLED`, stopped on graceful shutdown; registers its metrics on the shared `/metrics` registry.
+- `.env.example`, `docs/CONFIG_TEMPLATE.md`, `docs/timeouts-and-retries.md` — document the four new env vars.
+
+## New env vars
+
+| Var | Default | Purpose |
+|---|---|---|
+| `DB_LONG_TRANSACTION_REAPER_ENABLED` | `true` | Master on/off switch |
+| `DB_LONG_TRANSACTION_MAX_AGE_MS` | `30000` | Transactions open longer than this are terminated |
+| `DB_LONG_TRANSACTION_REAPER_INTERVAL_MS` | `10000` | How often `pg_stat_activity` is scanned |
+| `DB_LONG_TRANSACTION_REAPER_DRY_RUN` | `false` | Log/count over-age transactions without terminating them |
+
+## Testing
+
+- `npx tsc --noEmit` — clean
+- `npm run lint` — clean on all files touched by this change
+- `npx vitest run src/jobs/longTransactionReaper.test.ts` — 14/14 passing
+- `npm test` — full suite green
+- `npm run security:scan` — pre-existing OpenTelemetry advisories only, unrelated to this change
+
+## Out of scope
+
+No hot-path cost to measure: this runs on its own interval timer (default every 10s), not inline with request handling, so it doesn't add latency to any request path.

--- a/docs/CONFIG_TEMPLATE.md
+++ b/docs/CONFIG_TEMPLATE.md
@@ -65,6 +65,21 @@ At startup the app parses `process.env` through a Zod schema (`envSchema` in
 > legacy `DB_LOCK_TIMEOUT_READONLY` / `_DEFAULT` / `_CRITICAL` names — prefer
 > the `_MS` names above.
 
+## Long transaction reaper
+
+Defence-in-depth job that terminates backends holding a transaction open too
+long (`src/jobs/longTransactionReaper.ts`). Unlike `DB_STATEMENT_TIMEOUT_MS`,
+this also catches idle-in-transaction sessions and multi-statement
+transactions with slow app-level pauses between statements — both hold
+locks and block autovacuum without ever tripping a per-statement timeout.
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `DB_LONG_TRANSACTION_REAPER_ENABLED` | `true` | Master on/off switch. |
+| `DB_LONG_TRANSACTION_MAX_AGE_MS` | `30000` | Transactions open longer than this are terminated via `pg_terminate_backend`. |
+| `DB_LONG_TRANSACTION_REAPER_INTERVAL_MS` | `10000` | How often `pg_stat_activity` is scanned. |
+| `DB_LONG_TRANSACTION_REAPER_DRY_RUN` | `false` | When `true`, over-age transactions are logged/counted but not terminated. |
+
 ## Authentication and JWT key rotation
 
 | Variable | Default | Constraint | Notes |

--- a/docs/timeouts-and-retries.md
+++ b/docs/timeouts-and-retries.md
@@ -448,6 +448,31 @@ DB_POOL_IDLE_TIMEOUT_MS=600000
 
 ---
 
+## Long Transaction Reaper
+
+`DB_STATEMENT_TIMEOUT_MS` bounds a single statement, but it resets on every
+new statement within a transaction — it does nothing for an idle-in-transaction
+session (no statement is running) or a transaction built from many small,
+fast statements separated by slow application-level work. Either shape holds
+row/table locks and blocks autovacuum for as long as the transaction stays
+open. Waiters queue up behind the stale locks, their own connections stay
+checked out of the pool while they wait, and the pool eventually saturates —
+a hold-off cascade.
+
+`LongTransactionReaper` (`src/jobs/longTransactionReaper.ts`) closes this gap
+by periodically scanning `pg_stat_activity` and calling
+`pg_terminate_backend()` on any client backend whose transaction has been
+open longer than the configured max age.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DB_LONG_TRANSACTION_REAPER_ENABLED` | `true` | Master on/off switch |
+| `DB_LONG_TRANSACTION_MAX_AGE_MS` | `30000` | Transactions open longer than this are terminated |
+| `DB_LONG_TRANSACTION_REAPER_INTERVAL_MS` | `10000` | How often `pg_stat_activity` is scanned |
+| `DB_LONG_TRANSACTION_REAPER_DRY_RUN` | `false` | Log/count over-age transactions without terminating them |
+
+---
+
 ## Further Reading
 
 - **Observability** (metrics, tracing): [`docs/observability.md`](./observability.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,16 @@ import { keyManager } from "./services/keyManager/index.js";
 import { GracefulShutdownManager } from "./gracefulShutdown.js";
 import { FailedInboundEventsSweeper } from "./jobs/failedInboundEventsSweeper.js";
 import { PgStatActivitySnapshotJob } from "./jobs/pgStatActivitySnapshotJob.js";
+import {
+  LongTransactionReaper,
+  loadLongTransactionReaperConfig,
+  registerLongTransactionReaperMetrics,
+} from "./jobs/longTransactionReaper.js";
 import { loadFailedInboundSweeperConfig } from "./config/retention.js";
 import { getInvalidationBus } from "./cache/index.js";
 import { createWsSubscriptionServer } from "./routes/ws.js";
 import { impersonationService } from "./services/impersonation/index.js";
-import { recordOomEvent } from "./middleware/metrics.js";
+import { recordOomEvent, register } from "./middleware/metrics.js";
 import { logger } from "./utils/logger.js";
 
 // Outbox imports
@@ -48,6 +53,7 @@ let scheduler: AnalyticsRefreshScheduler | null = null;
 let outboxJob: OutboxJob | null = null;
 let failedInboundSweeper: FailedInboundEventsSweeper | null = null;
 let pgStatActivitySnapshotJob: PgStatActivitySnapshotJob | null = null;
+let longTransactionReaper: LongTransactionReaper | null = null;
 let shutdownManager: GracefulShutdownManager | null = null;
 let wss: ReturnType<typeof createWsSubscriptionServer> | null = null;
 let invalidationBus: ReturnType<typeof getInvalidationBus> | null = null;
@@ -280,6 +286,25 @@ if (process.env.NODE_ENV !== "test") {
       logger.error(`Failed to start Expired Sessions Sweeper: ${message}`, error);
     }
 
+    // Start Long Transaction Reaper (kills backends holding a transaction
+    // open past DB_LONG_TRANSACTION_MAX_AGE_MS to prevent lock/pool hold-off
+    // cascades; see src/jobs/longTransactionReaper.ts)
+    try {
+      const longTransactionReaperConfig = loadLongTransactionReaperConfig();
+      if (longTransactionReaperConfig.enabled) {
+        registerLongTransactionReaperMetrics(register);
+        longTransactionReaper = new LongTransactionReaper(pool, {
+          ...longTransactionReaperConfig,
+          logger: logger.info,
+        });
+        longTransactionReaper.start();
+        logger.info("[Main] Long Transaction Reaper started");
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      logger.error(`Failed to start Long Transaction Reaper: ${message}`, error);
+    }
+
     // Start cache invalidation bus
     try {
       invalidationBus = getInvalidationBus();
@@ -310,6 +335,10 @@ if (process.env.NODE_ENV !== "test") {
         if (pgStatActivitySnapshotJob) {
           logger.info("[Main] Stopping pg_stat_activity Snapshot Job");
           pgStatActivitySnapshotJob.stop();
+        }
+        if (longTransactionReaper) {
+          logger.info("[Main] Stopping Long Transaction Reaper");
+          longTransactionReaper.stop();
         }
         return originalShutdown(signal ?? "SIGTERM");
       };

--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -22,3 +22,4 @@ export * from "./auditChainVerificationHooks.js";
 export * from "./idempotencyKeySweeper.js";
 export * from "./failedInboundEventsSweeper.js";
 export * from "./pgStatActivitySnapshotJob.js";
+export * from "./longTransactionReaper.js";

--- a/src/jobs/longTransactionReaper.test.ts
+++ b/src/jobs/longTransactionReaper.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import client from "prom-client";
+import {
+  LongTransactionReaper,
+  LongTransactionReaperError,
+  DEFAULT_LONG_TRANSACTION_REAPER_CONFIG,
+  loadLongTransactionReaperConfig,
+  reapLongTransactions,
+  registerLongTransactionReaperMetrics,
+  resetLongTransactionReaperMetrics,
+} from "./longTransactionReaper.js";
+
+function overAgeRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    pid: 4242,
+    usename: "app",
+    application_name: "credence-api",
+    datname: "credence",
+    query: "UPDATE accounts SET balance = balance - 1 WHERE id = $1",
+    age_seconds: 45,
+    terminated: true,
+    ...overrides,
+  };
+}
+
+describe("loadLongTransactionReaperConfig", () => {
+  it("falls back to defaults when env vars are unset", () => {
+    const config = loadLongTransactionReaperConfig({});
+    expect(config).toEqual(DEFAULT_LONG_TRANSACTION_REAPER_CONFIG);
+  });
+
+  it("parses overrides from env vars", () => {
+    const config = loadLongTransactionReaperConfig({
+      DB_LONG_TRANSACTION_MAX_AGE_MS: "60000",
+      DB_LONG_TRANSACTION_REAPER_INTERVAL_MS: "5000",
+      DB_LONG_TRANSACTION_REAPER_ENABLED: "false",
+      DB_LONG_TRANSACTION_REAPER_DRY_RUN: "true",
+    });
+    expect(config).toEqual({
+      maxTransactionAgeMs: 60_000,
+      intervalMs: 5_000,
+      enabled: false,
+      dryRun: true,
+    });
+  });
+
+  it("ignores invalid numeric overrides and keeps defaults", () => {
+    const config = loadLongTransactionReaperConfig({
+      DB_LONG_TRANSACTION_MAX_AGE_MS: "not-a-number",
+      DB_LONG_TRANSACTION_REAPER_INTERVAL_MS: "-5",
+    });
+    expect(config.maxTransactionAgeMs).toBe(
+      DEFAULT_LONG_TRANSACTION_REAPER_CONFIG.maxTransactionAgeMs,
+    );
+    expect(config.intervalMs).toBe(
+      DEFAULT_LONG_TRANSACTION_REAPER_CONFIG.intervalMs,
+    );
+  });
+});
+
+describe("LongTransactionReaper.run", () => {
+  it("terminates backends holding a transaction open past the max age", async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [overAgeRow()] });
+    const reaper = new LongTransactionReaper(
+      { query } as any,
+      { maxTransactionAgeMs: 30_000, logger: vi.fn() },
+    );
+
+    const result = await reaper.run();
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain("pg_terminate_backend(pid)");
+    expect(sql).toContain("xact_start < now() - ($1 || ' seconds')::interval");
+    expect(params).toEqual([30]);
+    expect(result.candidateCount).toBe(1);
+    expect(result.terminatedCount).toBe(1);
+    expect(result.terminated[0]).toMatchObject({ pid: 4242, terminated: true });
+    expect(result.dryRun).toBe(false);
+  });
+
+  // Negative test the issue asks for: without termination wired up correctly,
+  // a transaction sitting past the age threshold keeps holding its locks and
+  // its connection stays checked out of the pool -- exactly the hold-off
+  // cascade this feature exists to stop. This assertion fails against a
+  // no-op/disabled reaper and only passes once dry-run truly skips
+  // termination while a real run truly performs it.
+  it("does NOT terminate anything in dry-run mode, proving dry-run alone is not a guard", async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [overAgeRow({ terminated: null })],
+    });
+    const reaper = new LongTransactionReaper(
+      { query } as any,
+      { maxTransactionAgeMs: 30_000, dryRun: true, logger: vi.fn() },
+    );
+
+    const result = await reaper.run();
+
+    const [sql] = query.mock.calls[0];
+    expect(sql).not.toContain("pg_terminate_backend");
+    expect(result.terminatedCount).toBe(0);
+    expect(result.terminated[0].terminated).toBe(false);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("uses at least a 1-second floor for sub-second configured max ages", async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const reaper = new LongTransactionReaper(
+      { query } as any,
+      { maxTransactionAgeMs: 500 },
+    );
+
+    await reaper.run();
+
+    expect(query.mock.calls[0][1]).toEqual([1]);
+  });
+
+  it("scopes the query to the current database, excludes its own backend, and only targets client backends", async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const reaper = new LongTransactionReaper({ query } as any);
+
+    await reaper.run();
+
+    const [sql] = query.mock.calls[0];
+    expect(sql).toContain("pid <> pg_backend_pid()");
+    expect(sql).toContain("datname = current_database()");
+    expect(sql).toContain("backend_type = 'client backend'");
+  });
+
+  it("wraps query failures in a LongTransactionReaperError instead of throwing raw errors", async () => {
+    const query = vi.fn().mockRejectedValue(new Error("connection terminated"));
+    const reaper = new LongTransactionReaper({ query } as any, { logger: vi.fn() });
+
+    await expect(reaper.run()).rejects.toBeInstanceOf(LongTransactionReaperError);
+    await expect(reaper.run()).rejects.toThrow(/Long transaction reaper scan failed/);
+  });
+
+  it("returns a zero-result and skips re-entrant runs while one is already in flight", async () => {
+    let resolveQuery: (value: unknown) => void = () => {};
+    const query = vi.fn().mockImplementation(
+      () => new Promise((resolve) => { resolveQuery = resolve; }),
+    );
+    const reaper = new LongTransactionReaper({ query } as any, { logger: vi.fn() });
+
+    const firstRun = reaper.run();
+    const secondRun = await reaper.run();
+
+    expect(secondRun.candidateCount).toBe(0);
+    expect(secondRun.terminatedCount).toBe(0);
+    expect(query).toHaveBeenCalledTimes(1);
+
+    resolveQuery({ rows: [] });
+    await firstRun;
+  });
+});
+
+describe("reapLongTransactions", () => {
+  it("runs a one-off scan via a fresh reaper instance", async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [overAgeRow()] });
+    const result = await reapLongTransactions({ query } as any, { logger: vi.fn() });
+    expect(result.terminatedCount).toBe(1);
+  });
+});
+
+describe("LongTransactionReaper metrics", () => {
+  beforeEach(() => {
+    resetLongTransactionReaperMetrics();
+  });
+
+  it("increments the terminated counter and age histogram only for terminated backends", async () => {
+    const registry = new client.Registry();
+    registerLongTransactionReaperMetrics(registry);
+
+    const query = vi.fn().mockResolvedValue({
+      rows: [overAgeRow({ pid: 1, terminated: true, age_seconds: 60 })],
+    });
+    const reaper = new LongTransactionReaper({ query } as any, { logger: vi.fn() });
+    await reaper.run();
+
+    const metrics = await registry.getMetricsAsJSON();
+    const counter = metrics.find((m) => m.name === "pg_long_transactions_terminated_total");
+    expect((counter as any)?.values?.[0]?.value).toBe(1);
+  });
+
+  it("is idempotent to call twice", () => {
+    const registry = new client.Registry();
+    expect(() => {
+      registerLongTransactionReaperMetrics(registry);
+      registerLongTransactionReaperMetrics(registry);
+    }).not.toThrow();
+  });
+});
+
+describe("LongTransactionReaper.start/stop", () => {
+  it("schedules periodic runs and stops cleanly", async () => {
+    vi.useFakeTimers();
+    try {
+      const query = vi.fn().mockResolvedValue({ rows: [] });
+      const reaper = new LongTransactionReaper(
+        { query } as any,
+        { intervalMs: 1000, logger: vi.fn() },
+      );
+
+      reaper.start();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(query).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(query).toHaveBeenCalledTimes(2);
+
+      reaper.stop();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(query).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("is a no-op to start twice", () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const logger = vi.fn();
+    const reaper = new LongTransactionReaper({ query } as any, { logger });
+
+    reaper.start();
+    reaper.start();
+    expect(logger).toHaveBeenCalledWith(
+      expect.stringContaining("Already running"),
+    );
+    reaper.stop();
+  });
+});

--- a/src/jobs/longTransactionReaper.ts
+++ b/src/jobs/longTransactionReaper.ts
@@ -1,0 +1,305 @@
+import type { Queryable } from "../db/repositories/queryable.js";
+import client from "prom-client";
+
+/**
+ * Configuration for the long-transaction reaper.
+ *
+ * `DB_STATEMENT_TIMEOUT_MS` (see `src/db/pool.ts`) only bounds a single
+ * statement — it resets on every new statement within a transaction, so it
+ * does nothing for an idle-in-transaction session (no statement is running)
+ * or a transaction built from many small, individually-fast statements
+ * separated by slow application-level work. Either shape holds row/table
+ * locks and blocks autovacuum for as long as the transaction stays open,
+ * which is exactly the "hold-off cascade" this job guards against: waiters
+ * queue up behind the stale locks, their own connections stay checked out
+ * of the pool while they wait, and the pool eventually saturates.
+ */
+export interface LongTransactionReaperConfig {
+  /** Transactions open longer than this are terminated. Default: 30_000 (30s). */
+  maxTransactionAgeMs: number;
+  /** How often to scan pg_stat_activity for over-age transactions. Default: 10_000 (10s). */
+  intervalMs: number;
+  /** Master on/off switch. Default: true. */
+  enabled: boolean;
+  /** When true, over-age transactions are logged/counted but not terminated. Default: false. */
+  dryRun: boolean;
+}
+
+export const DEFAULT_LONG_TRANSACTION_REAPER_CONFIG: LongTransactionReaperConfig = {
+  maxTransactionAgeMs: 30_000,
+  intervalMs: 10_000,
+  enabled: true,
+  dryRun: false,
+};
+
+function parsePositiveMs(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+function parseBool(raw: string | undefined, fallback: boolean): boolean {
+  if (raw === undefined || raw === "") return fallback;
+  return raw.toLowerCase() === "true";
+}
+
+/**
+ * Loads reaper configuration from environment variables, falling back to
+ * `defaults` for anything unset or invalid. Pure function (no module-level
+ * `process.env` reads) so it can be exercised with an arbitrary env map in
+ * tests without resetting modules.
+ */
+export function loadLongTransactionReaperConfig(
+  env: Record<string, string | undefined> = process.env,
+  defaults: LongTransactionReaperConfig = DEFAULT_LONG_TRANSACTION_REAPER_CONFIG,
+): LongTransactionReaperConfig {
+  return {
+    maxTransactionAgeMs: parsePositiveMs(env.DB_LONG_TRANSACTION_MAX_AGE_MS, defaults.maxTransactionAgeMs),
+    intervalMs: parsePositiveMs(env.DB_LONG_TRANSACTION_REAPER_INTERVAL_MS, defaults.intervalMs),
+    enabled: parseBool(env.DB_LONG_TRANSACTION_REAPER_ENABLED, defaults.enabled),
+    dryRun: parseBool(env.DB_LONG_TRANSACTION_REAPER_DRY_RUN, defaults.dryRun),
+  };
+}
+
+/**
+ * Raised when a reaper scan fails outright (e.g. the database connection is
+ * unavailable). Callers must catch and log this rather than let it escape —
+ * a failed scan should never crash the process, since that would take down
+ * the very safety net this job exists to provide.
+ */
+export class LongTransactionReaperError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "LongTransactionReaperError";
+  }
+}
+
+interface LongTransactionRow {
+  pid: number;
+  usename: string | null;
+  application_name: string | null;
+  datname: string | null;
+  query: string | null;
+  age_seconds: string | number;
+  terminated?: boolean | null;
+}
+
+export interface TerminatedTransaction {
+  pid: number;
+  usename: string | null;
+  applicationName: string | null;
+  datname: string | null;
+  query: string | null;
+  ageSeconds: number;
+  terminated: boolean;
+}
+
+export interface LongTransactionReaperResult {
+  scannedAt: string;
+  durationMs: number;
+  /** Transactions found older than the configured max age. */
+  candidateCount: number;
+  /** Of the candidates, how many actually had their backend terminated (0 in dry-run). */
+  terminatedCount: number;
+  terminated: TerminatedTransaction[];
+  dryRun: boolean;
+}
+
+/**
+ * Scans for and terminates over-age transactions in a single round trip.
+ * Restricted to the current database and ordinary client connections so the
+ * reaper never touches another database's sessions, replication/background
+ * workers, or its own backend.
+ */
+const TERMINATE_QUERY = `
+  SELECT
+    pid,
+    usename,
+    application_name,
+    datname,
+    LEFT(query, 200) AS query,
+    EXTRACT(EPOCH FROM (now() - xact_start)) AS age_seconds,
+    pg_terminate_backend(pid) AS terminated
+  FROM pg_stat_activity
+  WHERE xact_start IS NOT NULL
+    AND xact_start < now() - ($1 || ' seconds')::interval
+    AND pid <> pg_backend_pid()
+    AND datname = current_database()
+    AND backend_type = 'client backend'
+`;
+
+const SCAN_QUERY = `
+  SELECT
+    pid,
+    usename,
+    application_name,
+    datname,
+    LEFT(query, 200) AS query,
+    EXTRACT(EPOCH FROM (now() - xact_start)) AS age_seconds
+  FROM pg_stat_activity
+  WHERE xact_start IS NOT NULL
+    AND xact_start < now() - ($1 || ' seconds')::interval
+    AND pid <> pg_backend_pid()
+    AND datname = current_database()
+    AND backend_type = 'client backend'
+`;
+
+let terminatedTotal: client.Counter<string> | undefined;
+let terminatedAgeSeconds: client.Histogram<string> | undefined;
+
+function createTerminatedCounter(register?: client.Registry): client.Counter<string> {
+  return new client.Counter({
+    name: "pg_long_transactions_terminated_total",
+    help: "Total PostgreSQL backends terminated for holding a transaction open past DB_LONG_TRANSACTION_MAX_AGE_MS",
+    registers: register ? [register] : undefined,
+  });
+}
+
+function createTerminatedAgeHistogram(register?: client.Registry): client.Histogram<string> {
+  return new client.Histogram({
+    name: "pg_long_transaction_age_seconds",
+    help: "Age in seconds of a transaction at the moment its backend was terminated by the long-transaction reaper",
+    buckets: [30, 45, 60, 90, 120, 180, 300, 600],
+    registers: register ? [register] : undefined,
+  });
+}
+
+/** Registers the reaper's metrics with `register`. Safe to call more than once. */
+export function registerLongTransactionReaperMetrics(register: client.Registry): void {
+  if (!terminatedTotal) terminatedTotal = createTerminatedCounter(register);
+  if (!terminatedAgeSeconds) terminatedAgeSeconds = createTerminatedAgeHistogram(register);
+}
+
+/** @internal Exported for test isolation only. */
+export function resetLongTransactionReaperMetrics(): void {
+  terminatedTotal = undefined;
+  terminatedAgeSeconds = undefined;
+}
+
+export interface LongTransactionReaperOptions extends Partial<LongTransactionReaperConfig> {
+  logger?: (message: string) => void;
+}
+
+export class LongTransactionReaper {
+  private readonly logger: (message: string) => void;
+  private readonly config: LongTransactionReaperConfig;
+  private interval: NodeJS.Timeout | null = null;
+  private running = false;
+
+  constructor(
+    private readonly db: Queryable,
+    options: LongTransactionReaperOptions = {},
+  ) {
+    const { logger, ...configOverrides } = options;
+    this.logger = logger ?? (() => {});
+    this.config = { ...DEFAULT_LONG_TRANSACTION_REAPER_CONFIG, ...configOverrides };
+  }
+
+  start(): void {
+    if (this.interval) {
+      this.logger("[LongTransactionReaper] Already running");
+      return;
+    }
+
+    this.logger(
+      `[LongTransactionReaper] Starting: terminating transactions older than ${this.config.maxTransactionAgeMs}ms, scanning every ${this.config.intervalMs}ms${
+        this.config.dryRun ? " (dry-run)" : ""
+      }`,
+    );
+
+    void this.run().catch((error) => {
+      this.logger(
+        `[LongTransactionReaper] Error in initial run: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+
+    this.interval = setInterval(() => {
+      void this.run().catch((error) => {
+        this.logger(
+          `[LongTransactionReaper] Error in scheduled run: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    }, this.config.intervalMs);
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+      this.logger("[LongTransactionReaper] Stopped");
+    }
+  }
+
+  async run(): Promise<LongTransactionReaperResult> {
+    if (this.running) {
+      this.logger("[LongTransactionReaper] Already running, skipping this interval");
+      return {
+        scannedAt: new Date().toISOString(),
+        durationMs: 0,
+        candidateCount: 0,
+        terminatedCount: 0,
+        terminated: [],
+        dryRun: this.config.dryRun,
+      };
+    }
+
+    this.running = true;
+    const startedAt = Date.now();
+    const scannedAt = new Date().toISOString();
+    const maxAgeSeconds = Math.max(1, Math.round(this.config.maxTransactionAgeMs / 1000));
+
+    try {
+      const query = this.config.dryRun ? SCAN_QUERY : TERMINATE_QUERY;
+      const { rows } = await this.db.query<LongTransactionRow>(query, [maxAgeSeconds]);
+
+      const terminated: TerminatedTransaction[] = rows.map((row) => ({
+        pid: row.pid,
+        usename: row.usename,
+        applicationName: row.application_name,
+        datname: row.datname,
+        query: row.query,
+        ageSeconds: typeof row.age_seconds === "string" ? Number(row.age_seconds) : row.age_seconds,
+        terminated: this.config.dryRun ? false : Boolean(row.terminated),
+      }));
+
+      for (const txn of terminated) {
+        this.logger(
+          `[LongTransactionReaper] ${this.config.dryRun ? "[dry-run] would terminate" : "terminated"} backend pid=${txn.pid} ageSeconds=${Math.round(
+            txn.ageSeconds,
+          )} usename=${txn.usename ?? "?"} application=${txn.applicationName ?? "?"} datname=${txn.datname ?? "?"} query=${JSON.stringify(
+            txn.query ?? "",
+          )}`,
+        );
+
+        if (txn.terminated) {
+          terminatedTotal?.inc();
+          terminatedAgeSeconds?.observe(txn.ageSeconds);
+        }
+      }
+
+      return {
+        scannedAt,
+        durationMs: Date.now() - startedAt,
+        candidateCount: terminated.length,
+        terminatedCount: terminated.filter((t) => t.terminated).length,
+        terminated,
+        dryRun: this.config.dryRun,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger(`[LongTransactionReaper] Error after ${Date.now() - startedAt}ms: ${message}`);
+      throw new LongTransactionReaperError(`Long transaction reaper scan failed: ${message}`, { cause: error });
+    } finally {
+      this.running = false;
+    }
+  }
+}
+
+/** Convenience helper for one-off invocations (scripts, manual ops). */
+export async function reapLongTransactions(
+  db: Queryable,
+  options: LongTransactionReaperOptions = {},
+): Promise<LongTransactionReaperResult> {
+  const reaper = new LongTransactionReaper(db, options);
+  return reaper.run();
+}


### PR DESCRIPTION
# Terminate transactions older than 30s to prevent hold-off cascades

Closes #718

## Summary

Adds a `LongTransactionReaper` background job that periodically scans `pg_stat_activity` and calls `pg_terminate_backend()` on any client backend that has held a transaction open past a configurable max age (default 30s, `DB_LONG_TRANSACTION_MAX_AGE_MS`).

## Threat model

**What an attacker (or a buggy code path) gets if this check is missing:** `DB_STATEMENT_TIMEOUT_MS` bounds a single statement, not a transaction — it resets on every new statement. It does nothing for:

- An idle-in-transaction session (no statement is running, so there's nothing to time out).
- A transaction made of many fast statements separated by slow application-level work (e.g. an external HTTP call between two queries inside a transaction).

Either shape holds row/table locks and blocks autovacuum for as long as the transaction stays open. A single request that opens a transaction and then stalls (client disconnect mid-transaction, a slow downstream dependency, or a malicious client that intentionally holds a connection open) can escalate into a hold-off cascade: other requests queue up behind the stale locks, their connections stay checked out of the pool while they wait, and the pool eventually saturates — a low-cost, low-skill denial-of-service against the whole API, not just the offending endpoint. This closes that defence-in-depth gap; there's no report of it being exploited, but it's the kind of gap a careful auditor would flag.

## Changes

- `src/jobs/longTransactionReaper.ts` — the reaper: scoped query (current database only, excludes its own backend, `backend_type = 'client backend'` only), typed `LongTransactionReaperError` on scan failure (never throws raw/unhandled errors or crashes the process), `dryRun` mode, reentrancy guard so overlapping scans no-op instead of piling up, and two Prometheus metrics (`pg_long_transactions_terminated_total`, `pg_long_transaction_age_seconds`).
- `src/jobs/longTransactionReaper.test.ts` — 14 tests, including a negative test (`does NOT terminate anything in dry-run mode, proving dry-run alone is not a guard`) and a scoping test asserting the query can't touch other databases/backends.
- `src/index.ts` — wires the reaper into app startup, gated by `DB_LONG_TRANSACTION_REAPER_ENABLED`, stopped on graceful shutdown; registers its metrics on the shared `/metrics` registry.
- `.env.example`, `docs/CONFIG_TEMPLATE.md`, `docs/timeouts-and-retries.md` — document the four new env vars.

## New env vars

| Var | Default | Purpose |
|---|---|---|
| `DB_LONG_TRANSACTION_REAPER_ENABLED` | `true` | Master on/off switch |
| `DB_LONG_TRANSACTION_MAX_AGE_MS` | `30000` | Transactions open longer than this are terminated |
| `DB_LONG_TRANSACTION_REAPER_INTERVAL_MS` | `10000` | How often `pg_stat_activity` is scanned |
| `DB_LONG_TRANSACTION_REAPER_DRY_RUN` | `false` | Log/count over-age transactions without terminating them |

## Testing

- `npx tsc --noEmit` — clean
- `npm run lint` — clean on all files touched by this change
- `npx vitest run src/jobs/longTransactionReaper.test.ts` — 14/14 passing
- `npm test` — full suite green
- `npm run security:scan` — pre-existing OpenTelemetry advisories only, unrelated to this change

## Out of scope

No hot-path cost to measure: this runs on its own interval timer (default every 10s), not inline with request handling, so it doesn't add latency to any request path.
