### PR TITLE
fix(Credence-Backend): fresh-2026-04-backend-exports-fix-export-worker-

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -351,19 +351,6 @@ const result = await txManager.withTransaction(
 
 The span is created via the `withSpan` utility and exported by the configured `SpanProcessor` (ConsoleSpanExporter in dev; OTLP in production).
 
-## Database Query Spans
-
-Every database query executed through the connection pools (`pool`, `workerPool`, `replicaPool`) generates an OpenTelemetry span named `db.query` with the following attributes:
-
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `db.system` | string | Set to `"postgresql"`. |
-| `db.statement` | string | The SQL query string executed. |
-| `db.pool` | string | Which pool ran the query (`"api"`, `"worker"`, or `"replica"`). |
-| `db.row_count` | number | The row count returned by the query (if successful). |
-
-If the query throws an exception, the span status is set to `ERROR`, and the exception is captured/recorded on the span.
-
 ## Slow Query Logging
 
 Every query issued through `pool`, `workerPool`, or `replicaPool` (`src/db/pool.ts`) is timed. Any query taking at least `SLOW_QUERY_THRESHOLD_MS` (default `1000`, i.e. 1 second; `0` disables the check) emits a `db:slow-query` structured log — `LogEventType.DB_SLOW_QUERY` — with the query's plan attached, and increments Prometheus metrics.

--- a/src/jobs/exportPipeline.test.ts
+++ b/src/jobs/exportPipeline.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { pumpExportBatches } from './exportPipeline.js'
+import type { ExportRow } from './exportTypes.js'
+
+describe('pumpExportBatches', () => {
+  it('pulls the next batch only after the previous write completes', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+
+    async function* batches(): AsyncIterable<ExportRow[]> {
+      for (let i = 0; i < 5; i++) {
+        inFlight++
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        yield [{ id: i }]
+        inFlight--
+      }
+    }
+
+    const writeBatch = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    })
+
+    const result = await pumpExportBatches(batches(), writeBatch)
+
+    expect(result.totalRows).toBe(5)
+    expect(result.batchesProcessed).toBe(5)
+    expect(maxInFlight).toBe(1)
+    expect(writeBatch).toHaveBeenCalledTimes(5)
+  })
+})

--- a/src/jobs/exportPipeline.ts
+++ b/src/jobs/exportPipeline.ts
@@ -1,0 +1,23 @@
+import type { ExportRow } from './exportTypes.js'
+
+/**
+ * Pulls one batch at a time from the cursor and awaits the writer before
+ * requesting the next batch, yielding to the event loop between batches
+ * so row objects can be reclaimed under load.
+ */
+export async function pumpExportBatches(
+  cursor: AsyncIterable<ExportRow[]>,
+  writeBatch: (rows: ExportRow[]) => Promise<void>,
+): Promise<{ totalRows: number; batchesProcessed: number }> {
+  let totalRows = 0
+  let batchesProcessed = 0
+
+  for await (const batch of cursor) {
+    await writeBatch(batch)
+    totalRows += batch.length
+    batchesProcessed++
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+
+  return { totalRows, batchesProcessed }
+}

--- a/src/jobs/exportWorker.ts
+++ b/src/jobs/exportWorker.ts
@@ -4,6 +4,7 @@ import type {
   ExportWorkerOptions,
   ExportWorkerResult,
 } from './exportTypes.js'
+import { pumpExportBatches } from './exportPipeline.js'
 export type { ExportWorkerOptions, ExportWorkerResult } from './exportTypes.js'
 
 export class ExportWorker {
@@ -35,22 +36,25 @@ export class ExportWorker {
     try {
       const cursor = this.dataSource.openCursor(this.batchSize)
 
-      for await (const batch of cursor) {
+      let batchIndex = 0
+      let runningTotal = 0
+      const pumped = await pumpExportBatches(cursor, async (batch) => {
+        batchIndex++
         try {
           await this.writer.writeBatch(batch)
-          totalRows += batch.length
-          batchesProcessed++
-
+          runningTotal += batch.length
           this.logger(
-            `Batch ${batchesProcessed} written (${batch.length} rows, ${totalRows}/${totalCount} total)`,
+            `Batch ${batchIndex} written (${batch.length} rows, ${runningTotal}/${totalCount} total)`,
           )
         } catch (error) {
           errors++
           const message = error instanceof Error ? error.message : 'Unknown write error'
-          this.logger(`Batch ${batchesProcessed + 1} failed: ${message}`)
+          this.logger(`Batch ${batchIndex} failed: ${message}`)
           throw error
         }
-      }
+      })
+      totalRows = pumped.totalRows
+      batchesProcessed = pumped.batchesProcessed
 
       await this.writer.close()
       this.logger(`Export completed: ${totalRows} rows in ${batchesProcessed} batches`)

--- a/src/services/audit/index.ts
+++ b/src/services/audit/index.ts
@@ -231,29 +231,46 @@ export class AuditLogService {
       allowSuperScope?: boolean
     }
   ): AsyncGenerator<AuditLogEntry> {
-    // SECURITY: Enforce tenant scoping - deny by default
+    this.assertExportScope(tenantId, options)
+
+    const filters: AuditLogFilters = {
+      from: startDate.toISOString(),
+      to: endDate.toISOString(),
+    }
+
+    for await (const log of this.paginateLogs(tenantId, filters, options)) {
+      yield this.redactLogEntry(log)
+      await new Promise((resolve) => setImmediate(resolve))
+    }
+  }
+
+  private assertExportScope(
+    tenantId?: string,
+    options?: { allowSuperScope?: boolean },
+  ): void {
     if (!tenantId && !options?.allowSuperScope) {
       throw new Error(
         'Tenant scoping required: either provide tenantId or explicitly enable allowSuperScope for privileged access'
       )
     }
+  }
 
-    const startMs = startDate.getTime()
-    const endMs = endDate.getTime()
-
-    const { logs } = await this.getLogs(tenantId, {}, Number.MAX_SAFE_INTEGER, undefined, options)
-    for (const log of logs) {
-      const logTime = new Date(log.timestamp).getTime()
-      
-      // Apply tenant filter if provided (not in super-scope mode)
-      if (tenantId && log.tenantId !== tenantId) {
-        continue
+  private async *paginateLogs(
+    tenantId: string | undefined,
+    filters: AuditLogFilters,
+    options?: { allowSuperScope?: boolean },
+    pageSize = 500,
+  ): AsyncGenerator<AuditLogEntry> {
+    let cursor: string | undefined
+    while (true) {
+      const page = await this.getLogs(tenantId, filters, pageSize, cursor, options)
+      for (const log of page.logs) {
+        yield log
       }
-      
-      if (logTime >= startMs && logTime <= endMs) {
-        yield this.redactLogEntry(log)
-        await new Promise((resolve) => setImmediate(resolve))
+      if (!page.hasNextPage || !page.nextCursor) {
+        break
       }
+      cursor = page.nextCursor
     }
   }
 

--- a/src/services/exportService.test.ts
+++ b/src/services/exportService.test.ts
@@ -1,0 +1,86 @@
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import { AuditLogService, AuditAction } from './audit/index.js'
+import { InMemoryAuditLogsRepository } from '../db/repositories/auditLogsRepository.js'
+import {
+  ExportService,
+  createDiscardExportWriter,
+  createNdjsonExportWriter,
+} from './exportService.js'
+
+describe('ExportService', () => {
+  it('exports audit logs in bounded batches via ExportWorker', async () => {
+    const repo = new InMemoryAuditLogsRepository()
+    const auditLog = new AuditLogService(repo)
+    const tenantId = 'tenant-export'
+
+    for (let i = 0; i < 12; i++) {
+      await auditLog.logAction(
+        tenantId,
+        'admin-1',
+        'admin@example.com',
+        AuditAction.LIST_USERS,
+        `resource-${i}`,
+      )
+    }
+
+    const startDate = new Date(Date.now() - 60_000)
+    const endDate = new Date(Date.now() + 60_000)
+
+    const exportService = new ExportService(auditLog)
+    const result = await exportService.runAuditLogExport(
+      { startDate, endDate, tenantId },
+      createDiscardExportWriter(),
+      { batchSize: 5 },
+    )
+
+    expect(result.totalRows).toBe(12)
+    expect(result.batchesProcessed).toBe(3)
+    expect(result.errors).toBe(0)
+  })
+
+  it('paginates audit export stream instead of loading all rows at once', async () => {
+    const repo = new InMemoryAuditLogsRepository()
+    const auditLog = new AuditLogService(repo)
+    const querySpy = vi.spyOn(repo, 'query')
+
+    const tenantId = 'tenant-stream'
+    for (let i = 0; i < 1200; i++) {
+      await auditLog.logAction(
+        tenantId,
+        'admin-1',
+        'admin@example.com',
+        AuditAction.LIST_USERS,
+        `resource-${i}`,
+      )
+    }
+
+    const startDate = new Date(Date.now() - 60_000)
+    const endDate = new Date(Date.now() + 60_000)
+
+    let yielded = 0
+    for await (const _entry of auditLog.exportLogsStream(startDate, endDate, tenantId)) {
+      yielded++
+    }
+
+    expect(yielded).toBe(1200)
+    expect(querySpy.mock.calls.some((call) => call[1] === Number.MAX_SAFE_INTEGER)).toBe(false)
+    expect(querySpy.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('writes NDJSON lines and respects stream lifecycle', async () => {
+    const chunks: string[] = []
+    const stream = new PassThrough()
+    stream.on('data', (chunk) => chunks.push(chunk.toString()))
+
+    const writer = createNdjsonExportWriter(stream)
+    await writer.open()
+    await writer.writeBatch([{ id: 1 }, { id: 2 }])
+    await writer.close()
+
+    const lines = chunks.join('').trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0])).toEqual({ id: 1 })
+    expect(JSON.parse(lines[1])).toEqual({ id: 2 })
+  })
+})

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,0 +1,167 @@
+import type { Writable } from 'node:stream'
+import { ExportWorker } from '../jobs/exportWorker.js'
+import type {
+  ExportDataSource,
+  ExportRow,
+  ExportWorkerOptions,
+  ExportWorkerResult,
+  ExportWriter,
+} from '../jobs/exportTypes.js'
+import type { AuditLogService } from './audit/index.js'
+import type { AuditLogEntry } from './audit/types.js'
+
+export interface AuditLogExportParams {
+  startDate: Date
+  endDate: Date
+  tenantId?: string
+  allowSuperScope?: boolean
+}
+
+export interface ExportServiceOptions {
+  defaultBatchSize?: number
+}
+
+async function* batchEntries(
+  source: AsyncIterable<AuditLogEntry>,
+  batchSize: number,
+): AsyncGenerator<ExportRow[]> {
+  let batch: ExportRow[] = []
+  for await (const entry of source) {
+    batch.push(entry)
+    if (batch.length >= batchSize) {
+      yield batch
+      batch = []
+    }
+  }
+  if (batch.length > 0) {
+    yield batch
+  }
+}
+
+function writeWithBackpressure(
+  writable: NodeJS.WritableStream,
+  chunk: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error) => {
+      writable.off('drain', onDrain)
+      reject(err)
+    }
+    const onDrain = () => {
+      writable.off('error', onError)
+      resolve()
+    }
+
+    const ok = writable.write(chunk, (err) => {
+      if (err) {
+        onError(err)
+      }
+    })
+
+    if (ok) {
+      writable.off('error', onError)
+      resolve()
+    } else {
+      writable.once('drain', onDrain)
+      writable.once('error', onError)
+    }
+  })
+}
+
+/**
+ * NDJSON export writer that respects Writable backpressure (waits for drain).
+ */
+export function createNdjsonExportWriter(writable: Writable): ExportWriter {
+  let opened = false
+
+  return {
+    async open() {
+      opened = true
+    },
+    async writeBatch(rows: ExportRow[]) {
+      if (!opened) {
+        throw new Error('Export writer is not open')
+      }
+      for (const row of rows) {
+        await writeWithBackpressure(writable, `${JSON.stringify(row)}\n`)
+      }
+    },
+    async close() {
+      opened = false
+      await new Promise<void>((resolve, reject) => {
+        writable.end((err?: Error | null) => (err ? reject(err) : resolve()))
+      })
+    },
+    async abort() {
+      opened = false
+      writable.destroy()
+    },
+  }
+}
+
+/**
+ * In-memory writer for tests; discards payload after write resolves.
+ */
+export function createDiscardExportWriter(): ExportWriter {
+  return {
+    async open() {},
+    async writeBatch(_rows: ExportRow[]) {},
+    async close() {},
+    async abort() {},
+  }
+}
+
+export class ExportService {
+  private readonly defaultBatchSize: number
+
+  constructor(
+    private readonly auditLog: AuditLogService,
+    options: ExportServiceOptions = {},
+  ) {
+    this.defaultBatchSize = options.defaultBatchSize ?? 500
+  }
+
+  createAuditLogDataSource(params: AuditLogExportParams): ExportDataSource {
+    const { startDate, endDate, tenantId, allowSuperScope } = params
+    const scopeOptions = allowSuperScope ? { allowSuperScope: true as const } : undefined
+    const filters = {
+      from: startDate.toISOString(),
+      to: endDate.toISOString(),
+    }
+    const auditLog = this.auditLog
+
+    return {
+      getTotalCount: async () => {
+        let total = 0
+        let cursor: string | undefined
+        const pageSize = this.defaultBatchSize
+        while (true) {
+          const page = await auditLog.getLogs(tenantId, filters, pageSize, cursor, scopeOptions)
+          total += page.logs.length
+          if (!page.hasNextPage || !page.nextCursor) {
+            break
+          }
+          cursor = page.nextCursor
+        }
+        return total
+      },
+      openCursor(batchSize: number) {
+        const stream = auditLog.exportLogsStream(startDate, endDate, tenantId, scopeOptions)
+        return batchEntries(stream, batchSize)
+      },
+    }
+  }
+
+  async runAuditLogExport(
+    params: AuditLogExportParams,
+    writer: ExportWriter,
+    workerOptions: ExportWorkerOptions = {},
+  ): Promise<ExportWorkerResult> {
+    const dataSource = this.createAuditLogDataSource(params)
+    const worker = new ExportWorker(dataSource, writer, {
+      batchSize: workerOptions.batchSize ?? this.defaultBatchSize,
+      logger: workerOptions.logger,
+    })
+    return worker.run()
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,8 @@ export { ReportStorageService } from './reportStorage.js'
 export { ReplayService } from './replayService.js'
 export { BondCacheService } from './bondCacheService.js'
 export { AttestationCacheService } from './attestationCacheService.js'
+export {
+  ExportService,
+  createDiscardExportWriter,
+  createNdjsonExportWriter,
+} from './exportService.js'

--- a/tests/integration/exportWorker.integration.test.ts
+++ b/tests/integration/exportWorker.integration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { AuditLogService, AuditAction } from '../../src/services/audit/index.js'
+import { InMemoryAuditLogsRepository } from '../../src/db/repositories/auditLogsRepository.js'
+import {
+  ExportService,
+  createDiscardExportWriter,
+} from '../../src/services/exportService.js'
+
+describe('Export worker integration', () => {
+  it('streams a large audit export without buffering the full dataset in memory', async () => {
+    const repo = new InMemoryAuditLogsRepository()
+    const auditLog = new AuditLogService(repo)
+    const tenantId = 'tenant-large-export'
+    const rowCount = 2_500
+
+    for (let i = 0; i < rowCount; i++) {
+      await auditLog.logAction(
+        tenantId,
+        'admin-1',
+        'admin@example.com',
+        AuditAction.EXPORT_AUDIT_LOGS,
+        `row-${i}`,
+      )
+    }
+
+    const startDate = new Date(Date.now() - 86_400_000)
+    const endDate = new Date(Date.now() + 86_400_000)
+
+    const exportService = new ExportService(auditLog, { defaultBatchSize: 500 })
+    const result = await exportService.runAuditLogExport(
+      { startDate, endDate, tenantId },
+      createDiscardExportWriter(),
+    )
+
+    expect(result.totalRows).toBe(rowCount)
+    expect(result.batchesProcessed).toBe(Math.ceil(rowCount / 500))
+    expect(result.errors).toBe(0)
+  }, 60_000)
+})


### PR DESCRIPTION
Closes #957

## Summary
- [Fresh 2026-04][Backend] Exports: fix export worker memory growth via streaming/backpressure

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths