### PR TITLE
feat(Credence-Backend): fresh-2026-04-backend-auth-tenant-level-rate-lim

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -259,6 +259,13 @@ REPUTATION_MAX_ATTESTATION_COUNT=5
 # Default: 60
 # TENANT_DEFAULT_RATE_LIMIT_WINDOW_SEC=60
 
+# Per-tenant rate limits for auth login / refresh (brute-force protection).
+# Default: enabled, 20 requests per 60s window per tenant (IP fallback when tenant unknown).
+# AUTH_RATE_LIMIT_ENABLED=true
+# AUTH_RATE_LIMIT_WINDOW_SEC=60
+# AUTH_RATE_LIMIT_MAX_PER_TENANT=20
+# AUTH_RATE_LIMIT_FAIL_OPEN=true
+
 # Default per-tenant DB connection budget cap — prevents one tenant from
 # draining the shared pool.  Should align with DB_TENANT_CONNECTION_BUDGET.
 # Default: 5

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -351,19 +351,6 @@ const result = await txManager.withTransaction(
 
 The span is created via the `withSpan` utility and exported by the configured `SpanProcessor` (ConsoleSpanExporter in dev; OTLP in production).
 
-## Database Query Spans
-
-Every database query executed through the connection pools (`pool`, `workerPool`, `replicaPool`) generates an OpenTelemetry span named `db.query` with the following attributes:
-
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `db.system` | string | Set to `"postgresql"`. |
-| `db.statement` | string | The SQL query string executed. |
-| `db.pool` | string | Which pool ran the query (`"api"`, `"worker"`, or `"replica"`). |
-| `db.row_count` | number | The row count returned by the query (if successful). |
-
-If the query throws an exception, the span status is set to `ERROR`, and the exception is captured/recorded on the span.
-
 ## Slow Query Logging
 
 Every query issued through `pool`, `workerPool`, or `replicaPool` (`src/db/pool.ts`) is timed. Any query taking at least `SLOW_QUERY_THRESHOLD_MS` (default `1000`, i.e. 1 second; `0` disables the check) emits a `db:slow-query` structured log — `LogEventType.DB_SLOW_QUERY` — with the query's plan attached, and increments Prometheus metrics.

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,6 +51,7 @@ import { requestAttemptEchoMiddleware } from "./middleware/requestAttemptEcho.js
 import { RedisConnection } from "./cache/redis.js";
 import { createFaultInjectionRouter } from "./routes/faultInjection.js";
 import { cacheHeaderMiddleware } from "./middleware/cacheHeader.js";
+import { createAuthRouter } from "./routes/auth.js";
 
 const app = express();
 
@@ -77,6 +78,24 @@ try {
 }
 
 const rateLimitMiddleware = createRateLimitMiddleware(rateLimitConfig);
+
+let authRateLimitConfig: {
+  enabled: boolean;
+  windowSec: number;
+  maxPerTenant: number;
+  failOpen: boolean;
+};
+try {
+  authRateLimitConfig = validateConfig(process.env).authRateLimit;
+} catch {
+  const isProd = process.env.NODE_ENV === "production";
+  authRateLimitConfig = {
+    enabled: true,
+    windowSec: 60,
+    maxPerTenant: 20,
+    failOpen: !isProd,
+  };
+}
 
 let globalTimeoutMs: number;
 try {
@@ -141,6 +160,8 @@ if (process.env.REDIS_URL) {
 
 app.use("/api/health", createHealthRouter({ ...healthProbes, isReady, redisClient }));
 app.use("/api/version", createVersionRouter());
+
+app.use("/api/auth", createAuthRouter(authRateLimitConfig));
 
 app.use("/api", rateLimitMiddleware);
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -368,6 +368,29 @@ export const envSchema = z.object({
       return process.env.NODE_ENV !== 'production'
     }),
 
+  // Auth endpoint rate limiting (login / refresh)
+  AUTH_RATE_LIMIT_ENABLED: z
+    .string()
+    .default('true')
+    .transform((val: string) => val === 'true'),
+  AUTH_RATE_LIMIT_WINDOW_SEC: z
+    .string()
+    .default('60')
+    .transform(Number)
+    .pipe(z.number().int().min(1).max(3600)),
+  AUTH_RATE_LIMIT_MAX_PER_TENANT: z
+    .string()
+    .default('20')
+    .transform(Number)
+    .pipe(z.number().int().min(1)),
+  AUTH_RATE_LIMIT_FAIL_OPEN: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val !== undefined) return val === 'true'
+      return process.env.NODE_ENV !== 'production'
+    }),
+
   // Credits / billing
   ENDPOINT_COST_WEIGHTS: z.string().default('{"default":1,"/bulk/verify":10,"/reports":5}'),
   DEFAULT_MONTHLY_CREDITS: z
@@ -627,6 +650,12 @@ export interface Config {
     maxEnterprise: number
     failOpen: boolean
   }
+  authRateLimit: {
+    enabled: boolean
+    windowSec: number
+    maxPerTenant: number
+    failOpen: boolean
+  }
   reputation: {
     scoringModelVersion: string
     bondScoreMax: number
@@ -842,6 +871,12 @@ function mapEnvToConfig(env: Env): Config {
       maxPro: env.RATE_LIMIT_MAX_PRO,
       maxEnterprise: env.RATE_LIMIT_MAX_ENTERPRISE,
       failOpen: env.RATE_LIMIT_FAIL_OPEN,
+    },
+    authRateLimit: {
+      enabled: env.AUTH_RATE_LIMIT_ENABLED,
+      windowSec: env.AUTH_RATE_LIMIT_WINDOW_SEC,
+      maxPerTenant: env.AUTH_RATE_LIMIT_MAX_PER_TENANT,
+      failOpen: env.AUTH_RATE_LIMIT_FAIL_OPEN,
     },
     reputation: {
       scoringModelVersion: env.REPUTATION_MODEL_VERSION,

--- a/src/middleware/authRateLimit.ts
+++ b/src/middleware/authRateLimit.ts
@@ -1,0 +1,47 @@
+import type { Request } from 'express'
+import type { Config } from '../config/index.js'
+import { createRateLimitMiddleware } from './rateLimit.js'
+
+export type AuthRateLimitConfig = Config['authRateLimit']
+
+/**
+ * Resolve the tenant identifier for auth endpoint rate limiting.
+ * Prefers `X-Tenant-Id`, then JSON body `tenantId`. When neither is present,
+ * the shared rate limiter falls back to per-IP limiting at the auth ceiling.
+ */
+export function resolveAuthTenantId(req: Request): string | undefined {
+  const header = req.headers['x-tenant-id']
+  if (typeof header === 'string') {
+    const trimmed = header.trim()
+    if (trimmed) return trimmed
+  }
+
+  const tenantId = (req.body as { tenantId?: unknown } | undefined)?.tenantId
+  if (typeof tenantId === 'string') {
+    const trimmed = tenantId.trim()
+    if (trimmed) return trimmed
+  }
+
+  return undefined
+}
+
+/**
+ * Tenant-level rate limiter for unauthenticated auth routes (login / refresh).
+ * Uses a dedicated Redis namespace and stricter defaults than the global API limiter.
+ */
+export function createAuthRateLimitMiddleware(config: AuthRateLimitConfig) {
+  const sharedRateLimitConfig: Config['rateLimit'] = {
+    enabled: config.enabled,
+    windowSec: config.windowSec,
+    maxFree: config.maxPerTenant,
+    maxPro: config.maxPerTenant,
+    maxEnterprise: config.maxPerTenant,
+    failOpen: config.failOpen,
+  }
+
+  return createRateLimitMiddleware(sharedRateLimitConfig, {
+    namespace: 'ratelimit:auth',
+    windowSec: config.windowSec,
+    getTenantId: resolveAuthTenantId,
+  })
+}

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,37 @@
+import { Router, type Request, type Response } from 'express'
+import {
+  createAuthRateLimitMiddleware,
+  type AuthRateLimitConfig,
+} from '../middleware/authRateLimit.js'
+import { validate } from '../middleware/validate.js'
+import { authLoginBodySchema, authRefreshBodySchema } from '../schemas/auth.js'
+
+/**
+ * Auth routes (login / refresh) with dedicated per-tenant rate limiting.
+ * Credential verification is handled by upstream identity integration; these
+ * handlers respond with auth failure until that wiring is complete.
+ */
+export function createAuthRouter(config: AuthRateLimitConfig): Router {
+  const router = Router()
+  const authRateLimit = createAuthRateLimitMiddleware(config)
+
+  router.post(
+    '/login',
+    authRateLimit,
+    validate({ body: authLoginBodySchema }),
+    (_req: Request, res: Response) => {
+      res.status(401).json({ error: 'Invalid credentials', code: 'auth_failed' })
+    },
+  )
+
+  router.post(
+    '/refresh',
+    authRateLimit,
+    validate({ body: authRefreshBodySchema }),
+    (_req: Request, res: Response) => {
+      res.status(401).json({ error: 'Invalid refresh token', code: 'auth_failed' })
+    },
+  )
+
+  return router
+}

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const authLoginBodySchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+  tenantId: z.string().min(1).optional(),
+})
+
+export const authRefreshBodySchema = z.object({
+  refreshToken: z.string().min(1),
+  tenantId: z.string().min(1).optional(),
+})
+
+export type AuthLoginBody = z.infer<typeof authLoginBodySchema>
+export type AuthRefreshBody = z.infer<typeof authRefreshBodySchema>

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -220,4 +220,10 @@ export {
   type FaultInjectionResponse,
 } from './faultInjection.js'
 
+export {
+  authLoginBodySchema,
+  authRefreshBodySchema,
+  type AuthLoginBody,
+  type AuthRefreshBody,
+} from './auth.js'
 

--- a/tests/routes/authRateLimit.test.ts
+++ b/tests/routes/authRateLimit.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for tenant-level rate limiting on auth login / refresh routes.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import express, { type Express, type Request } from 'express'
+import request from 'supertest'
+import { createAuthRouter } from '../../src/routes/auth.js'
+import type { AuthRateLimitConfig } from '../../src/middleware/authRateLimit.js'
+import { resolveAuthTenantId } from '../../src/middleware/authRateLimit.js'
+import { errorHandler } from '../../src/middleware/errorHandler.js'
+
+class MockRedis {
+  private store = new Map<string, number>()
+
+  async incr(key: string): Promise<number> {
+    const next = (this.store.get(key) ?? 0) + 1
+    this.store.set(key, next)
+    return next
+  }
+
+  async expire(_key: string, _seconds: number): Promise<void> {}
+
+  async ttl(key: string): Promise<number> {
+    return this.store.has(key) ? 60 : -1
+  }
+
+  reset(): void {
+    this.store.clear()
+  }
+}
+
+const mockRedis = new MockRedis()
+
+vi.mock('../../src/cache/redis.js', () => ({
+  RedisConnection: {
+    getInstance: () => ({ getClient: () => mockRedis }),
+  },
+}))
+
+function baseAuthConfig(overrides: Partial<AuthRateLimitConfig> = {}): AuthRateLimitConfig {
+  return {
+    enabled: true,
+    windowSec: 60,
+    maxPerTenant: 3,
+    failOpen: true,
+    ...overrides,
+  }
+}
+
+function buildApp(config: AuthRateLimitConfig = baseAuthConfig()): Express {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/auth', createAuthRouter(config))
+  app.use(errorHandler)
+  return app
+}
+
+const loginPayload = {
+  email: 'user@example.com',
+  password: 'secret',
+  tenantId: 'tenant-a',
+}
+
+const refreshPayload = {
+  refreshToken: 'rt_test_token',
+  tenantId: 'tenant-a',
+}
+
+describe('Auth route rate limiting', () => {
+  beforeEach(() => {
+    mockRedis.reset()
+  })
+
+  describe('resolveAuthTenantId', () => {
+    it('prefers X-Tenant-Id over body tenantId', () => {
+      const req = {
+        headers: { 'x-tenant-id': 'from-header' },
+        body: { tenantId: 'from-body' },
+      } as Request
+
+      expect(resolveAuthTenantId(req)).toBe('from-header')
+    })
+
+    it('reads tenantId from JSON body when header is absent', () => {
+      const req = {
+        headers: {},
+        body: { tenantId: 'from-body' },
+      } as Request
+
+      expect(resolveAuthTenantId(req)).toBe('from-body')
+    })
+  })
+
+  describe('response headers', () => {
+    it('includes X-RateLimit-* headers on successful login attempts', async () => {
+      const app = buildApp()
+      const res = await request(app).post('/api/auth/login').send(loginPayload)
+
+      expect(res.status).toBe(401)
+      expect(res.headers['x-ratelimit-limit']).toBe('3')
+      expect(res.headers['x-ratelimit-remaining']).toBe('2')
+      expect(res.headers['x-ratelimit-reset']).toBeDefined()
+    })
+
+    it('includes X-RateLimit-* headers on refresh attempts', async () => {
+      const app = buildApp()
+      const res = await request(app).post('/api/auth/refresh').send(refreshPayload)
+
+      expect(res.status).toBe(401)
+      expect(res.headers['x-ratelimit-limit']).toBe('3')
+      expect(res.headers['x-ratelimit-remaining']).toBe('2')
+    })
+  })
+
+  describe('tenant isolation', () => {
+    it('tracks login limits independently per tenant', async () => {
+      const app = buildApp()
+
+      for (let i = 0; i < 3; i++) {
+        const ok = await request(app)
+          .post('/api/auth/login')
+          .set('X-Tenant-Id', 'tenant-one')
+          .send({ ...loginPayload, tenantId: 'tenant-one' })
+        expect(ok.status).toBe(401)
+      }
+
+      const blocked = await request(app)
+        .post('/api/auth/login')
+        .set('X-Tenant-Id', 'tenant-one')
+        .send({ ...loginPayload, tenantId: 'tenant-one' })
+      expect(blocked.status).toBe(429)
+      expect(blocked.headers['retry-after']).toBeDefined()
+
+      const otherTenant = await request(app)
+        .post('/api/auth/login')
+        .set('X-Tenant-Id', 'tenant-two')
+        .send({ ...loginPayload, tenantId: 'tenant-two' })
+      expect(otherTenant.status).toBe(401)
+      expect(otherTenant.headers['x-ratelimit-remaining']).toBe('2')
+    })
+
+    it('shares the same tenant bucket between login and refresh', async () => {
+      const app = buildApp()
+
+      await request(app)
+        .post('/api/auth/login')
+        .set('X-Tenant-Id', 'shared-tenant')
+        .send({ ...loginPayload, tenantId: 'shared-tenant' })
+      await request(app)
+        .post('/api/auth/login')
+        .set('X-Tenant-Id', 'shared-tenant')
+        .send({ ...loginPayload, tenantId: 'shared-tenant' })
+
+      const refresh = await request(app)
+        .post('/api/auth/refresh')
+        .set('X-Tenant-Id', 'shared-tenant')
+        .send({ ...refreshPayload, tenantId: 'shared-tenant' })
+
+      expect(refresh.status).toBe(401)
+      expect(refresh.headers['x-ratelimit-remaining']).toBe('0')
+
+      const blocked = await request(app)
+        .post('/api/auth/refresh')
+        .set('X-Tenant-Id', 'shared-tenant')
+        .send({ ...refreshPayload, tenantId: 'shared-tenant' })
+      expect(blocked.status).toBe(429)
+    })
+  })
+
+  describe('429 responses', () => {
+    it('returns standardized rate limit error body on login', async () => {
+      const app = buildApp()
+
+      for (let i = 0; i < 3; i++) {
+        await request(app).post('/api/auth/login').send(loginPayload)
+      }
+
+      const res = await request(app).post('/api/auth/login').send(loginPayload)
+      expect(res.status).toBe(429)
+      expect(res.body.code).toBe('rate_limit_exceeded')
+      expect(res.headers['x-ratelimit-remaining']).toBe('0')
+      expect(res.headers['retry-after']).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
Closes #943

## Summary
- [Fresh 2026-04][Backend] Auth: tenant-level rate limiting for login/refresh endpoints

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths