### PR TITLE
feat(Credence-Backend): add-a-reset-test-db-script-for-local-dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,7 @@ DB_URL=postgresql://user:password@localhost:5432/credence
 # Example (matches docker-compose.test.yml defaults):
 #   TEST_DATABASE_URL=postgresql://credence:credence@localhost:5433/credence_test
 # TEST_DATABASE_URL=
+# Reset drop/create/migrate: npm run test:db:reset (see docs/local-testing-guide.md)
 
 # ── Database Pool Tuning ─────────────────────────────────────────────────────
 # Maximum connections in the API pool (default: 20)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ All configuration is driven by environment variables. Copy `.env.example` to `.e
 | `npm run migrate`         | Run pending migrations (CI/production)     |
 | `npm run migrate:down`    | Rollback last migration                    |
 | `npm run migrate:dry-run` | Preview pending migrations without running |
+| `npm run test:db:reset`   | Drop, recreate, and migrate local test DB  |
 
 ## Developer Setup
 

--- a/docs/CONFIG_TEMPLATE.md
+++ b/docs/CONFIG_TEMPLATE.md
@@ -222,7 +222,7 @@ Consumed by `docker-compose.yml`, not by the app directly:
 | `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | `credence` | Container credentials; compose builds `DATABASE_URL` from them. |
 | `POSTGRES_PORT` | `5432` | Host-exposed Postgres port. |
 | `REDIS_PORT` | `6379` | Host-exposed Redis port. |
-| `TEST_DATABASE_URL` | unset | Integration tests connect directly to this URL instead of spinning up testcontainers (required in CI; matches `docker-compose.test.yml`). |
+| `TEST_DATABASE_URL` | unset | Integration tests connect directly to this URL instead of spinning up testcontainers (required in CI; matches `docker-compose.test.yml`). Reset locally with `npm run test:db:reset` (see [local-testing-guide.md](./local-testing-guide.md)). |
 
 ## Common pitfalls
 

--- a/docs/CONTRIBUTING-TESTING.md
+++ b/docs/CONTRIBUTING-TESTING.md
@@ -101,6 +101,15 @@ pnpm run migrate:dev
 DB_URL=postgresql://credence:credence@localhost:5433/credence_test pnpm run migrate:dev
 ```
 
+To drop, recreate, and re-apply all migrations on the test database in one step (same URL defaults as above):
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+npm run test:db:reset
+```
+
+Uses `TEST_DATABASE_URL` when set; otherwise `src/config/testDatabase.ts` defaults. Only the `credence_test` database name is allowed.
+
 ---
 
 ## Test Commands

--- a/docs/local-testing-guide.md
+++ b/docs/local-testing-guide.md
@@ -65,6 +65,9 @@ docker-compose -f docker-compose.test.yml exec test-db pg_isready
 # Run tests
 TEST_DATABASE_URL=postgresql://credence:credence@localhost:5433/credence_test npm test
 
+# Drop, recreate, and re-migrate the test database (requires test-db running)
+npm run test:db:reset
+
 # Stop when done
 docker-compose -f docker-compose.test.yml down
 ```

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -351,19 +351,6 @@ const result = await txManager.withTransaction(
 
 The span is created via the `withSpan` utility and exported by the configured `SpanProcessor` (ConsoleSpanExporter in dev; OTLP in production).
 
-## Database Query Spans
-
-Every database query executed through the connection pools (`pool`, `workerPool`, `replicaPool`) generates an OpenTelemetry span named `db.query` with the following attributes:
-
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `db.system` | string | Set to `"postgresql"`. |
-| `db.statement` | string | The SQL query string executed. |
-| `db.pool` | string | Which pool ran the query (`"api"`, `"worker"`, or `"replica"`). |
-| `db.row_count` | number | The row count returned by the query (if successful). |
-
-If the query throws an exception, the span status is set to `ERROR`, and the exception is captured/recorded on the span.
-
 ## Slow Query Logging
 
 Every query issued through `pool`, `workerPool`, or `replicaPool` (`src/db/pool.ts`) is timed. Any query taking at least `SLOW_QUERY_THRESHOLD_MS` (default `1000`, i.e. 1 second; `0` disables the check) emits a `db:slow-query` structured log — `LogEventType.DB_SLOW_QUERY` — with the query's plan attached, and increments Prometheus metrics.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "migrate:preflight": "tsx src/migrations/linter.ts pre-flight",
     "migrate:template": "tsx src/migrations/linter.ts template",
     "migrate:safety": "tsx src/migrations/linter.ts check --strict",
+    "test:db:reset": "npm run build && tsx scripts/reset-test-db.ts",
     "generate:openapi": "npx tsx scripts/generate-openapi.ts",
     "drill:horizon": "tsx scripts/horizon-failover-drill.ts",
     "drill:restore": "tsx scripts/restore-verify.ts"

--- a/scripts/reset-test-db.ts
+++ b/scripts/reset-test-db.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+/**
+ * Drop, recreate, and re-migrate the local test database.
+ *
+ * Requires a running Postgres instance (e.g. docker compose -f docker-compose.test.yml up -d).
+ * Uses TEST_DATABASE_URL when set; otherwise the default from src/config/testDatabase.ts.
+ */
+
+import dotenv from 'dotenv'
+import { resetTestDatabase } from '../src/db/resetTestDatabase.js'
+
+dotenv.config()
+
+async function main(): Promise<void> {
+  const { databaseUrl, migrationApplied } = await resetTestDatabase()
+
+  console.log(`✅ Test database reset at ${databaseUrl}`)
+  if (migrationApplied.length === 0) {
+    console.log('Migrations applied (fresh schema)')
+  } else {
+    console.log(`Applied ${migrationApplied.length} migration(s)`)
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`❌ Failed to reset test database: ${message}`)
+  process.exit(1)
+})

--- a/src/config/__tests__/testDatabase.test.ts
+++ b/src/config/__tests__/testDatabase.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  DEFAULT_TEST_DATABASE_NAME,
+  DEFAULT_TEST_DATABASE_URL,
+  resolveTestDatabaseUrl,
+} from '../testDatabase.js'
+
+describe('testDatabase config', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.TEST_DATABASE_URL
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('exposes defaults aligned with docker-compose.test.yml', () => {
+    expect(DEFAULT_TEST_DATABASE_NAME).toBe('credence_test')
+    expect(DEFAULT_TEST_DATABASE_URL).toContain(DEFAULT_TEST_DATABASE_NAME)
+    expect(DEFAULT_TEST_DATABASE_URL).toContain('5433')
+  })
+
+  it('resolveTestDatabaseUrl uses TEST_DATABASE_URL when set', () => {
+    process.env.TEST_DATABASE_URL = 'postgresql://u:p@host:5432/custom_test'
+    expect(resolveTestDatabaseUrl()).toBe('postgresql://u:p@host:5432/custom_test')
+  })
+
+  it('resolveTestDatabaseUrl falls back to default when unset', () => {
+    expect(resolveTestDatabaseUrl()).toBe(DEFAULT_TEST_DATABASE_URL)
+  })
+})

--- a/src/config/testDatabase.ts
+++ b/src/config/testDatabase.ts
@@ -1,0 +1,11 @@
+/** Canonical local test database name (matches `docker-compose.test.yml`). */
+export const DEFAULT_TEST_DATABASE_NAME = 'credence_test'
+
+/** Default connection URL when `TEST_DATABASE_URL` is unset (`docker-compose.test.yml` port 5433). */
+export const DEFAULT_TEST_DATABASE_URL = `postgresql://credence:credence@localhost:5433/${DEFAULT_TEST_DATABASE_NAME}`
+
+/** Resolves the integration-test database URL from the environment or the local default. */
+export function resolveTestDatabaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const fromEnv = env.TEST_DATABASE_URL?.trim()
+  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_TEST_DATABASE_URL
+}

--- a/src/db/__tests__/resetTestDatabase.test.ts
+++ b/src/db/__tests__/resetTestDatabase.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const pgMocks = vi.hoisted(() => {
+  const query = vi.fn().mockResolvedValue({ rows: [] })
+  const end = vi.fn().mockResolvedValue(undefined)
+  return {
+    query,
+    end,
+    Pool: vi.fn(function PoolMock() {
+      return { query, end }
+    }),
+  }
+})
+
+vi.mock('pg', () => ({
+  default: { Pool: pgMocks.Pool },
+}))
+
+import {
+  assertResetAllowedDatabaseName,
+  dropAndRecreateDatabase,
+  parseTestDatabaseTarget,
+  resetTestDatabase,
+} from '../resetTestDatabase.js'
+import { DEFAULT_TEST_DATABASE_NAME, DEFAULT_TEST_DATABASE_URL } from '../../config/testDatabase.js'
+import * as runner from '../../migrations/runner.js'
+
+describe('resetTestDatabase', () => {
+  beforeEach(() => {
+    pgMocks.query.mockClear()
+    pgMocks.end.mockClear()
+    pgMocks.Pool.mockClear()
+  })
+
+  describe('parseTestDatabaseTarget', () => {
+    it('returns admin URL pointed at postgres and the target database name', () => {
+      const { adminConnectionString, databaseName } = parseTestDatabaseTarget(
+        DEFAULT_TEST_DATABASE_URL,
+      )
+
+      expect(databaseName).toBe(DEFAULT_TEST_DATABASE_NAME)
+      expect(adminConnectionString).toContain('/postgres')
+      expect(adminConnectionString).not.toContain(`/${DEFAULT_TEST_DATABASE_NAME}`)
+    })
+
+    it('rejects URLs without a database name', () => {
+      expect(() => parseTestDatabaseTarget('postgresql://credence:credence@localhost:5433/')).toThrow(
+        'must include a database name',
+      )
+    })
+  })
+
+  describe('assertResetAllowedDatabaseName', () => {
+    it('allows the canonical test database name', () => {
+      expect(() => assertResetAllowedDatabaseName(DEFAULT_TEST_DATABASE_NAME)).not.toThrow()
+    })
+
+    it('refuses other database names', () => {
+      expect(() => assertResetAllowedDatabaseName('credence')).toThrow(/Refusing to reset/)
+    })
+  })
+
+  describe('dropAndRecreateDatabase', () => {
+    it('terminates connections, drops, and creates the database', async () => {
+      const query = vi.fn().mockResolvedValue({ rows: [] })
+      const pool = { query } as unknown as import('pg').Pool
+
+      await dropAndRecreateDatabase(pool, DEFAULT_TEST_DATABASE_NAME)
+
+      expect(query).toHaveBeenCalledTimes(3)
+      expect(String(query.mock.calls[0][0])).toContain('pg_terminate_backend')
+      expect(String(query.mock.calls[1][0])).toContain('DROP DATABASE')
+      expect(String(query.mock.calls[2][0])).toContain('CREATE DATABASE')
+    })
+  })
+
+  describe('resetTestDatabase', () => {
+    it('refuses non-test database URLs before connecting', async () => {
+      await expect(
+        resetTestDatabase({
+          testDatabaseUrl: 'postgresql://credence:credence@localhost:5432/credence',
+          skipMigrations: true,
+        }),
+      ).rejects.toThrow(/Refusing to reset/)
+
+      expect(pgMocks.Pool).not.toHaveBeenCalled()
+    })
+
+    it('applies migrations after drop/create', async () => {
+      const runMigrationSpy = vi
+        .spyOn(runner, 'runMigration')
+        .mockResolvedValue({ success: true, applied: ['001_initial_schema'] })
+
+      const result = await resetTestDatabase({
+        testDatabaseUrl: DEFAULT_TEST_DATABASE_URL,
+        migrationConfig: {
+          databaseUrl: DEFAULT_TEST_DATABASE_URL,
+          migrationsDir: 'dist/migrations',
+          migrationsTable: 'pgmigrations',
+          migrationsSchema: 'public',
+          transactional: true,
+          createSchema: true,
+        },
+      })
+
+      expect(pgMocks.Pool).toHaveBeenCalled()
+      expect(result.migrationApplied).toEqual(['001_initial_schema'])
+      expect(runMigrationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ direction: 'up', skipPreflight: true }),
+      )
+
+      runMigrationSpy.mockRestore()
+    })
+
+    it('skips migrations when skipMigrations is true', async () => {
+      const runMigrationSpy = vi.spyOn(runner, 'runMigration')
+
+      const result = await resetTestDatabase({
+        testDatabaseUrl: DEFAULT_TEST_DATABASE_URL,
+        skipMigrations: true,
+      })
+
+      expect(result.migrationApplied).toEqual([])
+      expect(runMigrationSpy).not.toHaveBeenCalled()
+
+      runMigrationSpy.mockRestore()
+    })
+  })
+})

--- a/src/db/resetTestDatabase.ts
+++ b/src/db/resetTestDatabase.ts
@@ -1,0 +1,120 @@
+import pg from 'pg'
+import {
+  DEFAULT_TEST_DATABASE_NAME,
+  resolveTestDatabaseUrl,
+} from '../config/testDatabase.js'
+import type { MigrationConfig } from '../migrations/config.js'
+import { runMigration } from '../migrations/runner.js'
+
+const { Pool } = pg
+
+export interface ResetTestDatabaseResult {
+  databaseUrl: string
+  migrationApplied: string[]
+}
+
+export interface ResetTestDatabaseOptions {
+  testDatabaseUrl?: string
+  skipMigrations?: boolean
+  verbose?: boolean
+  migrationConfig?: MigrationConfig
+}
+
+/** Splits a PostgreSQL URL into an admin connection (postgres DB) and target database name. */
+export function parseTestDatabaseTarget(connectionString: string): {
+  adminConnectionString: string
+  databaseName: string
+} {
+  let url: URL
+  try {
+    url = new URL(connectionString)
+  } catch {
+    throw new Error('TEST_DATABASE_URL must be a valid PostgreSQL connection string')
+  }
+
+  const databaseName = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  if (!databaseName) {
+    throw new Error('TEST_DATABASE_URL must include a database name in the path')
+  }
+
+  url.pathname = '/postgres'
+  return {
+    adminConnectionString: url.toString(),
+    databaseName,
+  }
+}
+
+/** Blocks accidental resets of non-test databases. */
+export function assertResetAllowedDatabaseName(databaseName: string): void {
+  if (databaseName !== DEFAULT_TEST_DATABASE_NAME) {
+    throw new Error(
+      `Refusing to reset database "${databaseName}". Only "${DEFAULT_TEST_DATABASE_NAME}" may be reset.`,
+    )
+  }
+}
+
+export async function dropAndRecreateDatabase(
+  adminPool: pg.Pool,
+  databaseName: string,
+): Promise<void> {
+  assertResetAllowedDatabaseName(databaseName)
+
+  await adminPool.query(
+    `SELECT pg_terminate_backend(pid)
+     FROM pg_stat_activity
+     WHERE datname = $1 AND pid <> pg_backend_pid()`,
+    [databaseName],
+  )
+  await adminPool.query(`DROP DATABASE IF EXISTS "${databaseName}"`)
+  await adminPool.query(`CREATE DATABASE "${databaseName}"`)
+}
+
+function migrationConfigForTestDatabase(databaseUrl: string): MigrationConfig {
+  return {
+    databaseUrl,
+    migrationsDir: process.env.MIGRATIONS_DIR ?? 'dist/migrations',
+    migrationsTable: process.env.MIGRATIONS_TABLE ?? 'pgmigrations',
+    migrationsSchema: process.env.MIGRATIONS_SCHEMA ?? 'public',
+    transactional: process.env.MIGRATIONS_TRANSACTIONAL !== 'false',
+    createSchema: process.env.MIGRATIONS_CREATE_SCHEMA !== 'false',
+  }
+}
+
+/**
+ * Drops and recreates the local test database, then applies migrations.
+ * Uses `TEST_DATABASE_URL` when set, otherwise {@link DEFAULT_TEST_DATABASE_URL}.
+ */
+export async function resetTestDatabase(
+  options: ResetTestDatabaseOptions = {},
+): Promise<ResetTestDatabaseResult> {
+  const databaseUrl = options.testDatabaseUrl ?? resolveTestDatabaseUrl()
+  const { adminConnectionString, databaseName } = parseTestDatabaseTarget(databaseUrl)
+  assertResetAllowedDatabaseName(databaseName)
+
+  const adminPool = new Pool({ connectionString: adminConnectionString })
+  try {
+    await dropAndRecreateDatabase(adminPool, databaseName)
+  } finally {
+    await adminPool.end()
+  }
+
+  if (options.skipMigrations) {
+    return { databaseUrl, migrationApplied: [] }
+  }
+
+  const migrationConfig =
+    options.migrationConfig ?? migrationConfigForTestDatabase(databaseUrl)
+
+  const result = await runMigration({
+    direction: 'up',
+    config: migrationConfig,
+    skipPreflight: true,
+    verbose: options.verbose ?? true,
+  })
+
+  if (!result.success) {
+    throw new Error(result.error ?? 'Migration failed after test database reset')
+  }
+
+  return { databaseUrl, migrationApplied: result.applied }
+}

--- a/tests/integration/testDatabase.ts
+++ b/tests/integration/testDatabase.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg'
 import { GenericContainer, Wait, type StartedTestContainer } from 'testcontainers'
 import { createClient, type RedisClientType } from 'redis'
+import { DEFAULT_TEST_DATABASE_NAME } from '../../src/config/testDatabase.js'
 
 export interface TestDatabase {
   pool: Pool
@@ -34,7 +35,7 @@ export async function createTestDatabase(): Promise<TestDatabase> {
 
   const user = 'credence'
   const password = 'credence'
-  const database = 'credence_test'
+  const database = DEFAULT_TEST_DATABASE_NAME
 
   try {
     const container: StartedTestContainer = await new GenericContainer('postgres:16-alpine')


### PR DESCRIPTION
Closes #683

## Summary
- Add a "reset test DB" script for local dev

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths