### PR TITLE
chore(api): add stable validation error codes and contract tests (#972)

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -18,6 +18,7 @@ This reference is generated from `src/lib/errorCatalog.ts` and is the source of 
 | --- | ---: | --- | --- |
 | `invalid_input` | 400 |  | Invalid input |
 | `unauthorized` | 401 | authentication | Authentication is required |
+| `crawler_blocked` | 403 | authorization | Automated crawling of admin surfaces is forbidden. |
 | `forbidden` | 403 | authorization | The authenticated caller is not allowed to perform this action |
 | `insufficient_credits` | 402 | business | Monthly credit budget exhausted |
 | `idempotency_key_mismatch` | 409 | business | Idempotency key is already bound to a different actor or payload |
@@ -27,6 +28,7 @@ This reference is generated from `src/lib/errorCatalog.ts` and is the source of 
 | `not_found` | 404 | resource | The requested resource was not found |
 | `conflict` | 409 | resource | The request conflicts with the current resource state |
 | `internal_server_error` | 500 | system | An unexpected internal server error occurred |
+| `missing_security_header` | 500 | system | A required security response header is missing |
 | `service_unavailable` | 503 | system | Service temporarily unavailable |
 | `batch_size_too_small` | 400 | validation | The batch size is below the allowed minimum |
 | `field_required` | 400 | validation | A required field is missing |
@@ -41,6 +43,7 @@ This reference is generated from `src/lib/errorCatalog.ts` and is the source of 
 | `value_too_small` | 400 | validation | The request contains a value below the allowed minimum |
 | `batch_size_exceeded` | 413 | validation | The batch size exceeds the allowed maximum |
 | `request_too_large` | 413 | validation | The request body exceeds the maximum allowed size |
+| `ssrf_blocked` | 422 | validation | The target URL resolves to a restricted or internal network address |
 
 ## Localization catalog
 
@@ -48,7 +51,7 @@ This reference is generated from `src/lib/errorCatalog.ts` and is the source of 
 
 | Locale | Coverage | Notes |
 | --- | ---: | --- |
-| `en` | 29 messages | Catalog default messages for active codes. |
+| `en` | 32 messages | Catalog default messages for active codes. |
 
 ## Deprecated codes
 

--- a/src/__tests__/validationContract.test.ts
+++ b/src/__tests__/validationContract.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import request from 'supertest'
 import express, { type Express } from 'express'
 import { z } from 'zod'
-import { validate } from '../middleware/validate.js'
+import { validate, formatZodErrors } from '../middleware/validate.js'
 import { errorHandler } from '../middleware/errorHandler.js'
 import { ErrorCode } from '../lib/errors.js'
 
@@ -21,6 +21,69 @@ describe('Validation Error Codes Contract', () => {
     app.use(errorHandler)
   }
 
+  // ── Envelope shape ─────────────────────────────────────────────────────
+
+  it('top-level error envelope always carries validation_failed code on validation errors', async () => {
+    const schema = z.object({ name: z.string() })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({})
+
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe(ErrorCode.VALIDATION_FAILED)
+    expect(res.body.error_code).toBe(ErrorCode.VALIDATION_FAILED)
+    expect(typeof res.body.error).toBe('string')
+  })
+
+  it('details array is always present with stable shape', async () => {
+    const schema = z.object({ name: z.string() })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({})
+
+    expect(Array.isArray(res.body.details)).toBe(true)
+    expect(res.body.details.length).toBeGreaterThan(0)
+    for (const d of res.body.details) {
+      expect(typeof d.path).toBe('string')
+      expect(typeof d.message).toBe('string')
+      expect(typeof d.code).toBe('string')
+    }
+  })
+
+  it('details path uses dot-notation for nested fields', async () => {
+    const schema = z.object({
+      user: z.object({
+        address: z.object({
+          zip: z.string().regex(/^\d{5}$/),
+        }),
+      }),
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ user: { address: { zip: 'abc' } } })
+
+    expect(res.body.details[0].path).toBe('user.address.zip')
+  })
+
+  it('details path is (root) for top-level parse failures', async () => {
+    const schema = z.string().min(5)
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send('abc')
+
+    expect(res.body.details[0].path).toBe('(root)')
+  })
+
+  // ── FIELD_REQUIRED (invalid_type, received undefined) ──────────────────
+
   it('returns FIELD_REQUIRED when a required field is missing', async () => {
     const schema = z.object({
       name: z.string()
@@ -32,10 +95,26 @@ describe('Validation Error Codes Contract', () => {
       .send({})
 
     expect(res.status).toBe(400)
-    expect(res.body.code).toBe(ErrorCode.VALIDATION_FAILED)
     expect(res.body.details[0].code).toBe(ErrorCode.FIELD_REQUIRED)
     expect(res.body.details[0].path).toBe('name')
   })
+
+  it('returns FIELD_REQUIRED when nested required field is missing', async () => {
+    const schema = z.object({
+      meta: z.object({ key: z.string() })
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ meta: {} })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.FIELD_REQUIRED)
+    expect(res.body.details[0].path).toBe('meta.key')
+  })
+
+  // ── INVALID_TYPE (invalid_type, wrong type) ────────────────────────────
 
   it('returns INVALID_TYPE when a field has wrong type', async () => {
     const schema = z.object({
@@ -51,6 +130,64 @@ describe('Validation Error Codes Contract', () => {
     expect(res.body.details[0].code).toBe(ErrorCode.INVALID_TYPE)
   })
 
+  it('returns INVALID_TYPE for invalid literal values', async () => {
+    const schema = z.object({
+      kind: z.literal('active')
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ kind: 'inactive' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_TYPE)
+  })
+
+  it('returns INVALID_TYPE for enum violations', async () => {
+    const schema = z.object({
+      status: z.enum(['pending', 'confirmed'])
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ status: 'unknown' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_TYPE)
+  })
+
+  it('returns INVALID_TYPE for union failures', async () => {
+    const schema = z.object({
+      value: z.union([z.string(), z.number()])
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ value: true })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_TYPE)
+  })
+
+  it('returns INVALID_TYPE for date with wrong type', async () => {
+    const schema = z.object({
+      date: z.date()
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ date: 'not-a-date' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_TYPE)
+  })
+
+  // ── INVALID_FORMAT (invalid_format / not_multiple_of / invalid_key) ─────
+
   it('returns INVALID_FORMAT for regex mismatches on non-address fields', async () => {
     const schema = z.object({
       id: z.string().regex(/^\d+$/)
@@ -64,6 +201,22 @@ describe('Validation Error Codes Contract', () => {
     expect(res.status).toBe(400)
     expect(res.body.details[0].code).toBe(ErrorCode.INVALID_FORMAT)
   })
+
+  it('returns INVALID_FORMAT for not_multiple_of', async () => {
+    const schema = z.object({
+      amount: z.number().multipleOf(5)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ amount: 7 })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_FORMAT)
+  })
+
+  // ── INVALID_ADDRESS (address-related format mismatches) ────────────────
 
   it('returns INVALID_ADDRESS for address regex mismatches', async () => {
     const schema = z.object({
@@ -79,7 +232,83 @@ describe('Validation Error Codes Contract', () => {
     expect(res.body.details[0].code).toBe(ErrorCode.INVALID_ADDRESS)
   })
 
-  it('returns VALUE_TOO_SMALL for min constraints', async () => {
+  it('returns INVALID_ADDRESS for fields whose name contains address', async () => {
+    const schema = z.object({
+      userAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ userAddress: 'invalid' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_ADDRESS)
+  })
+
+  // ── INVALID_STELLAR_ADDRESS (custom validator) ─────────────────────────
+
+  it('returns INVALID_STELLAR_ADDRESS for custom stellar address check', async () => {
+    const schema = z.object({
+      stellar: z.string().refine((v) => v.startsWith('G') && v.length === 56, {
+        message: 'INVALID_STELLAR_ADDRESS',
+      })
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ stellar: 'invalid' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_STELLAR_ADDRESS)
+  })
+
+  it('returns INVALID_STELLAR_ADDRESS when message contains stellar and address', async () => {
+    const schema = z.object({
+      dest: z.string().refine(() => false, { message: 'Invalid stellar address format' })
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ dest: 'GABC' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_STELLAR_ADDRESS)
+  })
+
+  it('returns INVALID_ADDRESS for custom address validation that does not mention stellar', async () => {
+    const schema = z.object({
+      wallet: z.string().refine(() => false, { message: 'Invalid wallet address' })
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ wallet: '0xbad' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_ADDRESS)
+  })
+
+  it('returns VALIDATION_FAILED for custom errors unrelated to addresses', async () => {
+    const schema = z.object({
+      value: z.string().refine(() => false, { message: 'Custom business rule failed' })
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ value: 'anything' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.VALIDATION_FAILED)
+  })
+
+  // ── VALUE_TOO_SMALL ────────────────────────────────────────────────────
+
+  it('returns VALUE_TOO_SMALL for number min constraints', async () => {
     const schema = z.object({
       count: z.number().min(10)
     })
@@ -93,7 +322,37 @@ describe('Validation Error Codes Contract', () => {
     expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_SMALL)
   })
 
-  it('returns VALUE_TOO_LARGE for max constraints', async () => {
+  it('returns VALUE_TOO_SMALL for string min length', async () => {
+    const schema = z.object({
+      code: z.string().min(8)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ code: 'short' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_SMALL)
+  })
+
+  it('returns VALUE_TOO_SMALL for array min items', async () => {
+    const schema = z.object({
+      tags: z.array(z.string()).min(2)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ tags: ['one'] })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_SMALL)
+  })
+
+  // ── VALUE_TOO_LARGE ────────────────────────────────────────────────────
+
+  it('returns VALUE_TOO_LARGE for number max constraints', async () => {
     const schema = z.object({
       count: z.number().max(10)
     })
@@ -107,6 +366,22 @@ describe('Validation Error Codes Contract', () => {
     expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_LARGE)
   })
 
+  it('returns VALUE_TOO_LARGE for string max length', async () => {
+    const schema = z.object({
+      code: z.string().max(3)
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ code: 'too-long' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_LARGE)
+  })
+
+  // ── UNEXPECTED_FIELD ───────────────────────────────────────────────────
+
   it('returns UNEXPECTED_FIELD for strict schema violations', async () => {
     const schema = z.object({
       name: z.string()
@@ -119,5 +394,65 @@ describe('Validation Error Codes Contract', () => {
 
     expect(res.status).toBe(400)
     expect(res.body.details[0].code).toBe(ErrorCode.UNEXPECTED_FIELD)
+  })
+
+  // ── Multiple issues ─────────────────────────────────────────────────────
+
+  it('returns multiple details when multiple fields are invalid', async () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number().min(18),
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ age: 15 })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details.length).toBeGreaterThanOrEqual(2)
+    const codes = res.body.details.map((d: any) => d.code)
+    expect(codes).toContain(ErrorCode.FIELD_REQUIRED)
+    expect(codes).toContain(ErrorCode.VALUE_TOO_SMALL)
+  })
+
+  it('returns 400 with validation_failed code for all validation errors', async () => {
+    const schema = z.object({
+      email: z.string().email(),
+    })
+    setupRoute(schema)
+
+    const res = await request(app)
+      .post('/test')
+      .send({ email: 'not-an-email' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe(ErrorCode.VALIDATION_FAILED)
+  })
+})
+
+describe('formatZodErrors - direct unit tests', () => {
+  it('handles invalid_key code', () => {
+    const issue = { code: 'invalid_key', path: ['key'], message: 'Invalid key' }
+    const result = formatZodErrors({ issues: [issue], name: 'ZodError' } as any)
+    expect(result[0].code).toBe(ErrorCode.INVALID_FORMAT)
+  })
+
+  it('handles invalid_arguments code', () => {
+    const issue = { code: 'invalid_arguments', path: [], message: 'Invalid arguments' }
+    const result = formatZodErrors({ issues: [issue], name: 'ZodError' } as any)
+    expect(result[0].code).toBe(ErrorCode.VALIDATION_FAILED)
+  })
+
+  it('handles invalid_return_type code', () => {
+    const issue = { code: 'invalid_return_type', path: [], message: 'Invalid return type' }
+    const result = formatZodErrors({ issues: [issue], name: 'ZodError' } as any)
+    expect(result[0].code).toBe(ErrorCode.VALIDATION_FAILED)
+  })
+
+  it('handles unknown code with VALIDATION_FAILED fallback', () => {
+    const issue = { code: 'some_new_code', path: ['field'], message: 'Unknown error' }
+    const result = formatZodErrors({ issues: [issue], name: 'ZodError' } as any)
+    expect(result[0].code).toBe(ErrorCode.VALIDATION_FAILED)
   })
 })

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -43,56 +43,14 @@ export interface ValidateOptions {
 
 /**
  * Format Zod errors into a consistent structure.
+ * Maps every Zod v4 issue code to a stable error catalog code.
  * @param error - ZodError from schema.safeParse()
  * @returns Array of { path, message, code } for client consumption
  */
 export function formatZodErrors(error: ZodError): Array<{ path: string; message: string; code: string }> {
   return error.issues.map((e) => {
-    let code: ErrorCode = ErrorCode.VALIDATION_FAILED
+    const code = mapZodIssueCode(e)
     const pathStr = e.path?.length ? e.path.join('.') : '(root)'
-    const lowerPath = pathStr.toLowerCase()
-    const lowerMessage = e.message.toLowerCase()
-
-    switch (e.code) {
-      case 'custom':
-        if (e.message === 'INVALID_STELLAR_ADDRESS') {
-          code = ErrorCode.INVALID_STELLAR_ADDRESS
-        } else if (lowerMessage.includes('stellar') && lowerMessage.includes('address')) {
-          code = ErrorCode.INVALID_STELLAR_ADDRESS
-        } else if (lowerPath.includes('address') || lowerMessage.includes('address')) {
-          code = ErrorCode.INVALID_ADDRESS
-        }
-        break
-      case 'invalid_type':
-        // If a required field is missing (value is undefined)
-        if ((e as any).received === 'undefined' || lowerMessage.includes('received undefined') || lowerMessage.includes('required')) {
-          code = ErrorCode.FIELD_REQUIRED
-        } else {
-          code = ErrorCode.INVALID_TYPE
-        }
-        break
-      case 'invalid_format':
-        // String format validations (email, uuid, etc.) in Zod 4
-        if (lowerPath.includes('address') || (lowerMessage.includes('address') && !lowerMessage.includes('email'))) {
-          code = ErrorCode.INVALID_ADDRESS
-        } else {
-          code = ErrorCode.INVALID_FORMAT
-        }
-        break
-      case 'invalid_value':
-        // Enum validation in Zod 4
-        code = ErrorCode.INVALID_TYPE
-        break
-      case 'too_small':
-        code = ErrorCode.VALUE_TOO_SMALL
-        break
-      case 'too_big':
-        code = ErrorCode.VALUE_TOO_LARGE
-        break
-      case 'unrecognized_keys':
-        code = ErrorCode.UNEXPECTED_FIELD
-        break
-    }
 
     return {
       path: pathStr,
@@ -100,6 +58,88 @@ export function formatZodErrors(error: ZodError): Array<{ path: string; message:
       code,
     }
   })
+}
+
+function mapZodIssueCode(issue: Record<string, unknown>): ErrorCode {
+  const e = issue as Record<string, unknown>
+  const code = e.code as string
+  const pathArr = e.path as Array<string | number>
+  const pathStr = pathArr?.length ? pathArr.join('.') : '(root)'
+  const lowerPath = pathStr.toLowerCase()
+  const lowerMessage = (e.message as string)?.toLowerCase() ?? ''
+
+  switch (code) {
+    case 'invalid_type': {
+      const received = e.received as string | undefined
+      if (
+        received === 'undefined' ||
+        lowerMessage.includes('received undefined') ||
+        lowerMessage.includes('required')
+      ) {
+        return ErrorCode.FIELD_REQUIRED
+      }
+      return ErrorCode.INVALID_TYPE
+    }
+
+    case 'invalid_value':
+    case 'invalid_literal':
+    case 'invalid_enum_value':
+      return ErrorCode.INVALID_TYPE
+
+    case 'invalid_string':
+    case 'invalid_format': {
+      if (
+        lowerPath.includes('address') ||
+        (lowerMessage.includes('address') && !lowerMessage.includes('email'))
+      ) {
+        return ErrorCode.INVALID_ADDRESS
+      }
+      return ErrorCode.INVALID_FORMAT
+    }
+
+    case 'invalid_date':
+      return ErrorCode.INVALID_FORMAT
+
+    case 'invalid_union':
+    case 'invalid_union_discriminator':
+      return ErrorCode.INVALID_TYPE
+
+    case 'invalid_arguments':
+    case 'invalid_return_type':
+      return ErrorCode.VALIDATION_FAILED
+
+    case 'too_small':
+      return ErrorCode.VALUE_TOO_SMALL
+
+    case 'too_big':
+      return ErrorCode.VALUE_TOO_LARGE
+
+    case 'unrecognized_keys':
+      return ErrorCode.UNEXPECTED_FIELD
+
+    case 'not_multiple_of':
+      return ErrorCode.INVALID_FORMAT
+
+    case 'invalid_key':
+      return ErrorCode.INVALID_FORMAT
+
+    case 'custom': {
+      const message = e.message as string
+      if (message === 'INVALID_STELLAR_ADDRESS') {
+        return ErrorCode.INVALID_STELLAR_ADDRESS
+      }
+      if (lowerMessage.includes('stellar') && lowerMessage.includes('address')) {
+        return ErrorCode.INVALID_STELLAR_ADDRESS
+      }
+      if (lowerPath.includes('address') || lowerMessage.includes('address')) {
+        return ErrorCode.INVALID_ADDRESS
+      }
+      return ErrorCode.VALIDATION_FAILED
+    }
+
+    default:
+      return ErrorCode.VALIDATION_FAILED
+  }
 }
 
 /**

--- a/tests/routes/validationContract.test.ts
+++ b/tests/routes/validationContract.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Route-level validation error contract tests.
+ *
+ * These tests verify that actual API routes return stable error shapes
+ * when validation fails, ensuring deterministic client handling.
+ *
+ * They test the full middleware stack (validate → handler → errorHandler)
+ * to catch any regressions in error code mapping or envelope shape.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import request from 'supertest'
+import express, { type Express, type Request, type Response, type NextFunction } from 'express'
+import { z } from 'zod'
+import { validate, type ValidateOptions } from '../../src/middleware/validate.js'
+import { errorHandler } from '../../src/middleware/errorHandler.js'
+import { ErrorCode } from '../../src/lib/errors.js'
+
+describe('Route validation error contract', () => {
+  let app: Express
+
+  beforeEach(() => {
+    app = express()
+    app.use(express.json())
+  })
+
+  const setupRoute = (opts: ValidateOptions) => {
+    app.post('/test', validate(opts), (_req: Request, res: Response) => {
+      res.status(200).json({ ok: true })
+    })
+    app.use(errorHandler)
+  }
+
+  // ── Error envelope stability ────────────────────────────────────────────
+
+  it('all validation errors return 400 with error, code, error_code fields', async () => {
+    setupRoute({ body: z.object({ name: z.string() }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 123 })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toMatchObject({
+      error: expect.any(String),
+      code: ErrorCode.VALIDATION_FAILED,
+      error_code: ErrorCode.VALIDATION_FAILED,
+    })
+  })
+
+  it('details field is an array when present', async () => {
+    setupRoute({ body: z.object({ name: z.string() }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({})
+
+    expect(Array.isArray(res.body.details)).toBe(true)
+    expect(res.body.details.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('each detail entry has path, message, and code strings', async () => {
+    setupRoute({ body: z.object({ name: z.string() }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({})
+
+    for (const d of res.body.details) {
+      expect(typeof d.path).toBe('string')
+      expect(typeof d.message).toBe('string')
+      expect(typeof d.code).toBe('string')
+    }
+  })
+
+  // ── Field-level error code stability ────────────────────────────────────
+
+  it('missing required body field yields FIELD_REQUIRED detail code', async () => {
+    setupRoute({ body: z.object({ requiredField: z.string() }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({})
+
+    expect(res.body.details[0].code).toBe(ErrorCode.FIELD_REQUIRED)
+    expect(res.body.details[0].path).toBe('requiredField')
+  })
+
+  it('wrong type body field yields INVALID_TYPE detail code', async () => {
+    setupRoute({ body: z.object({ count: z.number() }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({ count: 'not-a-number' })
+
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_TYPE)
+  })
+
+  it('invalid format yields INVALID_FORMAT detail code', async () => {
+    setupRoute({ body: z.object({ code: z.string().regex(/^\d{3}$/) }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({ code: 'abc' })
+
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_FORMAT)
+  })
+
+  it('value below minimum yields VALUE_TOO_SMALL detail code', async () => {
+    setupRoute({ body: z.object({ age: z.number().min(18) }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({ age: 15 })
+
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_SMALL)
+  })
+
+  it('value above maximum yields VALUE_TOO_LARGE detail code', async () => {
+    setupRoute({ body: z.object({ age: z.number().max(120) }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({ age: 200 })
+
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_LARGE)
+  })
+
+  it('unexpected field yields UNEXPECTED_FIELD detail code', async () => {
+    setupRoute({ body: z.object({ name: z.string() }).strict() })
+
+    const res = await request(app)
+      .post('/test')
+      .send({ name: 'Alice', unknownField: 'surprise' })
+
+    expect(res.body.details[0].code).toBe(ErrorCode.UNEXPECTED_FIELD)
+  })
+
+  it('address format mismatch yields INVALID_ADDRESS detail code', async () => {
+    setupRoute({ body: z.object({ address: z.string().regex(/^0x[a-fA-F0-9]{40}$/) }) })
+
+    const res = await request(app)
+      .post('/test')
+      .send({ address: 'bad' })
+
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_ADDRESS)
+  })
+
+  // ── Query parameter validation ──────────────────────────────────────────
+
+  it('validates query params and returns stable error codes', async () => {
+    setupRoute({ query: z.object({ page: z.coerce.number().min(1) }) })
+
+    const res = await request(app)
+      .post('/test')
+      .query({ page: '0' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe(ErrorCode.VALIDATION_FAILED)
+    expect(res.body.details[0].code).toBe(ErrorCode.VALUE_TOO_SMALL)
+  })
+
+  // ── Path parameter validation ───────────────────────────────────────────
+
+  it('validates path params and returns stable error codes', async () => {
+    app.post('/test/:id', validate({ params: z.object({ id: z.string().regex(/^\d+$/) }) }), (_req: Request, res: Response) => {
+      res.status(200).json({ ok: true })
+    })
+    app.use(errorHandler)
+
+    const res = await request(app)
+      .post('/test/abc')
+
+    expect(res.status).toBe(400)
+    expect(res.body.code).toBe(ErrorCode.VALIDATION_FAILED)
+    expect(res.body.details[0].code).toBe(ErrorCode.INVALID_FORMAT)
+  })
+
+  // ── Multiple sources validated simultaneously ───────────────────────────
+
+  it('validates body + query + params together and collects all errors', async () => {
+    app.post('/test/:id', validate({
+      params: z.object({ id: z.string().regex(/^\d+$/) }),
+      query: z.object({ limit: z.coerce.number().max(100) }),
+      body: z.object({ name: z.string() }),
+    }), (_req: Request, res: Response) => {
+      res.status(200).json({ ok: true })
+    })
+    app.use(errorHandler)
+
+    const res = await request(app)
+      .post('/test/bad')
+      .query({ limit: '999' })
+      .send({ name: 123 })
+
+    // Expect errors from all three sources
+    expect(res.status).toBe(400)
+    expect(res.body.details.length).toBeGreaterThanOrEqual(3)
+    const codes = res.body.details.map((d: any) => d.code)
+    expect(codes).toContain(ErrorCode.INVALID_FORMAT)  // params.id
+    expect(codes).toContain(ErrorCode.VALUE_TOO_LARGE)  // query.limit
+    expect(codes).toContain(ErrorCode.INVALID_TYPE)     // body.name
+  })
+})


### PR DESCRIPTION
Closes #972

# chore(api): add stable validation error codes and contract tests

Closes #972

## PR Summary
This pull request introduces stable validation error codes, expands contract and route-level tests, and updates relevant documentation.

---

## Overview of Changes

### 1. `src/middleware/validate.ts`
* Refactored `formatZodErrors` into a dedicated `mapZodIssueCode` function to handle all Zod v4 issue codes, including edge cases like `invalid_value`, `invalid_string`, and `invalid_arguments`.
* Implemented deterministic fallbacks for unknown error codes mapping to `VALIDATION_FAILED`.

### 2. `src/__tests__/validationContract.test.ts`
* Expanded test coverage from 7 to 31 tests.
* Added validation contracts for envelope shapes, dot-notation paths, nested fields, stable error codes, and multi-source simultaneous validation.

### 3. `tests/routes/validationContract.test.ts`
* Added a new test file containing 13 route-level contract tests covering the full middleware stack (`validate` -> `handler` -> `errorHandler`) across body, query, path parameters, and combined sources.

### 4. `docs/error-codes.md`
* Regenerated documentation to incorporate 3 missing error codes (`crawler_blocked`, `missing_security_header`, `ssrf_blocked`) and updated the total count to 32.

---

## Test Results
* **89 tests passing** across relevant files (pre-existing failures remain isolated to unrelated modules like auth, trust, WebSocket, and SDK parity).