### PR TITLE
chore(queue): validate attestation/withdrawal events, route poison payloads to DLQ

### DIFF
--- a/src/listeners/__tests__/attestationEvents.test.ts
+++ b/src/listeners/__tests__/attestationEvents.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { AttestationEventListener } from '../attestationEvents.js'
+import type { AttestationEvent, AttestationStore } from '../attestationEvents.js'
+import type { Attestation } from '../../types/attestation.js'
+
+function makeStore(): AttestationStore {
+  const attestation: Attestation = {
+    id: 'att-1',
+    subject: 'GSUBJECT',
+    verifier: 'GVERIFIER',
+    weight: 80,
+    claim: 'trusted',
+    createdAt: new Date().toISOString(),
+    revokedAt: null,
+  }
+
+  return {
+    create: vi.fn().mockReturnValue(attestation),
+    findById: vi.fn().mockReturnValue(undefined),
+    findBySubject: vi.fn().mockReturnValue({ attestations: [], total: 0 }),
+    revoke: vi.fn().mockReturnValue(undefined),
+  }
+}
+
+describe('AttestationEventListener - poison message routing', () => {
+  let listener: AttestationEventListener | undefined
+
+  afterEach(() => {
+    listener?.stop()
+    listener = undefined
+  })
+
+  it('routes a schema-invalid event to the DLQ instead of processing it', async () => {
+    const store = makeStore()
+    // weight is out of the 0-100 range accepted by attestationEventSchema.
+    const invalidEvent = {
+      id: 'evt-1',
+      pagingToken: 'pt-1',
+      type: 'add',
+      subject: 'GSUBJECT',
+      verifier: 'GVERIFIER',
+      weight: 150,
+      claim: 'trusted',
+      createdAt: new Date().toISOString(),
+      transactionHash: 'tx-1',
+    } as unknown as AttestationEvent
+
+    const fetchEvents = vi.fn().mockResolvedValue([invalidEvent])
+    const captureFailure = vi.fn().mockResolvedValue(undefined)
+
+    listener = new AttestationEventListener(
+      store,
+      fetchEvents,
+      { captureFailure },
+      { pollingInterval: 60_000 },
+    )
+
+    await listener.start()
+
+    expect(store.create).not.toHaveBeenCalled()
+    expect(captureFailure).toHaveBeenCalledTimes(1)
+    const [messageType, payload, reason] = captureFailure.mock.calls[0]
+    expect(messageType).toBe('attestation')
+    expect(payload).toBe(invalidEvent)
+    expect(reason).toContain('SCHEMA_VALIDATION_FAILED')
+
+    const stats = listener.getStats()
+    expect(stats.errors).toBe(1)
+    expect(stats.eventsProcessed).toBe(0)
+  })
+
+  it('processes a schema-valid event normally without touching the DLQ', async () => {
+    const store = makeStore()
+    const validEvent: AttestationEvent = {
+      id: 'evt-2',
+      pagingToken: 'pt-2',
+      type: 'add',
+      subject: 'GSUBJECT',
+      verifier: 'GVERIFIER',
+      weight: 80,
+      claim: 'trusted',
+      createdAt: new Date().toISOString(),
+      transactionHash: 'tx-2',
+    }
+
+    const fetchEvents = vi.fn().mockResolvedValue([validEvent])
+    const captureFailure = vi.fn().mockResolvedValue(undefined)
+
+    listener = new AttestationEventListener(
+      store,
+      fetchEvents,
+      { captureFailure },
+      { pollingInterval: 60_000 },
+    )
+
+    await listener.start()
+
+    expect(store.create).toHaveBeenCalledTimes(1)
+    expect(captureFailure).not.toHaveBeenCalled()
+    expect(listener.getStats().eventsProcessed).toBe(1)
+  })
+})

--- a/src/listeners/__tests__/horizonWithdrawalEvents.test.ts
+++ b/src/listeners/__tests__/horizonWithdrawalEvents.test.ts
@@ -234,4 +234,46 @@ describe('HorizonWithdrawalListener', () => {
       })
     })
   })
+
+  describe('poison message routing', () => {
+    it('routes a schema-invalid withdrawal event to the DLQ and does not process it', async () => {
+      const invalidEvent = {
+        id: 'op-1',
+        pagingToken: 'pt-1',
+        type: 'payment',
+        createdAt: new Date(),
+        bondId: 'bond-1-tx-1',
+        account: 'GABC',
+        amount: 'not-a-number', // fails decimalAmountSchema regex
+        assetType: 'native',
+        transactionHash: 'tx-1',
+        operationIndex: 0,
+      }
+
+      const captureFailure = vi.fn().mockResolvedValue(undefined)
+      const fetchSpy = vi
+        .spyOn(HorizonWithdrawalListener.prototype as any, 'fetchWithdrawalEvents')
+        .mockResolvedValue([invalidEvent])
+      const processSpy = vi.spyOn(HorizonWithdrawalListener.prototype as any, 'processWithdrawalEvent')
+
+      const invalidEventListener = createHorizonWithdrawalListener(
+        { pollingInterval: 100 },
+        undefined,
+        { captureFailure },
+      )
+
+      await invalidEventListener.start()
+      await invalidEventListener.stop()
+
+      fetchSpy.mockRestore()
+
+      expect(processSpy).not.toHaveBeenCalled()
+      expect(captureFailure).toHaveBeenCalledTimes(1)
+      const [messageType, , reason] = captureFailure.mock.calls[0]
+      expect(messageType).toBe('bond_withdrawal')
+      expect(reason).toContain('SCHEMA_VALIDATION_FAILED')
+
+      processSpy.mockRestore()
+    })
+  })
 })

--- a/src/listeners/attestationEvents.ts
+++ b/src/listeners/attestationEvents.ts
@@ -17,6 +17,8 @@
 
 import type { Attestation, CreateAttestationParams } from '../types/attestation.js'
 import type { IdempotencyGuard } from '../lib/idempotencyGuard.js'
+import { attestationEventSchema } from '../schemas/queue.js'
+import { validateMessage } from './messageValidator.js'
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Public types
@@ -179,6 +181,17 @@ export class AttestationEventListener {
 
       for (const event of events) {
         try {
+          const validation = validateMessage(attestationEventSchema, event)
+          if (!validation.valid) {
+            this.errors += 1
+            await this.replayService.captureFailure(
+              'attestation',
+              event,
+              `[${validation.reasonCode}] ${validation.detail}`,
+            )
+            continue
+          }
+
           const affected = await this.processEvent(event)
           if (affected) affectedAddresses.add(affected)
           this.lastCursor = event.pagingToken

--- a/src/listeners/horizonWithdrawalEvents.ts
+++ b/src/listeners/horizonWithdrawalEvents.ts
@@ -8,6 +8,8 @@ import {
   setHorizonListenerConfigured,
   setHorizonListenerRunning,
 } from '../services/health/runtimeState.js'
+import { withdrawalEventSchema } from '../schemas/queue.js'
+import { validateMessage } from './messageValidator.js'
 
 /**
  * Interface for bond withdrawal event data
@@ -200,14 +202,23 @@ export class HorizonWithdrawalListener {
         console.log(`[${STREAM_NAME}] Processing ${events.length} withdrawal events`)
         
         for (const event of events) {
-          await this.processWithdrawalEvent(event)
-          
-          // Persist cursor after each successfully processed event
+          const validation = validateMessage(withdrawalEventSchema, event)
+          if (!validation.valid) {
+            await this.replayService.captureFailure(
+              STREAM_NAME,
+              event,
+              `[${validation.reasonCode}] ${validation.detail}`,
+            )
+          } else {
+            await this.processWithdrawalEvent(event)
+          }
+
+          // Persist cursor after each processed event (validated or quarantined to DLQ)
           await this.cursorRepo.upsert({
             streamName: STREAM_NAME,
             pagingToken: event.pagingToken
           })
-          
+
           // Update local cursor only after successful persistence
           this.lastCursor = event.pagingToken
         }


### PR DESCRIPTION
## Summary

Closes #959.

The schema-validation + poison-message-to-DLQ infrastructure this issue asks for already existed on `main` (`src/schemas/queue.ts`, `src/listeners/messageValidator.ts` — `DlqReasonCode`, `validateMessage`, `DlqRouter`), merged back in April via #282/9ffe185. However only `horizonBondEvents.ts` actually called into it; `attestationEvents.ts` and `horizonWithdrawalEvents.ts` had matching Zod schemas (`attestationEventSchema`, `withdrawalEventSchema`) defined but unused, so those two listeners processed raw Horizon payloads with no validation and no DLQ path for malformed messages.

This PR wires both listeners up:
- `AttestationEventListener.poll()` now validates each event against `attestationEventSchema` before processing; invalid events are routed to the replay/DLQ sink with a `[SCHEMA_VALIDATION_FAILED] ...` reason and skipped.
- `HorizonWithdrawalListener.pollForEvents()` now validates each event against `withdrawalEventSchema` before processing; invalid events are routed to the DLQ the same way, and the cursor still advances past them so a single poison message can't stall the stream.

## Test plan
- [x] `npx vitest run src/listeners/__tests__/attestationEvents.test.ts src/listeners/__tests__/horizonWithdrawalEvents.test.ts src/listeners/__tests__/horizonBondEvents.test.ts src/schemas/queue.test.ts src/listeners/__tests__/messageValidator.test.ts` — 86/86 passing
- [x] `npm run build` — passes
- [x] `npm run lint` — no new errors introduced by this change