### PR TITLE
feat: surface pending migrations on npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The server **fails fast** on startup if any required environment variable is mis
 npm run dev
 ```
 
+`npm run dev` automatically checks for pending database migrations before starting the dev server. If any are found, a reminder to run `npm run migrate:dev` is printed. Set `DATABASE_URL` in your environment to enable this check.
+
 **Production:**
 
 ```bash
@@ -140,7 +142,7 @@ All configuration is driven by environment variables. Copy `.env.example` to `.e
 
 | Command                   | Description                                |
 | ------------------------- | ------------------------------------------ |
-| `npm run dev`             | Start with tsx watch                       |
+| `npm run dev`             | Check pending migrations, then start with tsx watch |
 | `npm run build`           | Compile TypeScript                         |
 | `npm start`               | Run compiled `dist/`                       |
 | `npm run lint`            | Run ESLint                                 |

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "predev": "tsx scripts/check-pending-migrations.ts",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",

--- a/scripts/check-pending-migrations.ts
+++ b/scripts/check-pending-migrations.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { dryRunMigration } from "../src/migrations/runner.js";
+import { exit } from "process";
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.warn(
+      "\n⚠️  DATABASE_URL not set — skipping pending migration check.",
+    );
+    console.warn("   Set DATABASE_URL to enable migration checks.");
+    exit(0);
+  }
+
+  try {
+    const result = await dryRunMigration({
+      skipPreflight: true,
+      verbose: false,
+    });
+
+    if (!result.success) {
+      if (
+        result.error?.includes("ECONNREFUSED") ||
+        result.error?.includes("database")?.toLowerCase()
+      ) {
+        console.warn(
+          "\n⚠️  Could not connect to database — skipping migration check.",
+        );
+        exit(0);
+      }
+      console.warn(`\n⚠️  Migration check warning: ${result.error}`);
+      exit(0);
+    }
+
+    if (result.applied.length === 0) {
+      exit(0);
+    }
+
+    console.warn("");
+    console.warn(
+      "⚠️  ───────────────────────────────────────────────────────────────",
+    );
+    console.warn(
+      `⚠️   ${result.applied.length} pending database migration(s) detected.`,
+    );
+    console.warn("⚠️   Run \x1b[1mnpm run migrate:dev\x1b[22m to apply them.");
+    console.warn(
+      "⚠️  ───────────────────────────────────────────────────────────────",
+    );
+    console.warn("");
+    exit(0);
+  } catch {
+    console.warn(
+      "\n⚠️  Could not check migrations — skipping. Ensure DATABASE_URL is set.",
+    );
+    exit(0);
+  }
+}
+
+main();


### PR DESCRIPTION
Surface pending migrations in npm run dev via a predev hook that prints a warning with count and migrate:dev hint if any are found. Gracefully skips when DATABASE_URL is not set.

Closes #894