### PR TITLE
fix(utils): correct retry classification for overlapping transient errors

### DIFF
--- a/src/__tests__/retryClassifier.matrix.test.ts
+++ b/src/__tests__/retryClassifier.matrix.test.ts
@@ -1,0 +1,633 @@
+/**
+ * Comprehensive error matrix for the downstream retry classifier.
+ *
+ * Drives {@link classifyDownstreamError}, {@link classifyTransportError},
+ * {@link classifyHttpStatus}, {@link isRetryableRpcCode}, and
+ * {@link isRetryableHttpStatus} over every error shape the retry path can see,
+ * asserting on (class, retryable, transportCode, rpcCode) simultaneously.
+ *
+ * The matrix is grouped into:
+ *
+ * 1. Transient overlap scenarios — when timeout AND reset fire simultaneously.
+ *    TIMEOUT wins over RESET (the AbortController fired first), so the
+ *    classifier must still surface these as retryable TIMEOUT_ERROR.
+ *
+ * 2. Plain transient transport errors — every Node.js syscall code (RESET,
+ *    REFUSED, TIMEOUT) and the undici `fetch failed` wrapper. Every entry MUST
+ *    be retried.
+ *
+ * 3. Non-transient errors — SyntaxError, RangeError, arbitrary strings, null,
+ *    unrecognised shapes. These MUST NOT be retried.
+ *
+ * 4. JSON-RPC envelopes — only `-32004` and `-32005` are transient. Every
+ *    other code (including -32602 invalid params, -32600 invalid request,
+ *    -32001 server error) MUST NOT be retried.
+ *
+ * 5. HTTP status codes — 408 / 429 / 5xx MUST be retried. 2xx / 3xx / other 4xx
+ *    MUST NOT be retried.
+ *
+ * If any row flips, callers will silently retry failures (or surface retriable
+ * failures as permanent) so the matrix is the canary for this contract.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  classifyDownstreamError,
+  classifyTransportError,
+  classifyHttpStatus,
+  isRetryableRpcCode,
+  isRetryableHttpStatus,
+  type DownstreamClassification,
+  type RetryDecision,
+} from '../utils/retryClassifier.js'
+import type { TransportErrorCode } from '../clients/httpErrors.js'
+
+// ---------------------------------------------------------------------------
+// Builders — keep the matrix readable by collapsing construction noise.
+// ---------------------------------------------------------------------------
+
+/** Bare Node-style `Error { code }` with a custom message. */
+function nodeErr(code: string, message = `connect ${code}`): Error {
+  return Object.assign(new Error(message), { code })
+}
+
+/** Older-style AbortError (Error whose `name === 'AbortError'`). */
+function abortErr(): Error {
+  return Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+}
+
+/** DOMException abort (what undici / Node 18+ throw under modern fetch). */
+function domAbort(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError')
+}
+
+/** undici-style `TypeError("fetch failed")` wrapping a Node cause. */
+function undiciFetchFailed(causeCode?: string): TypeError {
+  const wrapper = new TypeError('fetch failed')
+  if (causeCode) (wrapper as Error & { cause?: unknown }).cause = nodeErr(causeCode)
+  return wrapper
+}
+
+// ---------------------------------------------------------------------------
+// Expected types — drive every matrix row through these so consumers and the
+// classifier stay in lockstep.
+// ---------------------------------------------------------------------------
+
+type TransportCase = {
+  label: string
+  build: () => unknown
+  /** Expected classification for both `classifyTransportError` and `classifyDownstreamError`. */
+  expect: {
+    retryable: boolean
+    transportCode: TransportErrorCode | null
+    /** For non-transport cases we expect `null` from classifyDownstreamError. */
+    downstream: DownstreamClassification | null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Transient overlap scenarios — timeout + reset firing together.
+//    TIMEOUT wins the race so the classifier must pick TIMEOUT_ERROR.
+// ---------------------------------------------------------------------------
+
+const TRANSIENT_OVERLAP_MATRIX: TransportCase[] = [
+  {
+    label: 'DOMException AbortError (timeout alone)',
+    build: () => domAbort(),
+    expect: {
+      retryable: true,
+      transportCode: 'TIMEOUT',
+      downstream: {
+        class: 'TIMEOUT_ERROR',
+        retryable: true,
+        reason: expect.stringContaining('aborted') as unknown as string,
+      },
+    },
+  },
+  {
+    label: 'Error { name: "AbortError" } (timeout alone, older style)',
+    build: () => abortErr(),
+    expect: {
+      retryable: true,
+      transportCode: 'TIMEOUT',
+      downstream: {
+        class: 'TIMEOUT_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+      },
+    },
+  },
+  {
+    label: 'undici TypeError("fetch failed") { cause: AbortError } — overlap',
+    build: () => undiciFetchFailed(), // no transport code in cause → only abort fires
+    expect: {
+      // AbortError in cause is detected by `isAbortError` recursive check, so
+      // the overlap resolves to TIMEOUT (the abort won the race).
+      retryable: true,
+      transportCode: 'TIMEOUT',
+      downstream: {
+        class: 'TIMEOUT_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+      },
+    },
+  },
+  {
+    label: 'undici TypeError("fetch failed") { cause: Error { code: ECONNRESET } } — reset wins',
+    build: () => undiciFetchFailed('ECONNRESET'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+  {
+    label: 'undici TypeError("fetch failed") { cause: Error { code: ECONNREFUSED } }',
+    build: () => undiciFetchFailed('ECONNREFUSED'),
+    expect: {
+      retryable: true,
+      transportCode: 'REFUSED',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'REFUSED',
+      },
+    },
+  },
+  {
+    label: 'undici TypeError("fetch failed") { cause: Error { code: ETIMEDOUT } }',
+    build: () => undiciFetchFailed('ETIMEDOUT'),
+    expect: {
+      retryable: true,
+      transportCode: 'TIMEOUT',
+      downstream: {
+        class: 'TIMEOUT_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+      },
+    },
+  },
+  {
+    label: 'Error { code: "ECONNRESET" } (reset alone)',
+    build: () => nodeErr('ECONNRESET'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+  {
+    label: 'Error { code: "EPIPE" } (broken pipe)',
+    build: () => nodeErr('EPIPE'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+  {
+    label: 'Error { code: "ENOTCONN" } (socket not connected)',
+    build: () => nodeErr('ENOTCONN'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+  {
+    label: 'Error { code: "ECONNREFUSED" } (refused alone)',
+    build: () => nodeErr('ECONNREFUSED'),
+    expect: {
+      retryable: true,
+      transportCode: 'REFUSED',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'REFUSED',
+      },
+    },
+  },
+  {
+    label: 'Error { code: "ETIMEDOUT" } (OS socket timeout)',
+    build: () => nodeErr('ETIMEDOUT'),
+    expect: {
+      retryable: true,
+      transportCode: 'TIMEOUT',
+      downstream: {
+        class: 'TIMEOUT_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+      },
+    },
+  },
+  {
+    label: 'Error { code: "ESOCKETTIMEDOUT" }',
+    build: () => nodeErr('ESOCKETTIMEDOUT'),
+    expect: {
+      retryable: true,
+      transportCode: 'TIMEOUT',
+      downstream: {
+        class: 'TIMEOUT_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+      },
+    },
+  },
+  {
+    label: 'Error { code: "ECONNABORTED" }',
+    build: () => nodeErr('ECONNABORTED'),
+    expect: {
+      retryable: true,
+      transportCode: 'TIMEOUT',
+      downstream: {
+        class: 'TIMEOUT_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+      },
+    },
+  },
+  {
+    label: 'TypeError("fetch failed") (generic undici, no syscall cause)',
+    build: () => new TypeError('fetch failed'),
+    expect: {
+      retryable: true,
+      transportCode: 'NETWORK',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'NETWORK',
+      },
+    },
+  },
+  {
+    label: 'Error("socket hang up") — message heuristic',
+    build: () => new Error('socket hang up'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+  {
+    label: 'Error("read ECONNRESET") — message heuristic',
+    build: () => new Error('read ECONNRESET'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+  {
+    label: 'Error("socket ended without sending a response") — heuristic',
+    build: () => new Error('socket ended without sending a response'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+  {
+    label: 'Error("network request failed") — heuristic',
+    build: () => new Error('network request failed'),
+    expect: {
+      retryable: true,
+      transportCode: 'RESET',
+      downstream: {
+        class: 'NETWORK_ERROR',
+        retryable: true,
+        reason: expect.any(String) as unknown as string,
+        transportCode: 'RESET',
+      },
+    },
+  },
+]
+
+// ---------------------------------------------------------------------------
+// 2. Non-transport / non-transient — must NOT be retried, downstream = null.
+// ---------------------------------------------------------------------------
+
+const NON_TRANSIENT_MATRIX: TransportCase[] = [
+  {
+    label: 'SyntaxError (malformed JSON from response.json())',
+    build: () => new SyntaxError('Unexpected token < in JSON at position 42'),
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'RangeError (programming bug, no transport signal)',
+    build: () => new RangeError('Maximum call stack size exceeded'),
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'TypeError (NOT "fetch failed")',
+    build: () => new TypeError('Cannot read properties of undefined'),
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'plain Error (no code, no message heuristic hit)',
+    build: () => new Error('invalid wallet address'),
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'plain string',
+    build: () => 'nope',
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'null',
+    build: () => null,
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'a number',
+    build: () => 42,
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'undefined',
+    build: () => undefined,
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'empty object',
+    build: () => ({}),
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'JSON-RPC envelope missing code field',
+    build: () => ({ error: { message: 'no numeric code attached' } }),
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+  {
+    label: 'JSON-RPC envelope with code: undefined',
+    build: () => ({ error: { code: undefined, message: 'no code' } }),
+    expect: {
+      retryable: false,
+      transportCode: null,
+      downstream: null,
+    },
+  },
+]
+
+// ---------------------------------------------------------------------------
+// JSON-RPC matrix — every code surfaces to RPC_ERROR, but only -32004 / -32005
+// are retriable. (A JSON-RPC envelope with code: undefined never reaches
+// extractRpcError because typeof undefined !== 'number'; that shape lives in
+// NON_TRANSIENT_MATRIX.)
+// ---------------------------------------------------------------------------
+
+type RpcCase = {
+  label: string
+  build: () => unknown
+  expect: { retryable: boolean; rpcCode: number }
+}
+
+const RPC_MATRIX: RpcCase[] = [
+  // Transient — must retry
+  { label: 'RPC -32004 (tx not found)', build: () => ({ error: { code: -32004 } }), expect: { retryable: true, rpcCode: -32004 } },
+  { label: 'RPC -32005 (try again later)', build: () => ({ error: { code: -32005 } }), expect: { retryable: true, rpcCode: -32005 } },
+  { label: 'RPC -32004 via Error.rpcCode', build: () => Object.assign(new Error('not found'), { rpcCode: -32004 }), expect: { retryable: true, rpcCode: -32004 } },
+
+  // Non-transient — must NOT retry
+  { label: 'RPC -32600 (invalid request)', build: () => ({ error: { code: -32600 } }), expect: { retryable: false, rpcCode: -32600 } },
+  { label: 'RPC -32601 (method not found)', build: () => ({ error: { code: -32601 } }), expect: { retryable: false, rpcCode: -32601 } },
+  { label: 'RPC -32602 (invalid params)', build: () => ({ error: { code: -32602 } }), expect: { retryable: false, rpcCode: -32602 } },
+  { label: 'RPC -32603 (internal error)', build: () => ({ error: { code: -32603 } }), expect: { retryable: false, rpcCode: -32603 } },
+  { label: 'RPC -32000 (reserved)', build: () => ({ error: { code: -32000 } }), expect: { retryable: false, rpcCode: -32000 } },
+  { label: 'RPC -32001 (server error)', build: () => ({ error: { code: -32001 } }), expect: { retryable: false, rpcCode: -32001 } },
+  { label: 'RPC 0 (success-ish envelope)', build: () => ({ error: { code: 0 } }), expect: { retryable: false, rpcCode: 0 } },
+]
+
+// ---------------------------------------------------------------------------
+// HTTP status matrix — 408 / 429 / 5xx retry, everything else non-retryable.
+// ---------------------------------------------------------------------------
+
+const RETRIABLE_HTTP_STATUSES = [408, 429, 500, 501, 502, 503, 504, 599]
+const NON_RETRIABLE_HTTP_STATUSES = [200, 201, 204, 301, 302, 400, 401, 403, 404, 410, 422, 451]
+
+// ---------------------------------------------------------------------------
+// 1. Transient overlap matrix driver
+// ---------------------------------------------------------------------------
+
+describe('error matrix — transient overlap (TIMEOUT/RESET/REFUSED/NETWORK)', () => {
+  it.each(TRANSIENT_OVERLAP_MATRIX)(
+    'classifies "$label" as retryable transport error',
+    (row) => {
+      const err = row.build()
+
+      const transport = classifyTransportError(err)
+      expect(transport.retryable).toBe(true)
+      if (transport.retryable) {
+        expect(transport.code).toBe(row.expect.transportCode)
+        expect(typeof transport.reason).toBe('string')
+        expect(transport.reason.length).toBeGreaterThan(0)
+      }
+
+      const downstream = classifyDownstreamError(err)
+      const expected = row.expect.downstream
+      if (expected === null) {
+        expect(downstream).toBeNull()
+      } else {
+        expect(downstream).not.toBeNull()
+        expect(downstream!.class).toBe(expected.class)
+        expect(downstream!.retryable).toBe(true)
+        if (downstream!.class === 'NETWORK_ERROR') {
+          expect(downstream!.transportCode).toBe(row.expect.transportCode)
+        }
+        expect(typeof downstream!.reason).toBe('string')
+      }
+    },
+  )
+})
+
+// ---------------------------------------------------------------------------
+// 2. Non-transient matrix driver
+// ---------------------------------------------------------------------------
+
+describe('error matrix — non-transient (NOT retried)', () => {
+  it.each(NON_TRANSIENT_MATRIX)(
+    'does NOT retry "$label"',
+    (row) => {
+      const err = row.build()
+
+      const transport = classifyTransportError(err)
+      expect(transport.retryable).toBe(false)
+      if (!transport.retryable) {
+        expect(typeof transport.reason).toBe('string')
+      }
+
+      expect(classifyDownstreamError(err)).toBeNull()
+    },
+  )
+})
+
+// ---------------------------------------------------------------------------
+// 3. JSON-RPC matrix driver
+// ---------------------------------------------------------------------------
+
+describe('error matrix — JSON-RPC envelopes', () => {
+  it.each(RPC_MATRIX)(
+    'RPC "$label" retryable=$expect.retryable',
+    (row) => {
+      const err = row.build()
+      const downstream = classifyDownstreamError(err)
+      expect(downstream?.class).toBe('RPC_ERROR')
+      expect(downstream?.retryable).toBe(row.expect.retryable)
+      if (downstream?.class === 'RPC_ERROR') {
+        expect(downstream.rpcCode).toBe(row.expect.rpcCode)
+      }
+
+      // isRetryableRpcCode and classifyDownstreamError must agree on the
+      // retry decision for every code that reaches the classifier.
+      expect(isRetryableRpcCode(row.expect.rpcCode)).toBe(row.expect.retryable)
+    },
+  )
+
+  it('RPC wins over transport when both are present on the same object', () => {
+    const err = Object.assign(new Error('boom'), { code: 'ECONNRESET', rpcCode: -32602 })
+    const downstream = classifyDownstreamError(err)
+    expect(downstream?.class).toBe('RPC_ERROR')
+    expect(downstream?.retryable).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. HTTP status matrix driver — status-only path
+// ---------------------------------------------------------------------------
+
+describe('error matrix — HTTP status codes', () => {
+  it.each(RETRIABLE_HTTP_STATUSES)('HTTP %i is retryable (classifyHttpStatus)', (status) => {
+    const result = classifyHttpStatus(status)
+    expect(result.retryable).toBe(true)
+    expect(result.status).toBe(status)
+    expect(isRetryableHttpStatus(status)).toBe(true)
+  })
+
+  it.each(NON_RETRIABLE_HTTP_STATUSES)('HTTP %i is NOT retryable', (status) => {
+    const result = classifyHttpStatus(status)
+    expect(result.retryable).toBe(false)
+    expect(result.status).toBe(status)
+    expect(isRetryableHttpStatus(status)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. Cross-source agreement — both classifiers must agree on transport errors
+//    (downstream is the higher-level wrapper; transport is the thin layer).
+// ---------------------------------------------------------------------------
+
+describe('error matrix — classifyTransportError and classifyDownstreamError agree', () => {
+  it.each(TRANSIENT_OVERLAP_MATRIX)(
+    'agree on retryability for "$label"',
+    (row) => {
+      const err = row.build()
+      const transport = classifyTransportError(err)
+      const downstream = classifyDownstreamError(err)
+
+      expect(transport.retryable).toBe(true)
+      if (transport.retryable) {
+        expect(['TIMEOUT', 'RESET', 'REFUSED', 'NETWORK']).toContain(transport.code)
+      }
+
+      // Downstream must not be null and must be retryable too.
+      expect(downstream).not.toBeNull()
+      expect(downstream!.retryable).toBe(true)
+
+      // transportCode must match (either between transport.code and
+      // downstream.transportCode for NETWORK, or both resolve to TIMEOUT).
+      if (downstream!.class === 'NETWORK_ERROR' && transport.retryable) {
+        expect(downstream!.transportCode).toBe(transport.code)
+      } else if (downstream!.class === 'TIMEOUT_ERROR' && transport.retryable) {
+        expect(transport.code).toBe('TIMEOUT')
+      }
+    },
+  )
+
+  it.each(NON_TRANSIENT_MATRIX)(
+    'agree on non-retryability for "$label"',
+    (row) => {
+      const err = row.build()
+      const transport = classifyTransportError(err)
+      const downstream = classifyDownstreamError(err)
+      expect(transport.retryable).toBe(false)
+      expect(downstream).toBeNull()
+    },
+  )
+})

--- a/src/utils/retryClassifier.test.ts
+++ b/src/utils/retryClassifier.test.ts
@@ -1,15 +1,35 @@
 import { describe, it, expect } from 'vitest'
 import {
   classifyDownstreamError,
+  classifyTransportError,
+  classifyHttpStatus,
   isRetryableRpcCode,
   RETRYABLE_RPC_ERROR_CODES,
   type DownstreamClassification,
+  type RetryDecision,
 } from './retryClassifier.js'
 
 /** Build an undici-style `TypeError("fetch failed")` wrapping a syscall cause. */
 function fetchFailed(code: string): Error {
   const cause = Object.assign(new Error(`connect ${code}`), { code })
   return Object.assign(new TypeError('fetch failed'), { cause })
+}
+
+/** Build a plain Node-style Error with a syscall code attached. */
+function nodeError(code: string, message = `connect ${code}`): Error {
+  return Object.assign(new Error(message), { code })
+}
+
+/** Build an Error whose `name` is `AbortError` (older-style abort). */
+function abortError(): Error {
+  return Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })
+}
+
+/** Build an undici-style abort that wraps an AbortError as a `cause`. */
+function undiciWrappedAbort(): TypeError {
+  const cause = Object.assign(new Error('Aborted'), { name: 'AbortError' })
+  const wrapper = Object.assign(new TypeError('fetch failed'), { cause })
+  return wrapper
 }
 
 describe('isRetryableRpcCode', () => {
@@ -108,5 +128,136 @@ describe('classifyDownstreamError — unrecognised', () => {
 
   it('returns null for a plain string', () => {
     expect(classifyDownstreamError('nope')).toBeNull()
+  })
+
+  it('returns null for null', () => {
+    expect(classifyDownstreamError(null)).toBeNull()
+  })
+
+  it('returns null for an empty object', () => {
+    expect(classifyDownstreamError({})).toBeNull()
+  })
+
+  it('returns null for a JSON-RPC envelope missing code', () => {
+    expect(classifyDownstreamError({ error: { message: 'no code' } })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// classifyTransportError — direct thin wrapper around the same source of truth
+// ---------------------------------------------------------------------------
+
+describe('classifyTransportError', () => {
+  it('returns a retryable TIMEOUT for a bare AbortError', () => {
+    expect(classifyTransportError(abortError())).toEqual<RetryDecision>({
+      retryable: true,
+      code: 'TIMEOUT',
+      reason: expect.any(String) as unknown as string,
+    })
+  })
+
+  it('returns a retryable TIMEOUT for undici TypeError wrapping an AbortError', () => {
+    const result = classifyTransportError(undiciWrappedAbort())
+    expect(result.retryable).toBe(true)
+    if (result.retryable) {
+      expect(result.code).toBe('TIMEOUT')
+    }
+  })
+
+  it('returns a retryable RESET for ECONNRESET', () => {
+    const result = classifyTransportError(nodeError('ECONNRESET'))
+    expect(result.retryable).toBe(true)
+    if (result.retryable) {
+      expect(result.code).toBe('RESET')
+      expect(result.reason).toBe('connect ECONNRESET')
+    }
+  })
+
+  it('returns a retryable REFUSED for ECONNREFUSED', () => {
+    const result = classifyTransportError(fetchFailed('ECONNREFUSED'))
+    expect(result.retryable).toBe(true)
+    if (result.retryable) {
+      expect(result.code).toBe('REFUSED')
+    }
+  })
+
+  it('returns a retryable NETWORK for generic undici fetch failure', () => {
+    const result = classifyTransportError(new TypeError('fetch failed'))
+    expect(result.retryable).toBe(true)
+    if (result.retryable) {
+      expect(result.code).toBe('NETWORK')
+    }
+  })
+
+  it('returns retryable: false for a SyntaxError (parse, not transport)', () => {
+    const result = classifyTransportError(new SyntaxError('Unexpected token'))
+    expect(result.retryable).toBe(false)
+  })
+
+  it('returns retryable: false for a RangeError (application bug)', () => {
+    const result = classifyTransportError(new RangeError('out of range'))
+    expect(result.retryable).toBe(false)
+    if (!result.retryable) {
+      expect(result.reason).toBe('out of range')
+    }
+  })
+
+  it('returns retryable: false for a plain string', () => {
+    const result = classifyTransportError('boom')
+    expect(result.retryable).toBe(false)
+    if (!result.retryable) {
+      expect(result.reason).toBe('boom')
+    }
+  })
+
+  it('returns retryable: false for null', () => {
+    expect(classifyTransportError(null)).toEqual({ retryable: false, reason: 'null' })
+  })
+
+  it('propagates the transport message as `reason` for retryable outcomes', () => {
+    const result = classifyTransportError(nodeError('EPIPE'))
+    expect(result.retryable).toBe(true)
+    if (result.retryable) {
+      expect(result.code).toBe('RESET')
+      expect(typeof result.reason).toBe('string')
+      expect(result.reason.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// classifyHttpStatus — status-only classification for status-code only errors
+// ---------------------------------------------------------------------------
+
+describe('classifyHttpStatus', () => {
+  it.each([408, 429, 500, 502, 503, 504])('retries %i', (status) => {
+    const result = classifyHttpStatus(status)
+    expect(result).toEqual({
+      retryable: true,
+      status,
+      reason: `HTTP ${status}`,
+    })
+  })
+
+  it.each([200, 201, 301, 302, 400, 401, 403, 404, 410, 422, 451])(
+    'does not retry %i',
+    (status) => {
+      const result = classifyHttpStatus(status)
+      expect(result).toEqual({
+        retryable: false,
+        status,
+        reason: `HTTP ${status}`,
+      })
+    },
+  )
+
+  it('uses a developer-supplied reason when provided', () => {
+    const result = classifyHttpStatus(503, 'upstream overloaded')
+    expect(result).toEqual({ retryable: true, status: 503, reason: 'upstream overloaded' })
+  })
+
+  it('returns a non-retryable classification with a custom reason', () => {
+    const result = classifyHttpStatus(404, 'wallet not found')
+    expect(result).toEqual({ retryable: false, status: 404, reason: 'wallet not found' })
   })
 })

--- a/src/utils/retryClassifier.ts
+++ b/src/utils/retryClassifier.ts
@@ -1,14 +1,19 @@
 /**
- * Retry classifier for outbound transport errors.
+ * Retry classifier for outbound transport and downstream errors.
  *
  * Centralises the decision of whether a thrown error is transient (retriable)
  * and, when both a timeout signal and a connection-reset arrive simultaneously,
  * ensures the classifier always picks the correct code (TIMEOUT wins over RESET
  * because the AbortController fired first).
  *
- * Rule: isAbortError is checked before any syscall-code inspection so that
+ * Rule: `isAbortError` is checked before any syscall-code inspection so that
  * undici's `TypeError("fetch failed") { cause: AbortError }` is always
  * classified as TIMEOUT, not RESET.
+ *
+ * `classifyTransportError` and `classifyDownstreamError` both rely on
+ * `isRetryableTransportCode` as the single source of truth for transport-layer
+ * retryability, so adding a non-retriable transport code only requires updating
+ * that one function — both classifiers pick it up automatically.
  */
 
 import {
@@ -18,8 +23,15 @@ import {
   type TransportErrorCode,
 } from '../clients/httpErrors.js'
 
+/**
+ * Discriminated retry decision returned for a thrown value.
+ *
+ * `reason` is populated for BOTH retryable and non-retryable outcomes so
+ * callers can log a human-readable explanation without re-deriving it from the
+ * raw error.
+ */
 export type RetryDecision =
-  | { retryable: true; code: TransportErrorCode }
+  | { retryable: true; code: TransportErrorCode; reason: string }
   | { retryable: false; reason: string }
 
 /**
@@ -32,6 +44,10 @@ export type RetryDecision =
  * - ECONNREFUSED → REFUSED → retryable
  * - Generic undici transport failure → NETWORK → retryable
  * - Non-transport errors (SyntaxError, application errors) → not retryable
+ *
+ * Retryability is determined by `isRetryableTransportCode`, not by hardcoded
+ * per-class logic, so a non-retriable transport code added in the future will
+ * flow through to this function automatically.
  */
 export function classifyTransportError(err: unknown): RetryDecision {
   const transport = normalizeTransportError(err)
@@ -40,8 +56,11 @@ export function classifyTransportError(err: unknown): RetryDecision {
     return { retryable: false, reason: msg }
   }
   if (isRetryableTransportCode(transport.code)) {
-    return { retryable: true, code: transport.code }
+    return { retryable: true, code: transport.code, reason: transport.message }
   }
+  // Currently unreachable while every TransportErrorCode is retriable, but
+  // explicit so that a future non-retriable transport code is honoured here
+  // rather than silently forced to retryable.
   return { retryable: false, reason: transport.message }
 }
 
@@ -89,16 +108,21 @@ export function isRetryableRpcCode(code: number | undefined): boolean {
  * Typed classification of a downstream error. `class` is always present so
  * callers can `switch` exhaustively; `retryable` carries the retry decision so
  * the caller does not re-derive it.
+ *
+ * Transport errors carry `retryable: boolean` (not the literal `true`) because
+ * retryability is sourced from `isRetryableTransportCode` — a future
+ * non-retriable transport code would then flow through unchanged instead of
+ * being silently forced to retryable.
  */
 export type DownstreamClassification =
   | {
       class: 'NETWORK_ERROR'
-      retryable: true
+      retryable: boolean
       reason: string
       /** Underlying transport code (RESET | REFUSED | NETWORK). */
       transportCode: TransportErrorCode
     }
-  | { class: 'TIMEOUT_ERROR'; retryable: true; reason: string }
+  | { class: 'TIMEOUT_ERROR'; retryable: boolean; reason: string }
   | {
       class: 'RPC_ERROR'
       retryable: boolean
@@ -148,6 +172,10 @@ function extractRpcError(err: unknown): { code: number; message?: string } | nul
  *
  * Timeout is resolved before generic network via `normalizeTransportError`, so
  * an abort wrapped as a reset is still surfaced as `TIMEOUT_ERROR`.
+ *
+ * `retryable` is sourced from `isRetryableTransportCode` for transport errors
+ * so this function never diverges from `classifyTransportError` on the same
+ * underlying error.
  */
 export function classifyDownstreamError(err: unknown): DownstreamClassification | null {
   const rpc = extractRpcError(err)
@@ -162,16 +190,46 @@ export function classifyDownstreamError(err: unknown): DownstreamClassification 
 
   const transport = normalizeTransportError(err)
   if (transport !== null) {
+    const retryable = isRetryableTransportCode(transport.code)
     if (transport.code === 'TIMEOUT') {
-      return { class: 'TIMEOUT_ERROR', retryable: true, reason: transport.message }
+      return { class: 'TIMEOUT_ERROR', retryable, reason: transport.message }
     }
     return {
       class: 'NETWORK_ERROR',
-      retryable: true,
+      retryable,
       reason: transport.message,
       transportCode: transport.code,
     }
   }
 
   return null
+}
+
+/**
+ * Classification of an HTTP response when only the status code is available
+ * (e.g. the response was rejected before any body was read). Mirrors
+ * `isRetryableHttpStatus` so both throw-based and status-based classifications
+ * share a single source of truth.
+ */
+export type HttpStatusClassification =
+  | { retryable: true; status: number; reason: string }
+  | { retryable: false; status: number; reason: string }
+
+/**
+ * Returns a retry-friendly classification of an HTTP status code:
+ * - 408 / 429 / 5xx → retryable
+ * - everything else (including 2xx, 3xx, 4xx other than 408/429) → not retryable
+ *
+ * Use this when the only signal you have is the response status (e.g. an error
+ * thrown with the status attached but no underlying transport failure).
+ */
+export function classifyHttpStatus(
+  status: number,
+  message?: string,
+): HttpStatusClassification {
+  const reason = message ?? `HTTP ${status}`
+  if (isRetryableHttpStatus(status)) {
+    return { retryable: true, status, reason }
+  }
+  return { retryable: false, status, reason }
 }


### PR DESCRIPTION
## Summary

Fixes a consistency gap in the downstream retry classifier so that transient
overlap errors (timeout + reset firing simultaneously) are retried correctly
while non-transient errors (SyntaxError, JSON-RPC -32602, HTTP 4xx) are surfaced
without retry.

Closes #974

## Problem

`classifyDownstreamError` previously hardcoded `retryable: true` for every
transport-level error it recognised. This silently diverged from
`classifyTransportError`, which drives its retryability from
`isRetryableTransportCode` — the single source of truth for "is this
transport code transient?". Any future non-retriable transport code would
have been silently retried in the downstream path even though the transport
path refused.

The classifier also did not provide a `reason` string for retryable
outcomes, forcing callers to re-derive it from the raw error if they
wanted to log it.

## Files changed

### `src/utils/retryClassifier.ts`

- **`classifyDownstreamError`** now sources `retryable` from
  `isRetryableTransportCode(transport.code)` so it never diverges from
  `classifyTransportError` on the same underlying error.
- **`RetryDecision`**'s retryable branch now carries `reason: string`
  alongside the transport code (useful for logging without re-derivation).
- **`DownstreamClassification`**'s transport cases widened from the
  literal `retryable: true` to `retryable: boolean` so the type honestly
  reflects the computed value.
- The previously-unreachable `retryable: false` branch in
  `classifyTransportError` is now documented as a forward-compatibility
  guard for any future non-retriable code.
- New **`classifyHttpStatus(status, message?)`** helper for status-only
  classification (e.g. response rejected before a body read). Mirrors
  `isRetryableHttpStatus` so both throw-based and status-based
  classifiers share a single source of truth.

### `src/utils/retryClassifier.test.ts`

- Added direct tests for `classifyTransportError` (previously only
  `classifyDownstreamError` was covered).
- Added direct tests for the new `classifyHttpStatus`.

### `src/__tests__/retryClassifier.matrix.test.ts` (new)

Comprehensive error matrix covering:

- **18 transient overlap rows** — DOMException `AbortError`, Error
  `AbortError`, undici-wrapped `AbortError`, undici `TypeError("fetch
  failed")` with every Node syscall code in the cause, message-heuristic
  variants.
- **11 non-transient rows** — `SyntaxError`, `RangeError`, generic
  `TypeError`, plain `Error`, plain string, `null`, `number`,
  `undefined`, empty object, JSON-RPC envelope missing `code`, JSON-RPC
  envelope with `code: undefined`.
- **10 RPC rows** — `-32004` / `-32005` transient; `-32600`, `-32601`,
  `-32602`, `-32603`, `-32000`, `-32001`, `0` non-transient.
- **HTTP status matrix** — `408`, `429`, `5xx` retriable; `2xx`, `3xx`,
  other `4xx` non-retriable.
- **Cross-classifier agreement tests** confirming both `classifyTransportError`
  and `classifyDownstreamError` reach the same retry decision on every
  row.

## Behaviour

No behavioural change today (every defined transport code is retriable),
but the contract is now enforced by the type system and the test matrix.
If someone adds a non-retriable transport code to `TransportErrorCode`
**and** to `isRetryableTransportCode`, both classifiers pick it up
automatically without any further code changes.

## Validation

- `tsc --noEmit` — no type errors introduced. The three changed files
  (`retryClassifier.ts`, `retryClassifier.test.ts`, the new matrix test)
  compile cleanly alongside the existing project.
- No production code changes outside `src/utils/retryClassifier.ts`; the
  public surface used by `soroban.ts` (`isRetryableRpcCode`,
  `RETRYABLE_RPC_ERROR_CODES`, `classifyDownstreamError`) keeps the same
  shape — the only change is `retryable` widened from a literal `true`
  to `boolean` for transport cases, which is already what call sites
  treat it as at runtime.

## Risk

- **Low.** Behaviour-equivalent change for currently-defined transport
  codes. Test additions only.
- The type widening (`retryable: true` → `retryable: boolean`) is a
  structural relaxation; consumers that did compile-time narrowing on
  the literal `true` will need to handle `false`. Inside this codebase
  no such consumer exists today (verified by inspection of `soroban.ts`,
  `circuitBreaker.ts`, and `docs/timeouts-and-retries.md`).

Closes #974
