### PR TITLE
fix(shutdown): clamp job-drain wait to remaining grace-period budget

### DIFF
--- a/src/gracefulShutdown.test.ts
+++ b/src/gracefulShutdown.test.ts
@@ -336,6 +336,79 @@ describe("GracefulShutdownManager", () => {
       running = false;
     });
 
+    it("clamps the scheduler drain wait to the remaining grace-period budget instead of the full jobDrainTimeoutMs", async () => {
+      vi.useRealTimers();
+
+      // Server close eats into the grace-period budget before scheduler_drain
+      // even starts.
+      const server = makeServer();
+      server.close = vi.fn((cb?: (err?: Error) => void) => {
+        setTimeout(() => cb?.(), 200);
+      });
+
+      let running = true;
+      const scheduler: DrainableScheduler = {
+        stop: vi.fn(),
+        isJobRunning: () => running,
+      };
+
+      const metrics = makeMetrics();
+      const opts = makeOptions({
+        server,
+        scheduler,
+        metrics,
+        gracePeriodMs: 600,
+        // Requests far more than what remains after the 200ms server close —
+        // without clamping this would overshoot gracePeriodMs entirely.
+        jobDrainTimeoutMs: 5000,
+      });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      const schedulerDrainSeconds = (
+        metrics.observePhase as MockInstance
+      ).mock.calls.find((c) => c[0] === "scheduler_drain")?.[1] as number;
+
+      // Roughly 400ms remained (600 - 200), not the full 5s requested.
+      expect(schedulerDrainSeconds).toBeLessThan(0.5);
+
+      running = false;
+    });
+
+    it("does not wait at all when the grace-period budget is already exhausted before scheduler_drain starts", async () => {
+      vi.useRealTimers();
+
+      const server = makeServer();
+      server.close = vi.fn((cb?: (err?: Error) => void) => {
+        setTimeout(() => cb?.(), 300);
+      });
+
+      const scheduler: DrainableScheduler = {
+        stop: vi.fn(),
+        isJobRunning: () => true,
+      };
+
+      const metrics = makeMetrics();
+      const opts = makeOptions({
+        server,
+        scheduler,
+        metrics,
+        gracePeriodMs: 100, // already elapsed by the time server_close finishes
+        jobDrainTimeoutMs: 5000,
+      });
+      const mgr = new GracefulShutdownManager(opts);
+
+      await mgr.shutdown("SIGTERM");
+
+      const schedulerDrainSeconds = (
+        metrics.observePhase as MockInstance
+      ).mock.calls.find((c) => c[0] === "scheduler_drain")?.[1] as number;
+
+      // Negative remaining budget clamps to zero — no extra wait piled on top.
+      expect(schedulerDrainSeconds).toBeLessThan(0.05);
+    });
+
     it("skips job-running poll when scheduler has no isJobRunning()", async () => {
       const scheduler: DrainableScheduler = { stop: vi.fn() };
       const opts = makeOptions({ scheduler });

--- a/src/gracefulShutdown.ts
+++ b/src/gracefulShutdown.ts
@@ -50,6 +50,7 @@ export interface GracefulShutdownOptions {
 
 export class GracefulShutdownManager {
   private shuttingDown = false;
+  private shutdownStartedAt = 0;
   private forceExitTimer: NodeJS.Timeout | null = null;
   private readonly connections = new Set<Socket>();
   private wss: WebSocketServer | null = null;
@@ -103,6 +104,7 @@ export class GracefulShutdownManager {
     }
 
     this.shuttingDown = true;
+    this.shutdownStartedAt = Date.now();
     setReady(false);
     this.metrics.incShutdown(signal);
 
@@ -211,10 +213,18 @@ export class GracefulShutdownManager {
 
     if (typeof scheduler.isJobRunning !== "function") return;
 
-    const maxWaitMs = Math.min(
-      this.options.jobDrainTimeoutMs ?? this.gracePeriodMs * 0.7,
-      10_000,
+    // The scheduler-specific window must not push total shutdown time past
+    // gracePeriodMs: earlier phases (server close, ws drain, listener stop)
+    // already consumed part of that budget, and the independent
+    // forceExitTimer keeps running throughout. Clamp to whatever remains so
+    // we don't wait for a job that will just get killed anyway.
+    const elapsedSinceShutdownStart = Date.now() - this.shutdownStartedAt;
+    const remainingBudgetMs = Math.max(
+      0,
+      this.gracePeriodMs - elapsedSinceShutdownStart,
     );
+    const requestedWaitMs = this.options.jobDrainTimeoutMs ?? this.gracePeriodMs * 0.7;
+    const maxWaitMs = Math.min(requestedWaitMs, 10_000, remainingBudgetMs);
     const deadline = Date.now() + maxWaitMs;
 
     while (scheduler.isJobRunning() && Date.now() < deadline) {


### PR DESCRIPTION
## Summary
Fixes #1021.

The scheduler drain window in `GracefulShutdownManager` was computed as `min(jobDrainTimeoutMs ?? gracePeriodMs * 0.7, 10_000)`, independent of how much of the grace period earlier phases (server close, WS drain, listener stop) had already consumed. On a short-ish `gracePeriodMs`, that let the job-drain wait push total shutdown time past the global deadline — at which point the independent `forceExitTimer` fires first and hard-kills the process (destroying sockets, `forceExit(1)`) mid-drain, instead of letting the in-flight job settle and exiting cleanly.

The fix tracks `shutdownStartedAt` and clamps the drain wait to whatever grace-period budget actually remains by the time `scheduler_drain` runs, so it never schedules a wait that would overrun the global timeout.

## Changes
- `src/gracefulShutdown.ts`: track shutdown start time; clamp `drainScheduler`'s wait window to the remaining `gracePeriodMs` budget.
- `src/gracefulShutdown.test.ts`: two new tests — one proving the drain wait shrinks to fit the remaining budget when an earlier phase (server close) eats into it, one proving it clamps to zero when the budget is already exhausted.

## Test plan
- [x] `npx vitest run src/gracefulShutdown.test.ts src/__tests__/gracefulShutdown.test.ts` — all tests pass except one pre-existing, unrelated WS-drain test that also fails identically on unmodified `main` in this environment (network/localhost binding quirk, not related to this change).