### PR TITLE
feat(api): add structured error code mapping to remaining raw responses

### DIFF
--- a/src/routes/admin/webhooks.test.ts
+++ b/src/routes/admin/webhooks.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import express, { Request, Response, NextFunction } from 'express'
+import request from 'supertest'
+
+const { mockUserRef, mockAuditLogService, mockWebhookService } = vi.hoisted(() => ({
+  mockUserRef: { current: null as { id: string; email: string; role: string; tenantId: string } | null },
+  mockAuditLogService: {
+    logAction: vi.fn().mockResolvedValue(undefined),
+  },
+  mockWebhookService: {
+    rotateSecret: vi.fn(),
+    revokePreviousSecret: vi.fn(),
+  },
+}))
+
+vi.mock('../../middleware/auth.js', () => ({
+  UserRole: { ADMIN: 'admin', SUPER_ADMIN: 'super_admin', VERIFIER: 'verifier', USER: 'user' },
+  ApiScope: { WEBHOOKS_ADMIN: 'webhooks:admin' },
+  requireUserAuth: (req: Request, res: Response, next: NextFunction) => {
+    const user = mockUserRef.current
+    if (!user) {
+      res.status(401).json({ error: 'Unauthorized', message: 'User authentication required' })
+      return
+    }
+    ;(req as any).user = user
+    next()
+  },
+  requireAdminRole: (req: Request, res: Response, next: NextFunction) => {
+    const user = (req as any).user
+    if (!user || (user.role !== 'admin' && user.role !== 'super_admin')) {
+      res.status(403).json({ error: 'Forbidden', message: 'Admin role required' })
+      return
+    }
+    next()
+  },
+  requireApiKey: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}))
+
+vi.mock('../../services/audit/index.js', () => ({
+  auditLogService: mockAuditLogService,
+  AuditAction: { ROTATE_WEBHOOK_SECRET: 'ROTATE_WEBHOOK_SECRET' },
+}))
+
+vi.mock('../../db/pool.js', () => ({ pool: {} }))
+
+vi.mock('../../db/repositories/webhookRepository.js', () => ({
+  PostgresWebhookRepository: class {},
+}))
+
+vi.mock('../../services/webhooks/service.js', () => ({
+  WebhookService: class {
+    rotateSecret = mockWebhookService.rotateSecret
+    revokePreviousSecret = mockWebhookService.revokePreviousSecret
+  },
+}))
+
+import { createWebhookAdminRouter } from './webhooks.js'
+import { errorHandler } from '../../middleware/errorHandler.js'
+
+function setup() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/admin/webhooks', createWebhookAdminRouter())
+  app.use(errorHandler)
+  return app
+}
+
+describe('Webhook admin router — structured error codes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUserRef.current = {
+      id: 'user-1',
+      email: 'user@test.com',
+      role: 'verifier',
+      tenantId: 'tenant-1',
+    }
+  })
+
+  describe('POST /:id/rotate', () => {
+    it('rejects non-admin callers with a stable machine-readable code, not just a bare "Forbidden" string', async () => {
+      const res = await request(setup())
+        .post('/api/admin/webhooks/wh-1/rotate')
+        .send({})
+
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('Admin role required')
+      expect(res.body.code).toBe('forbidden')
+      expect(res.body.error_code).toBe('forbidden')
+    })
+
+    it('records a failure audit entry when a non-admin is rejected', async () => {
+      await request(setup())
+        .post('/api/admin/webhooks/wh-1/rotate')
+        .send({})
+
+      expect(mockAuditLogService.logAction).toHaveBeenCalledTimes(1)
+      expect(mockAuditLogService.logAction.mock.calls[0][3]).toBe('ROTATE_WEBHOOK_SECRET')
+    })
+
+    it('rotates the secret for admin callers', async () => {
+      mockUserRef.current = { id: 'admin-1', email: 'admin@test.com', role: 'admin', tenantId: 'tenant-1' }
+      mockWebhookService.rotateSecret.mockResolvedValue({
+        id: 'wh-1',
+        secret: 'new-secret',
+        secretUpdatedAt: '2026-01-01T00:00:00Z',
+      })
+
+      const res = await request(setup())
+        .post('/api/admin/webhooks/wh-1/rotate')
+        .send({})
+
+      expect(res.status).toBe(200)
+      expect(res.body.success).toBe(true)
+      expect(res.body.data.id).toBe('wh-1')
+    })
+  })
+})

--- a/src/routes/admin/webhooks.ts
+++ b/src/routes/admin/webhooks.ts
@@ -2,8 +2,8 @@ import { Router, Request, Response } from 'express'
 import { WebhookService } from '../../services/webhooks/service.js'
 import { PostgresWebhookRepository } from '../../db/repositories/webhookRepository.js'
 import { pool } from '../../db/pool.js'
-import { AuthenticatedRequest, requireUserAuth, requireAdminRole, requireApiKey, ApiScope } from '../../middleware/auth.js'
-import { auditLogService } from '../../services/audit/index.js'
+import { AuthenticatedRequest, requireUserAuth, requireAdminRole, requireApiKey, ApiScope, UserRole } from '../../middleware/auth.js'
+import { auditLogService, AuditAction } from '../../services/audit/index.js'
 import { sendError, ErrorCode } from '../../lib/errors.js'
 
 /**
@@ -47,7 +47,7 @@ export function createWebhookAdminRouter(): Router {
           req.ip,
           requestId
         )
-        res.status(403).json({ error: 'Forbidden', message: 'Admin role required' })
+        sendError(res, ErrorCode.FORBIDDEN, 'Admin role required')
         return
       }
 

--- a/src/routes/faultInjection.test.ts
+++ b/src/routes/faultInjection.test.ts
@@ -134,6 +134,29 @@ describe('Fault injection route', () => {
 
         expect(res.status).toBe(404)
       })
+
+      it('includes a stable machine-readable code on the 404 body', async () => {
+        const app = appWithFaultInjection(false)
+        const res = await request(app)
+          .post('/api/dev/fault-injection')
+          .send({})
+
+        expect(res.body.code).toBe('not_found')
+        expect(res.body.error_code).toBe('not_found')
+      })
+    })
+
+    describe('when DEV_MODE is enabled', () => {
+      it('includes a stable machine-readable code on the 400 validation body', async () => {
+        const app = appWithFaultInjection(true)
+        const res = await request(app)
+          .post('/api/dev/fault-injection')
+          .send({ statusCode: 200 })
+
+        expect(res.status).toBe(400)
+        expect(res.body.code).toBe('validation_failed')
+        expect(res.body.error_code).toBe('validation_failed')
+      })
     })
   })
 })

--- a/src/routes/faultInjection.ts
+++ b/src/routes/faultInjection.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express'
 import { faultInjectionRequestSchema } from '../schemas/faultInjection.js'
+import { sendError, ErrorCode } from '../lib/errors.js'
 
 export interface FaultInjectionRouterOptions {
   /** When true the fault-injection endpoint is active; otherwise it returns 404. */
@@ -21,16 +22,13 @@ export function createFaultInjectionRouter(options: FaultInjectionRouterOptions)
 
   router.post('/', (req: Request, res: Response) => {
     if (!options.devMode) {
-      res.status(404).json({ error: 'Not found' })
+      sendError(res, ErrorCode.NOT_FOUND, 'Not found')
       return
     }
 
     const parsed = faultInjectionRequestSchema.safeParse(req.body)
     if (!parsed.success) {
-      res.status(400).json({
-        error: 'Invalid request',
-        details: parsed.error.issues,
-      })
+      sendError(res, ErrorCode.VALIDATION_FAILED, 'Invalid request', parsed.error.issues)
       return
     }
 


### PR DESCRIPTION
## Summary
Fixes #1012.

Most of the API already runs error responses through the central error catalog (`ERROR_CATALOG` / `AppError` / `errorHandler`), which stamps every response with a stable `code`/`error_code` alongside the human message. A couple of routes still bypassed that path with raw `res.status(...).json({ error: ... })` calls, so those specific responses carried no machine-readable code:

- `src/routes/faultInjection.ts` — the dev-mode-disabled (404) and invalid-statusCode (400) responses.
- `src/routes/admin/webhooks.ts` — the RBAC rejection on `POST /:id/rotate` (403 "Forbidden"). This branch also referenced `UserRole` and `AuditAction` without importing them, so it would throw a `ReferenceError` before ever responding — fixed as part of making this branch reachable/testable.

## Changes
- `src/routes/faultInjection.ts`: route the 404/400 responses through the existing `sendError()` helper with `ErrorCode.NOT_FOUND` / `ErrorCode.VALIDATION_FAILED`.
- `src/routes/admin/webhooks.ts`: fix missing `UserRole`/`AuditAction` imports; route the RBAC 403 through `sendError(res, ErrorCode.FORBIDDEN, ...)`.
- `src/routes/faultInjection.test.ts`: assert `code`/`error_code` on both the 404 and 400 bodies.
- `src/routes/admin/webhooks.test.ts` (new): covers the rotate-secret route's RBAC rejection (with its error code), audit logging on rejection, and the admin happy path.

## Test plan
- [x] `npx vitest run src/routes/faultInjection.test.ts tests/routes/faultInjection.test.ts src/routes/admin/webhooks.test.ts` — 20/20 passing.