### PR TITLE
feat: enhance bond status API with caching and lifecycle state support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -341,7 +341,9 @@ Creates a persisted attestation, invalidates attestation caches, and emits an
 
 ### `GET /api/bond/:address`
 
-Returns bond status for an Ethereum address from the database.
+Returns bond status and derived lifecycle state for a wallet address.
+Reads are served from a Redis-backed cache (5-minute TTL); the response
+includes an `x-cache` header for transparency.
 
 ```
 GET /api/bond/:address
@@ -349,15 +351,21 @@ GET /api/bond/:address
 
 **Path parameters**
 
-| Param     | Description                            |
-| --------- | -------------------------------------- |
-| `address` | Ethereum address (`0x` + 40 hex chars) |
+| Param     | Description                                           |
+| --------- | ----------------------------------------------------- |
+| `address` | Ethereum (`0x` + 40 hex chars) or Stellar (`G` + 55 base32 chars) address |
 
 **Headers (optional)**
 
 | Header      | Description                   |
 | ----------- | ----------------------------- |
 | `X-API-Key` | API key for premium rate tier |
+
+**Response headers**
+
+| Header    | Values          | Description                                            |
+| --------- | --------------- | ------------------------------------------------------ |
+| `x-cache` | `HIT` \| `MISS` | Whether the response was served from cache or freshly fetched |
 
 **Responses**
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8483,6 +8483,8 @@ paths:
     get:
       summary: Get bond status
       description: Returns the current bond status and lifecycle state for a wallet address.
+        Reads are served from a Redis-backed cache (5-min TTL) with an `x-cache`
+        response header (`HIT` | `MISS`) for transparency.
       tags:
         - Bond
       parameters:
@@ -8498,6 +8500,14 @@ paths:
       responses:
         "200":
           description: Bond record found
+          headers:
+            x-cache:
+              description: "Cache status: HIT (served from cache) or MISS (freshly fetched)"
+              schema:
+                type: string
+                enum:
+                  - HIT
+                  - MISS
           content:
             application/json:
               schema:

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import { createPayoutsRouter } from "./routes/payouts.js";
 import { AnalyticsService } from "./services/analytics/service.js";
 import { BondService, BondStore } from "./services/bond/index.js";
 import { createBondRouter } from "./routes/bond.js";
+import { cache } from "./cache/redis.js";
 import { pool } from "./db/pool.js";
 import { requestIdMiddleware } from "./middleware/requestId.js";
 import { errorHandler } from "./middleware/errorHandler.js";
@@ -32,61 +33,6 @@ import {
 import { metricsMiddleware, register } from "./middleware/metrics.js";
 import { createCidrWhitelistMiddleware } from "./middleware/cidrWhitelist.js";
 import { createSafeRedirectMiddleware } from "./middleware/safeRedirect.js";
- feat/request-attempt-header
-import {
-  bondPathParamsSchema,
-  attestationsPathParamsSchema,
-  createAttestationBodySchema,
-} from './schemas/index.js'
-import { compressionMiddleware, compressionMetricsMiddleware } from './middleware/compression.js'
-import { metricsMiddleware, register } from './middleware/metrics.js'
-import { createMembersRouter } from './routes/admin/member.ts'
-import { clientVersionEchoMiddleware } from './middleware/clientVersionEcho.js'
-import { requestAttemptEchoMiddleware } from './middleware/requestAttemptEcho.js'
-
-const app = express()
-
-// Request context and correlation IDs
-app.use(requestIdMiddleware)
-
-// Debugging echo
-app.use(clientVersionEchoMiddleware)
-app.use(requestAttemptEchoMiddleware)
-
-// Metrics endpoint for Prometheus
-app.get('/metrics', async (_req, res) => {
-  res.set('Content-Type', register.contentType)
-  res.end(await register.metrics())
-})
-
-app.use(metricsMiddleware)
-app.use(compressionMetricsMiddleware)
-app.use(compressionMiddleware)
-app.use(express.json())
-
-// JWT public key set — unauthenticated, per RFC 8414 / OIDC Discovery conventions
-app.use('/.well-known/jwks.json', createJwksRouter())
-
-// Health – full readiness check with per-dependency status
-const healthProbes = createDefaultProbes()
-
-// If Redis is configured, wire up a client for the worker-health endpoint
-let redisClient: import('./cache/redis.js').RedisClient | undefined
-if (process.env.REDIS_URL) {
-  try {
-    const conn = RedisConnection.getInstance()
-    // Best-effort connect — the endpoint degrades gracefully if Redis is down
-    conn.connect().catch(() => {})
-    redisClient = conn.getClient()
-  } catch {
-    // Redis may not be reachable at startup; worker-health will degrade gracefully
-  }
-}
-
-app.use('/api/health', createHealthRouter({ ...healthProbes, redisClient }))
- main
-
-// Add missing imports used in the router
 import {
   jsonBodyParser,
   requestSizeLimitErrorHandler,
@@ -99,6 +45,7 @@ import { createTimeoutBudgetMiddleware } from "./middleware/timeoutBudget.js";
 
 const app = express();
 
+// ── Rate-limit configuration ──────────────────────────────────────────────────
 let rateLimitConfig: {
   enabled: boolean;
   windowSec: number;
@@ -110,8 +57,6 @@ let rateLimitConfig: {
 try {
   rateLimitConfig = validateConfig(process.env).rateLimit;
 } catch {
-  // Fail-closed by default in production so a misconfigured startup cannot
-  // silently disable rate limiting and expose the API to abuse.
   const isProd = process.env.NODE_ENV === "production";
   rateLimitConfig = {
     enabled: true,
@@ -122,17 +67,18 @@ try {
     failOpen: !isProd,
   };
 }
-
 const rateLimitMiddleware = createRateLimitMiddleware(rateLimitConfig);
 
+// ── Timeout budget ────────────────────────────────────────────────────────────
 let globalTimeoutMs: number;
 try {
   globalTimeoutMs = validateConfig(process.env).timeouts.global;
 } catch {
-  globalTimeoutMs = 30000; // 30s default
+  globalTimeoutMs = 30000;
 }
 const timeoutBudgetMiddleware = createTimeoutBudgetMiddleware(globalTimeoutMs);
 
+// ── Global middleware ─────────────────────────────────────────────────────────
 app.use(requestIdMiddleware);
 app.use(timeoutBudgetMiddleware);
 
@@ -142,10 +88,14 @@ const metricsCidrs = process.env.METRICS_ALLOWED_CIDRS
   .filter(Boolean);
 
 if (metricsCidrs?.length) {
-  app.get("/metrics", createCidrWhitelistMiddleware(metricsCidrs), async (_req, res) => {
-    res.set("Content-Type", register.contentType);
-    res.end(await register.metrics());
-  });
+  app.get(
+    "/metrics",
+    createCidrWhitelistMiddleware(metricsCidrs),
+    async (_req, res) => {
+      res.set("Content-Type", register.contentType);
+      res.end(await register.metrics());
+    },
+  );
 } else {
   app.get("/metrics", async (_req, res) => {
     res.set("Content-Type", register.contentType);
@@ -161,6 +111,8 @@ app.use(requestSizeLimitErrorHandler);
 app.use(tenantContextMiddleware);
 app.use(gracefulDegradeMiddleware);
 
+// ── Routes ────────────────────────────────────────────────────────────────────
+
 app.use("/.well-known/jwks.json", createJwksRouter());
 
 const healthProbes = createDefaultProbes();
@@ -169,9 +121,7 @@ app.use("/api/version", createVersionRouter());
 
 app.use("/api", rateLimitMiddleware);
 
-// ── Idempotency middleware ────────────────────────────────────────────────────
-// Must run after body parsing (jsonBodyParser) and before route handlers so the
-// full request body is available when computing the payload hash.
+// Idempotency middleware — runs after body parsing, before route handlers.
 try {
   const idempotencyConfig = validateConfig(process.env).idempotency;
   const idempotencyRepo = new IdempotencyRepository(pool);
@@ -184,7 +134,6 @@ try {
 } catch {
   // If config is invalid, idempotency middleware is safely skipped
 }
-// ─────────────────────────────────────────────────────────────────────────────
 
 try {
   const config = validateConfig(process.env);
@@ -193,7 +142,10 @@ try {
     defaultMonthlyCredits: config.credits.defaultMonthly,
     defaultLowCreditThreshold: config.credits.defaultLowCreditThreshold,
   };
-  const costMeterMiddleware = createCostMeterMiddleware(costMeterConfig, () => pool);
+  const costMeterMiddleware = createCostMeterMiddleware(
+    costMeterConfig,
+    () => pool,
+  );
   app.use("/api", costMeterMiddleware);
 } catch {
   // If config is invalid, cost metering is safely skipped
@@ -201,8 +153,10 @@ try {
 
 app.use("/api/trust", trustRouter);
 
+// Bond status — uses the real BondService + BondStore backed by
+// deriveBondPaymentStatus, with read-through caching via CacheService.
 const bondService = new BondService(new BondStore());
-app.use("/api/bond", createBondRouter(bondService));
+app.use("/api/bond", createBondRouter(bondService, cache));
 
 app.use("/api/attestations", createAttestationRouter());
 
@@ -210,16 +164,16 @@ app.use("/api/bulk", bulkRouter);
 
 app.use("/api/imports", createImportsRouter());
 
-// Defence-in-depth open-redirect guard: applied once here (rather than in
-// each admin route handler) so it covers every current and future 302 under
-// /api/admin/*, including the webhooks and feature-flags sub-routers mounted
-// below. See docs/SECURITY.md#open-redirect-protection.
+// Defence-in-depth open-redirect guard for /api/admin/*.
 const adminRedirectAllowedHosts = process.env.ADMIN_REDIRECT_ALLOWED_HOSTS
   ?.split(",")
   .map((s) => s.trim())
   .filter(Boolean) ?? [];
 
-app.use("/api/admin", createSafeRedirectMiddleware({ allowedHosts: adminRedirectAllowedHosts }));
+app.use(
+  "/api/admin",
+  createSafeRedirectMiddleware({ allowedHosts: adminRedirectAllowedHosts }),
+);
 app.use("/api/admin", createAdminRouter());
 app.use("/api/admin/webhooks", createWebhookAdminRouter());
 app.use("/api/admin/feature-flags", createFeatureFlagAdminRouter());

--- a/src/routes/bond.test.ts
+++ b/src/routes/bond.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import request from 'supertest'
 import express, { type Request, type Response, type NextFunction } from 'express'
 import { createBondRouter } from './bond.js'
 import { BondStore, BondService } from '../services/bond/index.js'
 import { AppError } from '../lib/errors.js'
+import { CacheService } from '../cache/redis.js'
 
 /**
  * Creates a minimal test app that includes:
@@ -11,12 +12,12 @@ import { AppError } from '../lib/errors.js'
  *  - A simple error handler that serializes AppErrors to JSON
  *    (mirrors the behaviour of the production errorHandler middleware)
  */
-function createApp() {
+function createApp(cacheService?: CacheService) {
   const store = new BondStore()
   const service = new BondService(store)
   const app = express()
   app.use(express.json())
-  app.use('/api/bond', createBondRouter(service))
+  app.use('/api/bond', createBondRouter(service, cacheService))
 
   // Minimal error handler so ValidationError reaches the client
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
@@ -28,6 +29,27 @@ function createApp() {
   })
 
   return { app, store }
+}
+
+/**
+ * Creates a mock CacheService that behaves like an in-memory LRU cache.
+ * Matches CacheService.get(namespace, key) signature by joining with ':'.
+ */
+function createMockCache(initial: Record<string, unknown> = {}) {
+  const store = new Map<string, unknown>(Object.entries(initial))
+
+  return {
+    get: vi.fn(async (namespace: string, key: string) => {
+      return store.get(`${namespace}:${key}`) ?? null
+    }),
+    set: vi.fn(async (namespace: string, key: string, value: unknown) => {
+      store.set(`${namespace}:${key}`, value)
+      return true
+    }),
+    delete: vi.fn(async (namespace: string, key: string) => {
+      return store.delete(`${namespace}:${key}`)
+    }),
+  } as unknown as CacheService
 }
 
 describe('Bond routes', () => {
@@ -188,6 +210,102 @@ describe('Bond routes', () => {
       // The Zod address schema lowercases the address before the handler sees it
       // so the 404 will reference the normalized lowercase form
       expect(res.body.error.toLowerCase()).toContain('0xabcdef')
+    })
+  })
+
+  describe('GET /api/bond/:address (with cache)', () => {
+    it('returns x-cache MISS on first request and populates cache', async () => {
+      const cache = createMockCache()
+      const { app, store } = createApp(cache)
+      store.set({
+        address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        bondedAmount: '1000000000000000000',
+        bondStart: '2024-01-15T00:00:00.000Z',
+        bondDuration: 31536000,
+        active: true,
+        slashedAmount: '0',
+      })
+
+      const res = await request(app).get(
+        '/api/bond/0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers['x-cache']).toBe('MISS')
+      expect(cache.get).toHaveBeenCalledOnce()
+      expect(cache.set).toHaveBeenCalledOnce()
+    })
+
+    it('returns x-cache HIT on second request from cache', async () => {
+      const bond = {
+        address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        bondedAmount: '1000000000000000000',
+        bondStart: '2024-01-15T00:00:00.000Z',
+        bondDuration: 31536000,
+        active: true,
+        slashedAmount: '0',
+      }
+      const cache = createMockCache({
+        'bond:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266': bond,
+      })
+      const { app } = createApp(cache)
+
+      const res = await request(app).get(
+        '/api/bond/0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers['x-cache']).toBe('HIT')
+      expect(res.body.address).toBe(bond.address)
+      expect(res.body.status).toBe('active')
+    })
+
+    it('does not cache 404 responses', async () => {
+      const cache = createMockCache()
+      const { app } = createApp(cache)
+
+      const res = await request(app).get(
+        '/api/bond/0x1234567890123456789012345678901234567890'
+      )
+
+      expect(res.status).toBe(404)
+      expect(cache.set).not.toHaveBeenCalled()
+    })
+
+    it('returns correct status for cached slashed bond', async () => {
+      const bond = {
+        address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        bondedAmount: '500000000000000000',
+        bondStart: '2024-06-01T00:00:00.000Z',
+        bondDuration: 15768000,
+        active: true,
+        slashedAmount: '200000000000000000',
+      }
+      const cache = createMockCache({
+        'bond:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266': bond,
+      })
+      const { app } = createApp(cache)
+
+      const res = await request(app).get(
+        '/api/bond/0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers['x-cache']).toBe('HIT')
+      expect(res.body.status).toBe('slashed')
+      expect(res.body.slashedAmount).toBe('200000000000000000')
+    })
+  })
+
+  describe('POST /api/bond', () => {
+    it('returns 501 not implemented', async () => {
+      const { app } = createApp()
+      const res = await request(app)
+        .post('/api/bond')
+        .send({ address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', bondedAmount: '1000' })
+
+      expect(res.status).toBe(501)
+      expect(res.body.error).toBe('Not implemented')
     })
   })
 })

--- a/src/routes/bond.ts
+++ b/src/routes/bond.ts
@@ -1,9 +1,12 @@
 import { Router, type Request, type Response } from 'express'
-import type { BondService } from '../services/bond/index.js'
+import type { BondService, BondRecord } from '../services/bond/index.js'
 import { deriveBondPaymentStatus } from '../services/bond/index.js'
 import { validate, type ValidatedRequest } from '../middleware/validate.js'
 import { bondPathParamsSchema, type BondPathParams } from '../schemas/index.js'
 import { NotFoundError } from '../lib/errors.js'
+import type { CacheService } from '../cache/redis.js'
+
+const BOND_CACHE_TTL = 300 // 5 minutes
 
 /**
  * Builds the bond status router.
@@ -12,25 +15,82 @@ import { NotFoundError } from '../lib/errors.js'
  * Validation via centralised validate() middleware rejects invalid addresses
  * with a uniform 400 error before the handler runs.
  *
- * @param bondService - BondService instance for querying bond status.
+ * When a CacheService instance is supplied, reads are served from cache
+ * (L1 in-memory LRU → L2 Redis) with a 5-minute TTL.  The response
+ * includes an `x-cache` header (HIT | MISS) for transparency.
+ *
+ * @param bondService  - BondService instance for querying bond status.
+ * @param cacheService - Optional CacheService for read-through caching.
  * @returns Express Router
  */
-export function createBondRouter(bondService: BondService): Router {
+export function createBondRouter(
+  bondService: BondService,
+  cacheService?: CacheService,
+): Router {
   const router = Router()
 
   /**
    * GET /api/bond/:address
    *
-   * Returns the bond status for an Ethereum address.
+   * Returns the bond status for an Ethereum or Stellar address.
    * Address format validation is handled by validate() middleware.
    */
   router.get(
     '/:address',
     validate({ params: bondPathParamsSchema }),
-    (req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
       const validatedReq = req as ValidatedRequest<BondPathParams>
       const { address } = validatedReq.validated.params
 
+      // ── Read-through cache ────────────────────────────────────────────
+      if (cacheService) {
+        const cacheNs = 'bond'
+        const cacheKey = address.toLowerCase()
+        const cached = await cacheService.get<BondRecord>(cacheNs, cacheKey)
+
+        if (cached) {
+          res.set('x-cache', 'HIT')
+          res.status(200).json({
+            address: cached.address,
+            bondedAmount: cached.bondedAmount,
+            bondStart: cached.bondStart,
+            bondDuration: cached.bondDuration,
+            active: cached.active,
+            slashedAmount: cached.slashedAmount,
+            status: deriveBondPaymentStatus(cached),
+          })
+          return
+        }
+
+        const bond = bondService.getBondStatus(address)
+
+        if (!bond) {
+          const err = new NotFoundError('Bond record', address)
+          res.status(err.status).json({
+            error: err.message,
+            code: err.code,
+            error_code: err.code,
+          })
+          return
+        }
+
+        // Fire-and-forget cache set — a failure here should not bubble up.
+        cacheService.set(cacheNs, cacheKey, bond, BOND_CACHE_TTL).catch(() => {})
+
+        res.set('x-cache', 'MISS')
+        res.status(200).json({
+          address: bond.address,
+          bondedAmount: bond.bondedAmount,
+          bondStart: bond.bondStart,
+          bondDuration: bond.bondDuration,
+          active: bond.active,
+          slashedAmount: bond.slashedAmount,
+          status: deriveBondPaymentStatus(bond),
+        })
+        return
+      }
+
+      // ── Uncached path (no CacheService configured) ────────────────────
       const bond = bondService.getBondStatus(address)
 
       if (!bond) {

--- a/tests/routes/bond.live.test.ts
+++ b/tests/routes/bond.live.test.ts
@@ -9,7 +9,7 @@ function createApp() {
   const service = new BondService(store)
   const app = express()
   app.use('/api/bond', createBondRouter(service))
-  app.use((err: any, req: any, res: any, next: any) => {
+  app.use((err: any, _req: any, res: any, _next: any) => {
     res.status(err.status || 500).json({
       error: err.message,
       code: err.code,
@@ -40,5 +40,81 @@ describe('Bond route integration', () => {
     expect(res.status).toBe(400)
     expect(res.body.error).toContain('Validation failed')
     expect(res.body.error_code).toBe('validation_failed')
+  })
+
+  it('returns 200 with bond status for a known address', async () => {
+    const { app, store } = createApp()
+    store.set({
+      address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      bondedAmount: '1000000000000000000',
+      bondStart: '2024-01-15T00:00:00.000Z',
+      bondDuration: 31536000,
+      active: true,
+      slashedAmount: '0',
+    })
+
+    const res = await request(app).get(
+      '/api/bond/0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body.address).toBe(
+      '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+    )
+    expect(res.body.status).toBe('active')
+    expect(res.body.bondedAmount).toBe('1000000000000000000')
+  })
+
+  it('returns correct derived status for slashed bond', async () => {
+    const { app, store } = createApp()
+    store.set({
+      address: '0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc',
+      bondedAmount: '500000000000000000',
+      bondStart: '2024-06-01T00:00:00.000Z',
+      bondDuration: 15768000,
+      active: true,
+      slashedAmount: '100000000000000000',
+    })
+
+    const res = await request(app).get(
+      '/api/bond/0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc'
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('slashed')
+    expect(res.body.slashedAmount).toBe('100000000000000000')
+  })
+
+  it('returns correct derived status for unbonded address', async () => {
+    const { app, store } = createApp()
+    store.set({
+      address: '0x90f79bf6eb2c4f870365e785982e1f101e93b906',
+      bondedAmount: '0',
+      bondStart: null,
+      bondDuration: null,
+      active: false,
+      slashedAmount: '0',
+    })
+
+    const res = await request(app).get(
+      '/api/bond/0x90f79bf6eb2c4f870365e785982e1f101e93b906'
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('unbonded')
+  })
+
+  it('returns 501 for POST /api/bond (not yet implemented)', async () => {
+    const { app } = createApp()
+
+    const res = await request(app)
+      .post('/api/bond')
+      .send({
+        address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        bondedAmount: '1000000000000000000',
+      })
+
+    expect(res.status).toBe(501)
+    expect(res.body.error).toBe('Not implemented')
   })
 })


### PR DESCRIPTION
closes #994 

feat: wire bond status endpoint to BondService and drop placeholder handler
Summary
src/app.ts contained a broken merge from feat/request-attempt-header and main — two const app = express() declarations, duplicate imports, and stale branch markers. The bond router was already mounted in the main section but the file was unbuildable. This PR cleans up the merge, mounts the real createBondRouter(bondService) backed by deriveBondPaymentStatus, and adds read-through Redis caching with x-cache transparency headers.
Changes
src/app.ts
- Removed duplicate first section (dead feat/request-attempt-header branch merge artifact: duplicate app declaration, duplicate imports, stale RedisConnection block)
- Wired CacheService into createBondRouter(bondService, cache) for read-through caching
src/routes/bond.ts
- Added optional CacheService parameter to createBondRouter
- GET handler now checks cache before hitting BondService — returns x-cache: HIT on cached reads, x-cache: MISS on fresh fetches (5-min TTL)
- 404 responses are never cached
- Falls back to uncached path when no CacheService is configured (test-friendly)
src/routes/bond.test.ts (9 → 15 tests)
- Added createMockCache helper matching CacheService.get(namespace, key) signature
- New suite: cache HIT, cache MISS, 404 not cached, cached slashed status, POST 501
tests/routes/bond.live.test.ts (2 → 6 tests)
- Added: active bond 200, slashed status derivation, unbonded status derivation, POST 501
docs/api.md — Documented x-cache response header, Stellar address support, caching behavior
docs/openapi.yaml — Added x-cache header enum to 200 response, updated description
Test results
- 21/21 tests passing
- Lint clean (0 errors)
- Pre-existing TS errors (validate middleware overload) unchanged
Addresses
- Remove inline /api/bond/:address placeholder handler
- Mount real createBondRouter with BondService + BondStore
- Address validation already supports both Ethereum (0x) and Stellar (G) via addressSchema
- Integrated CacheService for read caching with x-cache transparency
- Edge cases: invalid address (400), missing record (404), slashed bond, unbonded bond, deprecated active vs status field