### PR TITLE
fix(webhooks): harden signature verification

### DIFF
--- a/src/lib/webhookVerifier.test.ts
+++ b/src/lib/webhookVerifier.test.ts
@@ -96,6 +96,38 @@ describe('safeCompareHex', () => {
   it('returns false when lengths differ', () => {
     expect(safeCompareHex('a'.repeat(64), 'a'.repeat(32))).toBe(false)
   })
+
+  it('returns false when first argument is null', () => {
+    expect(safeCompareHex(null as unknown as string, 'a'.repeat(64))).toBe(false)
+  })
+
+  it('returns false when first argument is undefined', () => {
+    expect(safeCompareHex(undefined as unknown as string, 'a'.repeat(64))).toBe(false)
+  })
+
+  it('returns false when second argument is null', () => {
+    expect(safeCompareHex('a'.repeat(64), null as unknown as string)).toBe(false)
+  })
+
+  it('returns false when second argument is undefined', () => {
+    expect(safeCompareHex('a'.repeat(64), undefined as unknown as string)).toBe(false)
+  })
+
+  it('returns false when first argument is a number', () => {
+    expect(safeCompareHex(42 as unknown as string, 'a'.repeat(64))).toBe(false)
+  })
+
+  it('returns false when both arguments are empty strings', () => {
+    expect(safeCompareHex('', '')).toBe(false)
+  })
+
+  it('returns false gracefully when input contains non-hex characters (Buffer.from safety)', () => {
+    expect(safeCompareHex('zz'.repeat(32), 'aa'.repeat(32))).toBe(false)
+  })
+
+  it('returns false gracefully on odd-length hex string', () => {
+    expect(safeCompareHex('a'.repeat(63), 'b'.repeat(63))).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -147,6 +179,16 @@ describe('verifySignature', () => {
   it('returns missing_signature when rawSignature is empty string', () => {
     const result = verifySignature('', body, secret)
     expect(result).toEqual({ ok: false, reason: 'missing_signature' })
+  })
+
+  it('returns missing_timestamp when body is null', () => {
+    const result = verifySignature(validSig, null as unknown as string, secret)
+    expect(result).toEqual({ ok: false, reason: 'missing_timestamp' })
+  })
+
+  it('returns missing_timestamp when body is undefined', () => {
+    const result = verifySignature(validSig, undefined as unknown as string, secret)
+    expect(result).toEqual({ ok: false, reason: 'missing_timestamp' })
   })
 
   it('returns malformed_signature for non-hex header value', () => {

--- a/src/lib/webhookVerifier.ts
+++ b/src/lib/webhookVerifier.ts
@@ -30,8 +30,13 @@ export function computeHmac(body: string, secret: string): string {
 }
 
 export function safeCompareHex(a: string, b: string): boolean {
-  if (a.length !== b.length) return false
-  return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'))
+  if (typeof a !== 'string' || typeof b !== 'string') return false
+  if (a.length !== b.length || a.length === 0) return false
+  try {
+    return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'))
+  } catch {
+    return false
+  }
 }
 
 export function verifySignature(
@@ -45,6 +50,7 @@ export function verifySignature(
   if (rawSignature == null || rawSignature === '') {
     return { ok: false, reason: 'missing_signature' }
   }
+  if (typeof body !== 'string') return { ok: false, reason: 'missing_timestamp' }
 
   const received = parseSignatureHeader(rawSignature)
   if (!received) return { ok: false, reason: 'malformed_signature' }

--- a/src/services/webhooks/delivery.test.ts
+++ b/src/services/webhooks/delivery.test.ts
@@ -27,6 +27,18 @@ describe('signPayload', () => {
     const sig2 = signPayload('{"event":"bond.slashed"}', secret)
     expect(sig1).not.toBe(sig2)
   })
+
+  it('throws TypeError when secret is null', () => {
+    expect(() => signPayload('{}', null as unknown as string)).toThrow(TypeError)
+  })
+
+  it('throws TypeError when secret is undefined', () => {
+    expect(() => signPayload('{}', undefined as unknown as string)).toThrow(TypeError)
+  })
+
+  it('throws TypeError when secret is empty string', () => {
+    expect(() => signPayload('{}', '')).toThrow(TypeError)
+  })
 })
 
 describe('deliverWebhook', () => {

--- a/src/services/webhooks/delivery.ts
+++ b/src/services/webhooks/delivery.ts
@@ -70,6 +70,9 @@ const DEFAULT_WEBHOOK_RETRY = {
  * Generate HMAC-SHA256 signature for webhook payload.
  */
 export function signPayload(payload: string, secret: string): string {
+  if (typeof secret !== 'string' || !secret) {
+    throw new TypeError('signPayload: secret must be a non-empty string')
+  }
   return createHmac('sha256', secret).update(payload).digest('hex')
 }
 
@@ -77,6 +80,7 @@ export function signPayload(payload: string, secret: string): string {
  * Constant-time comparison to prevent timing attacks on certificate pinning.
  */
 function constantTimeEqual(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false
   if (a.length !== b.length) return false
   let result = 0
   for (let i = 0; i < a.length; i++) {

--- a/tests/integration/webhookSignature.integration.test.ts
+++ b/tests/integration/webhookSignature.integration.test.ts
@@ -1,0 +1,237 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createHmac } from 'node:crypto'
+
+import { verifyWebhookSignature } from '../../src/middleware/webhookSignature.js'
+import { verifySignature, safeCompareHex } from '../../src/lib/webhookVerifier.js'
+
+function sign(body: string, secret: string): string {
+  return createHmac('sha256', secret).update(body).digest('hex')
+}
+
+describe('webhook signature hardening — integration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-06-25T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 401 when signature header is empty string', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: 'test-secret',
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', '')
+      .send(body)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when signature header is whitespace-only', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: 'test-secret',
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', '   ')
+      .send(body)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when body is null', async () => {
+    const app = express()
+    app.use(express.json({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: 'test-secret',
+        getBody: () => 'null',
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const sig = sign('null', 'test-secret')
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', `sha256=${sig}`)
+      .send(null)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when secret function returns null', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: () => null,
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const sig = sign(body, 'test-secret')
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', `sha256=${sig}`)
+      .send(body)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when secret function returns undefined', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: () => undefined,
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const sig = sign(body, 'test-secret')
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', `sha256=${sig}`)
+      .send(body)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a mutated signature with constant-time behaviour', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: 'test-secret',
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const sig = sign(body, 'test-secret')
+
+    // flip one hex char — must fail
+    const mutated = (parseInt(sig[0], 16) ^ 0xf).toString(16) + sig.slice(1)
+
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', `sha256=${mutated}`)
+      .send(body)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('accepts valid request through the full pipeline', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: 'test-secret',
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const sig = sign(body, 'test-secret')
+
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', `sha256=${sig}`)
+      .send(body)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+  })
+
+  it('safeCompareHex handles edge cases without throwing', () => {
+    expect(safeCompareHex('a'.repeat(64), 'b'.repeat(64))).toBe(false)
+    expect(safeCompareHex(null as unknown as string, 'abc')).toBe(false)
+    expect(safeCompareHex('abc', undefined as unknown as string)).toBe(false)
+    expect(safeCompareHex('', '')).toBe(false)
+  })
+
+  it('returns 401 when multiple signature headers are sent as array', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: 'test-secret',
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', ['sig1', 'sig2'])
+      .send(body)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('return 401 when previous secret is used (no current secret match)', async () => {
+    const app = express()
+    app.use(express.text({ type: '*/*' }))
+    app.post(
+      '/webhook',
+      verifyWebhookSignature({
+        secret: 'current-secret',
+        getBody: (req) => (typeof req.body === 'string' ? req.body : ''),
+      }),
+      (_req, res) => res.status(200).json({ ok: true }),
+    )
+
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const sig = sign(body, 'previous-secret')
+
+    const res = await request(app)
+      .post('/webhook')
+      .set('X-Webhook-Signature', `sha256=${sig}`)
+      .send(body)
+
+    expect(res.status).toBe(401) // middleware only uses current secret
+  })
+
+  it('verifySignature with both secrets returns ok:true when previous secret matches', () => {
+    const body = JSON.stringify({ event: 'test', timestamp: '2026-06-25T12:00:00.000Z' })
+    const sig = sign(body, 'previous-secret')
+    const result = verifySignature(`sha256=${sig}`, body, 'current-secret', 'previous-secret')
+    expect(result).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
Closes #954

---

## Description

Fix null/undefined verification paths and enforce constant-time comparison across webhook signature verification.

### Changes

- **`safeCompareHex`** — wrapped `Buffer.from` + `timingSafeEqual` in try-catch so malformed hex returns `false` instead of crashing the process
- **`signPayload`** — added null/undefined