### PR TITLE
perf(db): add indexes for high-latency transaction queries

### DIFF
--- a/src/migrations/006_add_tx_indexes.test.ts
+++ b/src/migrations/006_add_tx_indexes.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { up, down } from './006_add_tx_indexes.js'
+import type { MigrationBuilder } from 'node-pg-migrate'
+
+function createMockPgm(): MigrationBuilder {
+  return {
+    sql: vi.fn(),
+  } as unknown as MigrationBuilder
+}
+
+const sqlOf = (pgm: MigrationBuilder): string[] =>
+  vi.mocked(pgm.sql).mock.calls.map((call) => call[0] as string)
+
+describe('006_add_tx_indexes', () => {
+  let pgm: MigrationBuilder
+
+  beforeEach(() => {
+    pgm = createMockPgm()
+  })
+
+  describe('up', () => {
+    it('creates covering index on settlements(bond_id, settled_at DESC, id DESC)', async () => {
+      await up(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_settlements_bond_settled_at'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/)
+      expect(stmt).toMatch(/ON settlements \(bond_id, settled_at DESC, id DESC\)/)
+    })
+
+    it('creates index on settlements(transaction_hash)', async () => {
+      await up(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_settlements_transaction_hash'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/)
+      expect(stmt).toMatch(/ON settlements \(transaction_hash\)/)
+    })
+
+    it('creates covering index on bonds(identity_id, created_at DESC)', async () => {
+      await up(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_bonds_identity_created_at'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/)
+      expect(stmt).toMatch(/ON bonds \(identity_id, created_at DESC\)/)
+    })
+
+    it('creates partial index on bonds(bond_end) WHERE active = TRUE', async () => {
+      await up(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_bonds_active_bond_end'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/CREATE INDEX CONCURRENTLY IF NOT EXISTS/)
+      expect(stmt).toMatch(/ON bonds \(bond_end\)/)
+      expect(stmt).toMatch(/WHERE active = TRUE/)
+    })
+
+    it('issues exactly four CREATE INDEX statements', async () => {
+      await up(pgm)
+      const stmts = sqlOf(pgm)
+      const creates = stmts.filter((s) => /CREATE INDEX/.test(s))
+      expect(creates).toHaveLength(4)
+    })
+
+    it('every CREATE INDEX uses CONCURRENTLY and IF NOT EXISTS for safety', async () => {
+      await up(pgm)
+      const stmts = sqlOf(pgm)
+      const creates = stmts.filter((s) => /CREATE INDEX/.test(s))
+      for (const s of creates) {
+        expect(s).toMatch(/CONCURRENTLY/)
+        expect(s).toMatch(/IF NOT EXISTS/)
+      }
+    })
+  })
+
+  describe('down', () => {
+    it('drops idx_settlements_bond_settled_at', async () => {
+      await down(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_settlements_bond_settled_at'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/DROP INDEX CONCURRENTLY IF EXISTS/)
+    })
+
+    it('drops idx_settlements_transaction_hash', async () => {
+      await down(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_settlements_transaction_hash'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/DROP INDEX CONCURRENTLY IF EXISTS/)
+    })
+
+    it('drops idx_bonds_identity_created_at', async () => {
+      await down(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_bonds_identity_created_at'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/DROP INDEX CONCURRENTLY IF EXISTS/)
+    })
+
+    it('drops idx_bonds_active_bond_end', async () => {
+      await down(pgm)
+
+      const stmts = sqlOf(pgm)
+      const stmt = stmts.find((s) => s.includes('idx_bonds_active_bond_end'))
+      expect(stmt).toBeDefined()
+      expect(stmt).toMatch(/DROP INDEX CONCURRENTLY IF EXISTS/)
+    })
+
+    it('issues exactly four DROP INDEX statements', async () => {
+      await down(pgm)
+      const stmts = sqlOf(pgm)
+      const drops = stmts.filter((s) => /DROP INDEX/.test(s))
+      expect(drops).toHaveLength(4)
+    })
+
+    it('up and down are symmetric (every created index has a matching drop)', async () => {
+      const upPgm = createMockPgm()
+      const downPgm = createMockPgm()
+
+      await up(upPgm)
+      await down(downPgm)
+
+      const upStmts = sqlOf(upPgm)
+      const downStmts = sqlOf(downPgm)
+
+      const indexNamePattern = /idx_[a-z0-9_]+/g
+      const upNames = new Set(upStmts.flatMap((s) => s.match(indexNamePattern) ?? []))
+      const downNames = new Set(downStmts.flatMap((s) => s.match(indexNamePattern) ?? []))
+
+      expect(upNames).toEqual(downNames)
+    })
+  })
+})

--- a/src/migrations/006_add_tx_indexes.ts
+++ b/src/migrations/006_add_tx_indexes.ts
@@ -1,4 +1,4 @@
-import type { Pool } from 'pg'
+import { MigrationBuilder } from 'node-pg-migrate'
 
 /**
  * Migration 006: Add indexes for high-latency transaction queries
@@ -55,33 +55,42 @@ import type { Pool } from 'pg'
  *           bond_end, slashed_amount, active, created_at, updated_at
  *    FROM bonds WHERE active = TRUE AND bond_end < NOW();
  * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Impact:   Indexes are created with CONCURRENTLY so they do not block writes
+ *           during creation. IF NOT EXISTS keeps the migration idempotent.
+ * Rollback: DROP INDEX CONCURRENTLY IF EXISTS for each index.
  */
-export async function up(pool: Pool): Promise<void> {
-  await pool.query(`
-    -- settlements: covering index for findByBondId sorted result set
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_settlements_bond_settled_at
-      ON settlements (bond_id, settled_at DESC, id DESC);
+export const shorthands = undefined
 
-    -- settlements: index for findByTransactionHash and upsert duplicate check
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_settlements_transaction_hash
-      ON settlements (transaction_hash);
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // settlements: covering index for findByBondId sorted result set
+  pgm.sql(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_settlements_bond_settled_at ' +
+      'ON settlements (bond_id, settled_at DESC, id DESC);'
+  )
 
-    -- bonds: covering index for findByIdentityId ORDER BY created_at DESC
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bonds_identity_created_at
-      ON bonds (identity_id, created_at DESC);
+  // settlements: index for findByTransactionHash and upsert duplicate check
+  pgm.sql(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_settlements_transaction_hash ' +
+      'ON settlements (transaction_hash);'
+  )
 
-    -- bonds: partial index for findExpired (active bonds approaching/past bond_end)
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bonds_active_bond_end
-      ON bonds (bond_end)
-      WHERE active = TRUE;
-  `)
+  // bonds: covering index for findByIdentityId ORDER BY created_at DESC
+  pgm.sql(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bonds_identity_created_at ' +
+      'ON bonds (identity_id, created_at DESC);'
+  )
+
+  // bonds: partial index for findExpired (active bonds approaching/past bond_end)
+  pgm.sql(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bonds_active_bond_end ' +
+      'ON bonds (bond_end) WHERE active = TRUE;'
+  )
 }
 
-export async function down(pool: Pool): Promise<void> {
-  await pool.query(`
-    DROP INDEX CONCURRENTLY IF EXISTS idx_settlements_bond_settled_at;
-    DROP INDEX CONCURRENTLY IF EXISTS idx_settlements_transaction_hash;
-    DROP INDEX CONCURRENTLY IF EXISTS idx_bonds_identity_created_at;
-    DROP INDEX CONCURRENTLY IF EXISTS idx_bonds_active_bond_end;
-  `)
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS idx_bonds_active_bond_end;')
+  pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS idx_bonds_identity_created_at;')
+  pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS idx_settlements_transaction_hash;')
+  pgm.sql('DROP INDEX CONCURRENTLY IF EXISTS idx_settlements_bond_settled_at;')
 }


### PR DESCRIPTION
## Summary

Fixes #986 — adds missing indexes for high-latency transaction queries with EXPLAIN-verified query plans.

## Problem

`006_add_tx_indexes.ts` was written using raw `Pool.query()` instead of the project-standard `node-pg-migrate` `MigrationBuilder` API, so it would not run through the migration runner.

## Changes

**`src/migrations/006_add_tx_indexes.ts`** — rewritten to `pgm.sql()` (same pattern as `006_add_hot_path_partial_indexes.ts`):

| Index | Table | Purpose |
|---|---|---|
| `idx_settlements_bond_settled_at` | `settlements` | Covers `findByBondId ORDER BY settled_at DESC, id DESC` |
| `idx_settlements_transaction_hash` | `settlements` | Covers `findByTransactionHash` + upsert duplicate check |
| `idx_bonds_identity_created_at` | `bonds` | Covers `findByIdentityId ORDER BY created_at DESC` |
| `idx_bonds_active_bond_end` | `bonds` | Partial index for `findExpired WHERE active = TRUE` |

All indexes created with `CONCURRENTLY IF NOT EXISTS` — no write locks, idempotent.
Rollback drops all four `CONCURRENTLY IF EXISTS` in reverse order.

**`src/migrations/006_add_tx_indexes.test.ts`** — 12 unit tests with mocked `MigrationBuilder`, covering:
- Each index is created with the correct table/columns
- All CREATE INDEX statements use CONCURRENTLY + IF NOT EXISTS
- Exactly 4 CREATE and 4 DROP statements
- up/down symmetry (same index names in both directions)

## Testing

```
✓ src/migrations/006_add_tx_indexes.test.ts  (12 tests, 12 passed)
```

Closes #986