### PR TITLE
Fix: Add a `req.metrics` shim for lightweight per-request counters (Auto-Generated)

### DIFF
--- a/docs/request-metrics.md
+++ b/docs/request-metrics.md
@@ -1,0 +1,41 @@
+# Per-request metrics
+
+Handlers can use the lightweight `req.metrics` shim for counters that are only relevant to the current request. These counters are deliberately separate from the global metrics registry and are not exported automatically.
+
+## Enabling the shim
+
+Register the middleware before routes that use it:
+
+```ts
+import { requestMetrics } from './middleware/requestMetrics.js'
+
+app.use(requestMetrics)
+```
+
+The middleware creates a fresh counter store for every request.
+
+## Handler usage
+
+```ts
+router.get('/example', (req, res) => {
+  req.metrics.increment('example.started')
+
+  const result = doWork()
+  req.metrics.inc('example.completed')
+
+  res.json({
+    result,
+    requestMetrics: req.metrics.snapshot(),
+  })
+})
+```
+
+Available operations:
+
+- `increment(name, amount?)` increments a counter and returns its new value.
+- `inc(name, amount?)` is an alias for `increment`.
+- `get(name)` returns the current value, or `0` when the counter has not been used.
+- `snapshot()` returns a plain object containing the current counters.
+- `reset()` clears all counters for the current request.
+
+Counter state is created per request, so values cannot leak between requests or modify the global metrics registry. Counter names must be non-empty strings and increments must be finite numbers.

--- a/src/middleware/requestMetrics.test.ts
+++ b/src/middleware/requestMetrics.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Request, Response } from 'express'
+import { createRequestMetrics, requestMetrics } from './requestMetrics.js'
+
+describe('request metrics shim', () => {
+  it('keeps counters isolated per request', () => {
+    const first = createRequestMetrics()
+    const second = createRequestMetrics()
+
+    expect(first.increment('cache.hit')).toBe(1)
+    expect(first.inc('cache.hit', 2)).toBe(3)
+    expect(first.get('cache.hit')).toBe(3)
+    expect(second.get('cache.hit')).toBe(0)
+  })
+
+  it('returns a copy of the current counters', () => {
+    const metrics = createRequestMetrics()
+    metrics.increment('db.query', 2)
+
+    const snapshot = metrics.snapshot()
+    snapshot['db.query'] = 99
+
+    expect(metrics.get('db.query')).toBe(2)
+  })
+
+  it('resets only the current request counters', () => {
+    const metrics = createRequestMetrics()
+    metrics.increment('handler.invoked')
+
+    metrics.reset()
+
+    expect(metrics.snapshot()).toEqual({})
+  })
+
+  it('initializes req.metrics and calls next', () => {
+    const req = {} as Request
+    const next = vi.fn()
+
+    requestMetrics(req, {} as Response, next)
+
+    req.metrics.increment('handler.invoked')
+    expect(req.metrics.get('handler.invoked')).toBe(1)
+    expect(next).toHaveBeenCalledOnce()
+  })
+
+  it('rejects invalid counter names and amounts', () => {
+    const metrics = createRequestMetrics()
+
+    expect(() => metrics.increment('')).toThrow('Metric name must be a non-empty string')
+    expect(() => metrics.increment('invalid', Number.NaN)).toThrow('Metric increment must be a finite number')
+  })
+})

--- a/src/middleware/requestMetrics.ts
+++ b/src/middleware/requestMetrics.ts
@@ -1,0 +1,64 @@
+import type { NextFunction, Request, Response } from 'express'
+
+export interface RequestMetrics {
+  increment(name: string, amount?: number): number
+  inc(name: string, amount?: number): number
+  get(name: string): number
+  snapshot(): Record<string, number>
+  reset(): void
+}
+
+function validateCounterName(name: string): void {
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    throw new TypeError('Metric name must be a non-empty string')
+  }
+}
+
+function validateAmount(amount: number): void {
+  if (!Number.isFinite(amount)) {
+    throw new TypeError('Metric increment must be a finite number')
+  }
+}
+
+export function createRequestMetrics(): RequestMetrics {
+  const counters = new Map<string, number>()
+
+  const increment = (name: string, amount = 1): number => {
+    validateCounterName(name)
+    validateAmount(amount)
+
+    const nextValue = (counters.get(name) ?? 0) + amount
+    counters.set(name, nextValue)
+    return nextValue
+  }
+
+  return {
+    increment,
+    inc: increment,
+    get(name: string): number {
+      validateCounterName(name)
+      return counters.get(name) ?? 0
+    },
+    snapshot(): Record<string, number> {
+      return Object.fromEntries(counters)
+    },
+    reset(): void {
+      counters.clear()
+    },
+  }
+}
+
+export function requestMetrics(req: Request, _res: Response, next: NextFunction): void {
+  req.metrics = createRequestMetrics()
+  next()
+}
+
+export const requestMetricsMiddleware = requestMetrics
+
+declare global {
+  namespace Express {
+    interface Request {
+      metrics: RequestMetrics
+    }
+  }
+}


### PR DESCRIPTION
Closes #806

This PR was generated by the DripTide AI coder and scoped strictly to issue #806.

### Changes
Adds an isolated per-request metrics counter store with increment/inc, get, snapshot, and reset operations; provides Express middleware and Request type augmentation; adds unit tests and user-facing documentation.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #806` so the Drips Wave bot resolves the issue on merge._