### PR TITLE
Fix: Add a `/api/v1/echo` endpoint for connectivity testing (Auto-Generated)

### DIFF
--- a/docs/echo.md
+++ b/docs/echo.md
@@ -1,0 +1,26 @@
+# Echo endpoint
+
+The unauthenticated `GET /api/v1/echo` endpoint is provided for connectivity and proxy diagnostics.
+
+It returns the request headers in a JSON response:
+
+```json
+{
+  "headers": {
+    "accept": "*/*",
+    "x-connectivity-test": "echo-value"
+  }
+}
+```
+
+Header names are normalized to lowercase by Express. Header values are returned as strings or arrays of strings, matching the incoming request representation.
+
+Example:
+
+```bash
+curl -i \
+  -H 'X-Connectivity-Test: echo-value' \
+  https://example.com/api/v1/echo
+```
+
+This endpoint intentionally does not require an `Authorization` header and should only be used for connectivity testing and diagnostics.

--- a/src/__tests__/echo.test.ts
+++ b/src/__tests__/echo.test.ts
@@ -1,0 +1,30 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+
+import { registerEchoEndpoint } from '../echo.js'
+
+describe('GET /api/v1/echo', () => {
+  it('returns the request headers without authentication', async () => {
+    const app = express()
+    registerEchoEndpoint(app)
+
+    const response = await request(app)
+      .get('/api/v1/echo')
+      .set('X-Connectivity-Test', 'echo-value')
+
+    expect(response.status).toBe(200)
+    expect(response.body.headers['x-connectivity-test']).toBe('echo-value')
+    expect(response.body.headers.host).toBeDefined()
+  })
+
+  it('is available without an Authorization header', async () => {
+    const app = express()
+    registerEchoEndpoint(app)
+
+    const response = await request(app).get('/api/v1/echo')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toHaveProperty('headers')
+  })
+})

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -1,0 +1,31 @@
+import type { Express, Request, Response } from 'express'
+import { Router } from 'express'
+
+import { echoResponseSchema } from './schemas/echo.js'
+
+/**
+ * Handles the unauthenticated connectivity-test endpoint.
+ *
+ * Express normalizes request header names to lowercase. Header values are
+ * returned as received so callers can verify proxy and connectivity behavior.
+ */
+export function echoHandler(req: Request, res: Response): void {
+  const response = {
+    headers: req.headers,
+  }
+
+  // Keep the runtime response aligned with the public response contract.
+  echoResponseSchema.parse(response)
+  res.json(response)
+}
+
+export const echoRouter = Router()
+echoRouter.get('/api/v1/echo', echoHandler)
+
+/**
+ * Registers the echo endpoint on an Express application.
+ * No authentication middleware is applied by this registration function.
+ */
+export function registerEchoEndpoint(app: Express): void {
+  app.use(echoRouter)
+}

--- a/src/schemas/echo.ts
+++ b/src/schemas/echo.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+const headerValueSchema = z.union([z.string(), z.array(z.string())])
+
+export const echoResponseSchema = z.object({
+  headers: z.record(z.string(), headerValueSchema),
+})
+
+export type EchoResponse = z.infer<typeof echoResponseSchema>


### PR DESCRIPTION
Closes #804

This PR was generated by the DripTide AI coder and scoped strictly to issue #804.

### Changes
Adds an echo handler, Zod response schema, unit tests, and endpoint documentation for GET /api/v1/echo.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #804` so the Drips Wave bot resolves the issue on merge._