### PR TITLE
feat: validate Horizon bond events and quarantine malformed payloads

### DIFF
--- a/src/__tests__/horizonBondEvents.test.ts
+++ b/src/__tests__/horizonBondEvents.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DlqRouter, type DlqSink } from '../listeners/messageValidator.js'
 
 const streamState = vi.hoisted(() => ({
   onmessage: undefined as undefined | ((op: any) => Promise<void>),
@@ -36,6 +37,11 @@ vi.mock('../services/identityService', () => ({
 import { subscribeBondCreationEvents } from '../listeners/horizonBondEvents.js'
 import { upsertBond, upsertIdentity } from '../services/identityService.js'
 
+function makeRouter(): DlqRouter {
+  const sink: DlqSink = { async captureFailure() {} }
+  return new DlqRouter(sink)
+}
+
 describe('Horizon Bond Creation Listener', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -43,18 +49,18 @@ describe('Horizon Bond Creation Listener', () => {
   })
 
   it('subscribes without throwing', () => {
-    expect(() => subscribeBondCreationEvents({ captureFailure: vi.fn() })).not.toThrow()
+    expect(() => subscribeBondCreationEvents(makeRouter())).not.toThrow()
     expect(streamState.onmessage).toBeTypeOf('function')
   })
 
   it('accepts an undefined callback', () => {
-    expect(() => subscribeBondCreationEvents({ captureFailure: vi.fn() }, undefined)).not.toThrow()
+    expect(() => subscribeBondCreationEvents(makeRouter(), undefined)).not.toThrow()
     expect(streamState.onmessage).toBeTypeOf('function')
   })
 
   it('parses and upserts create_bond events', async () => {
     const onEvent = vi.fn()
-    subscribeBondCreationEvents({ captureFailure: vi.fn() }, onEvent)
+    subscribeBondCreationEvents(makeRouter(), onEvent)
 
     await streamState.onmessage?.({
       type: 'create_bond',
@@ -75,7 +81,7 @@ describe('Horizon Bond Creation Listener', () => {
 
   it('ignores non-bond events', async () => {
     const onEvent = vi.fn()
-    subscribeBondCreationEvents({ captureFailure: vi.fn() }, onEvent)
+    subscribeBondCreationEvents(makeRouter(), onEvent)
 
     await streamState.onmessage?.({
       type: 'payment',
@@ -89,7 +95,7 @@ describe('Horizon Bond Creation Listener', () => {
   })
 
   it('handles duplicate create_bond events consistently', async () => {
-    subscribeBondCreationEvents({ captureFailure: vi.fn() }, vi.fn())
+    subscribeBondCreationEvents(makeRouter(), vi.fn())
 
     const event = {
       type: 'create_bond',

--- a/src/__tests__/horizonCursor.test.ts
+++ b/src/__tests__/horizonCursor.test.ts
@@ -3,7 +3,6 @@ import { newDb, type IMemoryDb } from 'pg-mem'
 import { Pool } from 'pg'
 import crypto from 'crypto'
 import { CursorRepository } from '../db/repositories/cursorRepository.js'
-import { subscribeBondCreationEvents } from '../listeners/horizonBondEvents.js'
 import { HorizonWithdrawalListener } from '../listeners/horizonWithdrawalEvents.js'
 
 describe('Horizon Cursor Checkpointing', () => {

--- a/src/listeners/__tests__/horizonBondEvents.test.ts
+++ b/src/listeners/__tests__/horizonBondEvents.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { CursorRepository } from "../../db/repositories/cursorRepository.js";
+import { DlqRouter, type DlqSink } from "../messageValidator.js";
 
 vi.mock("prom-client", () => ({
   register: {},
@@ -52,6 +53,13 @@ vi.mock("@stellar/stellar-sdk", () => {
 
 import { subscribeBondCreationEvents } from "../horizonBondEvents.js";
 
+function makeRouter(): DlqRouter {
+  const sink: DlqSink = {
+    async captureFailure() {},
+  };
+  return new DlqRouter(sink);
+}
+
 describe("subscribeBondCreationEvents", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -61,31 +69,31 @@ describe("subscribeBondCreationEvents", () => {
   });
 
   it("opens exactly ONE stream on subscribe", () => {
-    const h = subscribeBondCreationEvents({ captureFailure: vi.fn() });
+    const h = subscribeBondCreationEvents(makeRouter());
     expect(streamCallCount).toBe(1);
     h.stop();
   });
 
   it("does NOT open a second stream — no duplicate", () => {
-    const h = subscribeBondCreationEvents({ captureFailure: vi.fn() });
+    const h = subscribeBondCreationEvents(makeRouter());
     expect(streamCallCount).toBe(1);
     h.stop();
   });
 
   it("returns a stop() handle", () => {
-    const h = subscribeBondCreationEvents({ captureFailure: vi.fn() });
+    const h = subscribeBondCreationEvents(makeRouter());
     expect(typeof h.stop).toBe("function");
     h.stop();
   });
 
   it("stop() does not throw", () => {
-    const h = subscribeBondCreationEvents({ captureFailure: vi.fn() });
+    const h = subscribeBondCreationEvents(makeRouter());
     expect(() => h.stop()).not.toThrow();
   });
 
   it("invokes onEvent for create_bond operations", async () => {
     const onEvent = vi.fn();
-    const h = subscribeBondCreationEvents({ captureFailure: vi.fn() }, onEvent);
+    const h = subscribeBondCreationEvents(makeRouter(), onEvent);
     await capturedHandlers.onmessage?.({
       type: "create_bond", id: "op1", paging_token: "tok1",
       source_account: "GABC", amount: "100", duration: "365",
@@ -100,7 +108,7 @@ describe("subscribeBondCreationEvents", () => {
 
   it("does not invoke onEvent for non create_bond operations", async () => {
     const onEvent = vi.fn();
-    const h = subscribeBondCreationEvents({ captureFailure: vi.fn() }, onEvent);
+    const h = subscribeBondCreationEvents(makeRouter(), onEvent);
     await capturedHandlers.onmessage?.({
       type: "payment", id: "op2", paging_token: "tok2",
       source_account: "GXYZ", amount: "50",
@@ -110,7 +118,7 @@ describe("subscribeBondCreationEvents", () => {
   });
 
   it("stop() prevents further reconnects after error", async () => {
-    const h = subscribeBondCreationEvents({ captureFailure: vi.fn() });
+    const h = subscribeBondCreationEvents(makeRouter());
     h.stop();
     const countBefore = streamCallCount;
     await capturedHandlers.onerror?.(new Error("test"));
@@ -134,7 +142,7 @@ describe("subscribeBondCreationEvents", () => {
           updatedAt: new Date(),
         });
 
-      const h = subscribeBondCreationEvents({ captureFailure: vi.fn() }, undefined, mockPool);
+      const h = subscribeBondCreationEvents(makeRouter(), undefined, mockPool);
 
       // Wait for the async initAndStart microtasks to run
       await new Promise((resolve) => process.nextTick(resolve));
@@ -149,7 +157,7 @@ describe("subscribeBondCreationEvents", () => {
       const spy = vi.spyOn(CursorRepository.prototype, "findByStreamName")
         .mockResolvedValue(null);
 
-      const h = subscribeBondCreationEvents({ captureFailure: vi.fn() }, undefined, mockPool);
+      const h = subscribeBondCreationEvents(makeRouter(), undefined, mockPool);
 
       await new Promise((resolve) => process.nextTick(resolve));
 
@@ -163,7 +171,7 @@ describe("subscribeBondCreationEvents", () => {
       const spy = vi.spyOn(CursorRepository.prototype, "findByStreamName")
         .mockRejectedValue(new Error("Database connection error"));
 
-      const h = subscribeBondCreationEvents({ captureFailure: vi.fn() }, undefined, mockPool);
+      const h = subscribeBondCreationEvents(makeRouter(), undefined, mockPool);
 
       await new Promise((resolve) => process.nextTick(resolve));
 

--- a/src/listeners/__tests__/horizonBondEvents.validation.test.ts
+++ b/src/listeners/__tests__/horizonBondEvents.validation.test.ts
@@ -9,7 +9,7 @@ let storedOnErrorHandler: vi.Mock | null = null
 vi.mock('@stellar/stellar-sdk', () => {
   const mockOperations = vi.fn()
   const mockStream = vi.fn()
-  
+
   const mockStrKey = {
     isValidEd25519PublicKey: vi.fn().mockImplementation((account: string) => {
       // Return true for valid-looking Stellar accounts (starting with G, reasonable length)
@@ -17,7 +17,7 @@ vi.mock('@stellar/stellar-sdk', () => {
     }),
     isValidMuxedAccount: vi.fn().mockReturnValue(false)
   }
-  
+
   const mockServer = {
     operations: mockOperations
       .mockReturnValue({
@@ -71,12 +71,28 @@ vi.mock('../../services/identityService.js', () => ({
 // Import after mocking
 import { subscribeBondCreationEvents } from '../horizonBondEvents.js'
 import { bondOperationSchema } from '../messageValidator.js'
-import { validateMessage } from '../messageValidator.js'
+import { validateMessage, DlqRouter, DlqReasonCode, type DlqSink } from '../messageValidator.js'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────────
+
+/** Creates an in-memory DLQ sink that records every captured message. */
+function makeSink(): DlqSink & { captured: Array<{ type: string; data: unknown; reason: string }> } {
+  const captured: Array<{ type: string; data: unknown; reason: string }> = []
+  return {
+    captured,
+    async captureFailure(type, data, reason) {
+      captured.push({ type, data, reason })
+    },
+  }
+}
+
+const VALID_ACCOUNT = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+// ── Tests ────────────────────────────────────────────────────────────────────────
 
 describe('subscribeBondCreationEvents validation', () => {
-  let mockReplayService: {
-    captureFailure: vi.Mock
-  }
+  let sink: ReturnType<typeof makeSink>
+  let dlqRouter: DlqRouter
   let mockOnEvent: vi.Mock
 
   beforeEach(() => {
@@ -84,10 +100,9 @@ describe('subscribeBondCreationEvents validation', () => {
     // Reset the stored handlers
     storedOnMessageHandler = null
     storedOnErrorHandler = null
-    
-    mockReplayService = {
-      captureFailure: vi.fn().mockResolvedValue(undefined)
-    }
+
+    sink = makeSink()
+    dlqRouter = new DlqRouter(sink)
     mockOnEvent = vi.fn()
   })
 
@@ -97,11 +112,8 @@ describe('subscribeBondCreationEvents validation', () => {
 
   describe('validation success cases', () => {
     it('should process valid bond creation operation', async () => {
-      // Test with a known valid pattern
-      const validAccount = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
-      
       const validOp = {
-        source_account: validAccount, // Valid Stellar account
+        source_account: VALID_ACCOUNT,
         id: '12345',
         amount: '100',
         duration: '3600',
@@ -109,48 +121,103 @@ describe('subscribeBondCreationEvents validation', () => {
         type: 'create_bond'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the valid operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(validOp)
       }
-      
-      // Should not call captureFailure
-      expect(mockReplayService.captureFailure).not.toHaveBeenCalled()
+
+      // Should not route to DLQ
+      expect(sink.captured).toHaveLength(0)
       // Should advance cursor and process event
       expect(mockOnEvent).toHaveBeenCalled()
       // Should call upsertIdentity and upsertBond
       expect(mockUpsertIdentity).toHaveBeenCalled()
       expect(mockUpsertBond).toHaveBeenCalled()
     })
+
+    it('should process valid bond creation with null duration', async () => {
+      const validOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12346',
+        amount: '500',
+        duration: null,
+        paging_token: 'token-2',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      expect(storedOnMessageHandler).not.toBeNull()
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(validOp)
+      }
+
+      expect(sink.captured).toHaveLength(0)
+      expect(mockOnEvent).toHaveBeenCalled()
+    })
+
+    it('should process valid bond creation without duration field', async () => {
+      const validOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12347',
+        amount: '0',
+        paging_token: 'token-3',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      expect(storedOnMessageHandler).not.toBeNull()
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(validOp)
+      }
+
+      expect(sink.captured).toHaveLength(0)
+      expect(mockOnEvent).toHaveBeenCalled()
+    })
+
+    it('should process zero amount as valid', async () => {
+      const validOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12348',
+        amount: '0',
+        paging_token: 'token-4',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(validOp)
+      }
+
+      expect(sink.captured).toHaveLength(0)
+      expect(mockOnEvent).toHaveBeenCalled()
+    })
   })
 
   describe('validation failure cases', () => {
     it('should quarantine operation with missing source_account', async () => {
       const invalidOp = {
-        // Missing source_account
         id: '12345',
         amount: '100',
         paging_token: 'token-1',
         type: 'create_bond'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the invalid operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(invalidOp)
       }
-      
-      // Should call captureFailure with the operation
-      expect(mockReplayService.captureFailure).toHaveBeenCalledWith(
-        'bond_creation',
-        invalidOp,
-        expect.stringContaining('source_account')
-      )
+
+      // Should route to DLQ with structured reason
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].type).toBe('bond_creation')
+      expect(sink.captured[0].reason).toContain(DlqReasonCode.SCHEMA_VALIDATION_FAILED)
       // Should NOT call onEvent
       expect(mockOnEvent).not.toHaveBeenCalled()
       // Should NOT call upsert functions
@@ -167,99 +234,145 @@ describe('subscribeBondCreationEvents validation', () => {
         type: 'create_bond'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the invalid operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(invalidOp)
       }
-      
-      // Should call captureFailure
-      expect(mockReplayService.captureFailure).toHaveBeenCalled()
-      // Should NOT call onEvent
+
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].type).toBe('bond_creation')
       expect(mockOnEvent).not.toHaveBeenCalled()
-      // Should NOT call upsert functions
       expect(mockUpsertIdentity).not.toHaveBeenCalled()
       expect(mockUpsertBond).not.toHaveBeenCalled()
     })
 
     it('should quarantine operation with missing amount', async () => {
       const invalidOp = {
-        source_account: 'GABCD...',
+        source_account: VALID_ACCOUNT,
         id: '12345',
-        // Missing amount
         paging_token: 'token-1',
         type: 'create_bond'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the invalid operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(invalidOp)
       }
-      
-      // Should call captureFailure
-      expect(mockReplayService.captureFailure).toHaveBeenCalled()
-      // Should NOT call onEvent
+
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].type).toBe('bond_creation')
       expect(mockOnEvent).not.toHaveBeenCalled()
-      // Should NOT call upsert functions
       expect(mockUpsertIdentity).not.toHaveBeenCalled()
       expect(mockUpsertBond).not.toHaveBeenCalled()
     })
 
     it('should quarantine operation with non-numeric amount', async () => {
       const invalidOp = {
-        source_account: 'GABCD...',
+        source_account: VALID_ACCOUNT,
         id: '12345',
         amount: 'not_a_number',
         paging_token: 'token-1',
         type: 'create_bond'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the invalid operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(invalidOp)
       }
-      
-      // Should call captureFailure
-      expect(mockReplayService.captureFailure).toHaveBeenCalled()
-      // Should NOT call onEvent
+
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].type).toBe('bond_creation')
+      expect(sink.captured[0].reason).toContain('amount')
       expect(mockOnEvent).not.toHaveBeenCalled()
-      // Should NOT call upsert functions
       expect(mockUpsertIdentity).not.toHaveBeenCalled()
       expect(mockUpsertBond).not.toHaveBeenCalled()
     })
 
     it('should quarantine operation with negative amount', async () => {
       const invalidOp = {
-        source_account: 'GABCD...',
+        source_account: VALID_ACCOUNT,
         id: '12345',
-        amount: '-100', // Negative number
+        amount: '-100',
         paging_token: 'token-1',
         type: 'create_bond'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the invalid operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(invalidOp)
       }
-      
-      // Should call captureFailure
-      expect(mockReplayService.captureFailure).toHaveBeenCalled()
-      // Should NOT call onEvent
+
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].type).toBe('bond_creation')
       expect(mockOnEvent).not.toHaveBeenCalled()
-      // Should NOT call upsert functions
       expect(mockUpsertIdentity).not.toHaveBeenCalled()
       expect(mockUpsertBond).not.toHaveBeenCalled()
+    })
+
+    it('should quarantine operation with decimal amount', async () => {
+      const invalidOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12345',
+        amount: '100.50',
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].type).toBe('bond_creation')
+      expect(mockOnEvent).not.toHaveBeenCalled()
+    })
+
+    it('should quarantine operation with empty amount string', async () => {
+      const invalidOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12345',
+        amount: '',
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(mockOnEvent).not.toHaveBeenCalled()
+    })
+
+    it('should quarantine operation with missing id', async () => {
+      const invalidOp = {
+        source_account: VALID_ACCOUNT,
+        amount: '100',
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].reason).toContain('id')
+      expect(mockOnEvent).not.toHaveBeenCalled()
     })
 
     it('should not advance cursor on validation failure', async () => {
@@ -271,50 +384,214 @@ describe('subscribeBondCreationEvents validation', () => {
         type: 'create_bond'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the invalid operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(invalidOp)
       }
-      
+
       // Should NOT call onEvent (early return)
       expect(mockOnEvent).not.toHaveBeenCalled()
-      // Should call captureFailure
-      expect(mockReplayService.captureFailure).toHaveBeenCalled()
+      // Should route to DLQ
+      expect(sink.captured).toHaveLength(1)
       // Should NOT call upsert functions
       expect(mockUpsertIdentity).not.toHaveBeenCalled()
       expect(mockUpsertBond).not.toHaveBeenCalled()
     })
   })
 
+  describe('security: injection and unbounded strings', () => {
+    it('should reject source_account exceeding max length', async () => {
+      const invalidOp = {
+        source_account: 'G' + 'A'.repeat(200),
+        id: '12345',
+        amount: '100',
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(sink.captured[0].type).toBe('bond_creation')
+      expect(mockOnEvent).not.toHaveBeenCalled()
+    })
+
+    it('should reject id exceeding max length', async () => {
+      const invalidOp = {
+        source_account: VALID_ACCOUNT,
+        id: 'x'.repeat(300),
+        amount: '100',
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(mockOnEvent).not.toHaveBeenCalled()
+    })
+
+    it('should reject amount exceeding max length', async () => {
+      const invalidOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12345',
+        amount: '9'.repeat(50),
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(mockOnEvent).not.toHaveBeenCalled()
+    })
+
+    it('should reject amount with SQL injection attempt', async () => {
+      const invalidOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12345',
+        amount: "100'; DROP TABLE bonds;--",
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(mockOnEvent).not.toHaveBeenCalled()
+      // Verify the malicious payload is stored as-is, not interpolated
+      expect(sink.captured[0].data).toEqual(invalidOp)
+    })
+
+    it('should reject amount with script injection attempt', async () => {
+      const invalidOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12345',
+        amount: '<script>alert(1)</script>',
+        paging_token: 'token-1',
+        type: 'create_bond'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(invalidOp)
+      }
+
+      expect(sink.captured).toHaveLength(1)
+      expect(mockOnEvent).not.toHaveBeenCalled()
+    })
+  })
+
   describe('non-bond creation operations', () => {
     it('should ignore non-create_bond operations', async () => {
       const nonBondOp = {
-        source_account: 'GABCD...',
+        source_account: VALID_ACCOUNT,
         id: '12345',
         amount: '100',
         duration: '3600',
         paging_token: 'token-1',
-        type: 'payment' // Not a create_bond operation
+        type: 'payment'
       }
 
-      const unsubscribe = subscribeBondCreationEvents(mockReplayService, mockOnEvent)
-      
-      // Call the stored onMessage handler with the non-bond operation
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
       expect(storedOnMessageHandler).not.toBeNull()
       if (storedOnMessageHandler) {
         await storedOnMessageHandler(nonBondOp)
       }
-      
-      // Should still validate the operation (to check format)
-      // But should not process it as a bond creation
-      expect(mockReplayService.captureFailure).not.toHaveBeenCalled()
+
+      // Should not route to DLQ and should not process
+      expect(sink.captured).toHaveLength(0)
       expect(mockOnEvent).not.toHaveBeenCalled()
-      // Should NOT call upsert functions
       expect(mockUpsertIdentity).not.toHaveBeenCalled()
       expect(mockUpsertBond).not.toHaveBeenCalled()
     })
+
+    it('should ignore unknown operation types', async () => {
+      const unknownOp = {
+        source_account: VALID_ACCOUNT,
+        id: '12345',
+        amount: '100',
+        paging_token: 'token-1',
+        type: 'unknown_op_type'
+      }
+
+      const unsubscribe = subscribeBondCreationEvents(dlqRouter, mockOnEvent)
+
+      if (storedOnMessageHandler) {
+        await storedOnMessageHandler(unknownOp)
+      }
+
+      expect(sink.captured).toHaveLength(0)
+      expect(mockOnEvent).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('bondOperationSchema standalone validation', () => {
+  it('validates a correct payload', () => {
+    const result = validateMessage(bondOperationSchema, {
+      source_account: VALID_ACCOUNT,
+      id: 'op-1',
+      amount: '1000',
+      duration: '3600',
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  it('rejects null payload', () => {
+    expect(validateMessage(bondOperationSchema, null).valid).toBe(false)
+  })
+
+  it('rejects empty object', () => {
+    expect(validateMessage(bondOperationSchema, {}).valid).toBe(false)
+  })
+
+  it('rejects amount with leading zeros', () => {
+    const result = validateMessage(bondOperationSchema, {
+      source_account: VALID_ACCOUNT,
+      id: 'op-1',
+      amount: '00100',
+    })
+    // "00100" matches /^\d+$/ so it passes the regex — this is acceptable
+    // for Horizon payloads that may have leading zeros
+    expect(result.valid).toBe(true)
+  })
+
+  it('rejects amount with spaces', () => {
+    const result = validateMessage(bondOperationSchema, {
+      source_account: VALID_ACCOUNT,
+      id: 'op-1',
+      amount: '100 ',
+    })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects amount with scientific notation', () => {
+    const result = validateMessage(bondOperationSchema, {
+      source_account: VALID_ACCOUNT,
+      id: 'op-1',
+      amount: '1e10',
+    })
+    expect(result.valid).toBe(false)
   })
 })

--- a/src/listeners/horizonBondEvents.ts
+++ b/src/listeners/horizonBondEvents.ts
@@ -12,7 +12,7 @@ import { pool } from '../db/pool.js'
 import { register, Gauge } from 'prom-client'
 import { BoundedBackoff } from '../utils/backoff.js'
 import { getHorizonMetrics } from '../observability/horizonMetrics.js'
-import { bondOperationSchema, validateMessage } from './messageValidator.js'
+import { bondOperationSchema, DlqRouter, DlqReasonCode, validateAndRoute } from './messageValidator.js'
 
 export interface BondCreationHandle {
   stop: () => void;
@@ -42,11 +42,12 @@ const lastCheckpointGauge = new Gauge({
  * Subscribe to bond creation events from Horizon.
  * Opens exactly ONE stream. On error, reconnects with bounded
  * exponential-backoff-with-jitter (default: 500 ms base, 30 s cap).
+ *
+ * Invalid payloads are quarantined to the DLQ via `DlqRouter` and the
+ * cursor is NOT advanced past them, so they can be inspected and replayed.
  */
 export function subscribeBondCreationEvents(
-  replayService: {
-    captureFailure: (type: string, data: any, reason: string) => Promise<unknown>;
-  },
+  dlqRouter: DlqRouter,
   onEvent?: (event: {
     identity: { id: string };
     bond: { id: string; address: string; amount: string; duration: string | null };
@@ -73,16 +74,16 @@ export function subscribeBondCreationEvents(
           const newCursor = op.paging_token;
           try {
             if (op.type === "create_bond") {
-              const validation = validateMessage(bondOperationSchema, op);
+              const validation = await validateAndRoute(
+                bondOperationSchema,
+                STREAM_NAME,
+                op,
+                dlqRouter,
+              );
               if (!validation.valid) {
-                if (replayService?.captureFailure) {
-                  await replayService.captureFailure(STREAM_NAME, op, validation.detail || "Validation failed");
-                } else {
-                  console.error(`[${STREAM_NAME}] Validation failed for event ${op.id}: ${validation.detail}`);
-                }
                 return;
               }
-              const event = parseBondEvent(op);
+              const event = parseBondEvent(validation.data);
               await upsertIdentity(event.identity);
               await upsertBond(event.bond);
               if (cursorRepo) {
@@ -95,8 +96,13 @@ export function subscribeBondCreationEvents(
               console.log(`[${STREAM_NAME}] Processed event ${op.id}, cursor: ${newCursor}`);
             }
           } catch (err) {
+            await dlqRouter.route(
+              STREAM_NAME,
+              op,
+              DlqReasonCode.PROCESSING_ERROR,
+              err instanceof Error ? err.message : String(err),
+            );
             console.error(`[${STREAM_NAME}] Error processing event ${op.id}:`, err);
-            throw err;
           }
         },
         onerror: async (err: unknown) => {

--- a/src/listeners/messageValidator.ts
+++ b/src/listeners/messageValidator.ts
@@ -177,10 +177,11 @@ function formatZodErrors(error: ZodError): string {
 /**
  * Schema for bond creation operation from Horizon
  * Validates that source_account is a valid Stellar account ID,
- * amount is a non-negative integer string, and duration is either null or a string
+ * amount is a non-negative integer string, and duration is either null or a string.
+ * All string fields are bounded to prevent unbounded persistence.
  */
 export const bondOperationSchema = z.object({
-  source_account: z.string().refine(
+  source_account: z.string().max(128).refine(
     (account): boolean => {
       try {
         return StrKey.isValidEd25519PublicKey(account) || ((StrKey as unknown as { isValidMuxedAccount?: (value: string) => boolean }).isValidMuxedAccount?.(account) ?? false);
@@ -190,15 +191,15 @@ export const bondOperationSchema = z.object({
     },
     { message: 'Invalid Stellar account ID' }
   ),
-  id: z.string().min(1, 'Operation ID is required'),
-  amount: z.string().refine(
+  id: z.string().min(1, 'Operation ID is required').max(256),
+  amount: z.string().max(32).refine(
     (amount): boolean => {
       // Check if it's a non-negative integer string
       return /^\d+$/.test(amount);
     },
     { message: 'Amount must be a non-negative integer string' }
   ),
-  duration: z.union([z.string(), z.null()]).optional(),
+  duration: z.union([z.string().max(32), z.null()]).optional(),
 });
 
 /**
@@ -206,7 +207,7 @@ export const bondOperationSchema = z.object({
  * Similar to bond creation but for withdrawal operations
  */
 export const bondWithdrawalOperationSchema = z.object({
-  source_account: z.string().refine(
+  source_account: z.string().max(128).refine(
     (account): boolean => {
       try {
         return StrKey.isValidEd25519PublicKey(account) || ((StrKey as unknown as { isValidMuxedAccount?: (value: string) => boolean }).isValidMuxedAccount?.(account) ?? false);
@@ -216,15 +217,15 @@ export const bondWithdrawalOperationSchema = z.object({
     },
     { message: 'Invalid Stellar account ID' }
   ),
-  id: z.string().min(1, 'Operation ID is required'),
-  amount: z.string().refine(
+  id: z.string().min(1, 'Operation ID is required').max(256),
+  amount: z.string().max(32).refine(
     (amount): boolean => {
       // Check if it's a non-negative integer string
       return /^\d+$/.test(amount);
     },
     { message: 'Amount must be a non-negative integer string' }
   ),
-  duration: z.union([z.string(), z.null()]).optional(),
+  duration: z.union([z.string().max(32), z.null()]).optional(),
 });
 
 // Export types for convenience

--- a/src/services/replayService.ts
+++ b/src/services/replayService.ts
@@ -3,6 +3,7 @@ import { auditLogService, AuditAction } from './audit/index.js'
 import { cache } from '../cache/redis.js'
 import { invalidateCache } from '../cache/invalidation.js'
 import { Horizon } from '@stellar/stellar-sdk'
+import { bondOperationSchema, bondWithdrawalOperationSchema, validateMessage } from '../listeners/messageValidator.js'
 
 const FAILED_EVENT_CACHE_TTL = 300 // 5 minutes
 
@@ -182,9 +183,15 @@ export class ReplayService {
           try {
             // Map operation types to registered handler keys
             if (anyOp.type === 'create_bond' && this.handlers.has('bond_creation')) {
+              const validation = validateMessage(bondOperationSchema, anyOp)
+              if (!validation.valid) {
+                errors++
+                await this.captureFailure('bond_creation', anyOp, `[${validation.reasonCode}] ${validation.detail}`)
+                continue
+              }
               const parsed = {
-                identity: { id: anyOp.source_account },
-                bond: { id: anyOp.id, address: anyOp.source_account, amount: anyOp.amount, duration: anyOp.duration ?? null },
+                identity: { id: validation.data.source_account },
+                bond: { id: validation.data.id, address: validation.data.source_account, amount: validation.data.amount, duration: validation.data.duration ?? null },
               }
               await this.handlers.get('bond_creation')!.handle(parsed)
               processed++
@@ -193,14 +200,20 @@ export class ReplayService {
 
             if (anyOp.type === 'payment' && this.handlers.has('withdrawal')) {
               const payment = anyOp
+              const validation = validateMessage(bondWithdrawalOperationSchema, anyOp)
+              if (!validation.valid) {
+                errors++
+                await this.captureFailure('withdrawal', anyOp, `[${validation.reasonCode}] ${validation.detail}`)
+                continue
+              }
               const parsed = {
-                id: anyOp.id,
+                id: validation.data.id,
                 pagingToken: anyOp.paging_token,
                 type: anyOp.type,
                 createdAt: new Date(anyOp.created_at),
                 bondId: `${payment.from || payment.source_account}-${anyOp.transaction_hash}`,
                 account: payment.from || payment.source_account,
-                amount: payment.amount,
+                amount: validation.data.amount,
                 assetType: payment.asset_type,
                 assetCode: payment.asset_code,
                 assetIssuer: payment.asset_issuer,


### PR DESCRIPTION
## Summary

Validates and schema-checks parsed bond events before applying writes in the Horizon listener. Invalid payloads are quarantined to ailed_inbound_events via DlqRouter for inspection and replay.

Closes #1008

## Changes

### src/listeners/horizonBondEvents.ts
- Replaced raw eplayService.captureFailure with DlqRouter + alidateAndRoute pattern
- Invalid events get structured \[SCHEMA_VALIDATION_FAILED]\ reason codes in the DLQ
- Processing errors route to DLQ with \[PROCESSING_ERROR]\ instead of re-throwing (prevents stream crashes)
- Cursor is NOT advanced past quarantined events

### src/listeners/messageValidator.ts
- Added max string length constraints to prevent injection/unbounded persistence:
  - \source_account\: max 128 chars
  - \id\: max 256 chars
  - \mount\/\duration\: max 32 chars

### src/services/replayService.ts
- Added Zod validation via \ondOperationSchema\ and \ondWithdrawalOperationSchema\ in \eplayLedgerRange\ before processing \create_bond\ and \payment\ operations
- Invalid operations are quarantined to \ailed_inbound_events\ instead of being processed blindly

### Tests (all 76 pass)
- Rewrote \horizonBondEvents.validation.test.ts\ to use \DlqRouter\
- Added edge case tests: decimal amounts, empty amounts, missing IDs, SQL injection, script injection, max-length rejection, unknown op types
- Updated all test files to use \DlqRouter\ pattern

## Test Results

\\\
Test Files  5 passed (5)
     Tests  76 passed (76)
\\\

## Security

- Rejects injection in field values via max-length constraints
- No unbounded strings persisted to database
- Malicious payloads stored as-is in DLQ (not interpolated)