### PR TITLE
fix(admin): deduplicate route handlers, add idempotency middleware, a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -592,7 +591,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -605,7 +603,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1846,7 +1843,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2132,7 +2128,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
       "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -2829,7 +2824,6 @@
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3013,7 +3007,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3494,7 +3487,6 @@
       "integrity": "sha512-lOt/VDh+sihAx3OUxCE5CC0qZfAhIzE3Dxw75NJ3P0C6ruUgT9b/jZKECE1ctpbxSVic9OkLdXz5UEX39ks4Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@istanbuljs/schema": "^0.1.3",
@@ -3520,7 +3512,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -3700,7 +3691,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4434,7 +4424,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5525,7 +5514,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6907,7 +6895,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8779,7 +8766,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -10742,7 +10728,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -10851,7 +10836,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11042,7 +11026,6 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11121,7 +11104,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",

--- a/src/routes/admin/admin.test.ts
+++ b/src/routes/admin/admin.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for admin routes covering:
+ * - Only-admin access control (401/403 for non-admin users)
+ * - Idempotent mutation endpoints (Idempotency-Key header)
+ * - Audit logging on every admin action
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import express, { type Express } from 'express'
+import { auditLogService, AuditAction } from '../../services/audit/index.js'
+
+// ── Hoisted mock pool (stable across tests) ────────────────────────
+
+vi.mock('../../db/pool.js', () => {
+  const idempotencyStore = new Map<string, any>()
+
+  return {
+    pool: {
+      query: vi.fn(async (sql: string, params: any[]) => {
+        if (sql.includes('SELECT') && sql.includes('idempotency_keys')) {
+          const key = params[0]
+          const row = idempotencyStore.get(key)
+          if (row && new Date(row.expires_at) > new Date()) {
+            return { rows: [row] }
+          }
+          return { rows: [] }
+        }
+
+        if (sql.includes('INSERT INTO idempotency_keys') || (sql.includes('ON CONFLICT') && sql.includes('idempotency_keys'))) {
+          const [key, requestHash, responseCode, responseBody, expiresAt] = params
+          idempotencyStore.set(key, {
+            key,
+            request_hash: requestHash,
+            response_code: responseCode,
+            response_body: responseBody,
+            expires_at: expiresAt,
+            created_at: new Date(),
+          })
+          return { rowCount: 1 }
+        }
+
+        return { rows: [], rowCount: 0 }
+      }),
+    },
+  }
+})
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+async function request(
+  app: Express,
+  method: 'GET' | 'POST',
+  path: string,
+  headers: Record<string, string> = {},
+  body?: unknown,
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        server.close()
+        reject(new Error('Could not get server address'))
+        return
+      }
+
+      const url = `http://127.0.0.1:${addr.port}${path}`
+      const opts: RequestInit = {
+        method,
+        headers: { 'Content-Type': 'application/json', ...headers },
+      }
+      if (body !== undefined) opts.body = JSON.stringify(body)
+
+      fetch(url, opts)
+        .then(async (res) => {
+          const json = await res.json()
+          server.close()
+          resolve({ status: res.status, body: json })
+        })
+        .catch((err) => {
+          server.close()
+          reject(err)
+        })
+    })
+  })
+}
+
+function errorHandler(err: any, _req: any, res: any, _next: any) {
+  res.status(500).json({ error: err.message || 'Internal error' })
+}
+
+// ── Admin auth helpers ─────────────────────────────────────────────
+
+const ADMIN_AUTH = { Authorization: 'Bearer admin-key-12345' }
+const VERIFIER_AUTH = { Authorization: 'Bearer verifier-key-67890' }
+const FAKE_AUTH = { Authorization: 'Bearer fake-key-99999' }
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe('Admin Routes — Only-Admin Access Control', () => {
+  let app: Express
+
+  beforeEach(async () => {
+    const { createAdminRouter } = await import('./index.js')
+    app = express()
+    app.use(express.json())
+    app.use('/api/admin', createAdminRouter())
+    app.use(errorHandler)
+  })
+
+  it('returns_401_when_no_auth_token', async () => {
+    const { status, body } = await request(app, 'POST', '/api/admin/roles/assign', {}, { userId: 'user-1', role: 'admin' })
+    expect(status).toBe(401)
+    expect((body as any).error).toBe('Unauthorized')
+  })
+
+  it('returns_401_for_invalid_token', async () => {
+    const { status } = await request(app, 'POST', '/api/admin/roles/assign', FAKE_AUTH, { userId: 'user-1', role: 'admin' })
+    expect(status).toBe(401)
+  })
+
+  it('returns_403_when_user_is_not_admin', async () => {
+    const { status, body } = await request(app, 'POST', '/api/admin/roles/assign', VERIFIER_AUTH, { userId: 'user-1', role: 'admin' })
+    expect(status).toBe(403)
+    expect((body as any).error).toBe('Forbidden')
+  })
+
+  it('returns_403_when_user_is_not_admin_on_get_endpoint', async () => {
+    const { status, body } = await request(app, 'GET', '/api/admin/users', VERIFIER_AUTH)
+    expect(status).toBe(403)
+    expect((body as any).error).toBe('Forbidden')
+  })
+})
+
+describe('Admin Routes — Idempotent Mutations', () => {
+  let app: Express
+
+  beforeEach(async () => {
+    const { createAdminRouter } = await import('./index.js')
+    app = express()
+    app.use(express.json())
+    app.use('/api/admin', createAdminRouter())
+    app.use(errorHandler)
+  })
+
+  it('processes_new_idempotency_key_for_role_assignment', async () => {
+    const headers = { ...ADMIN_AUTH, 'idempotency-key': 'ia-test-new-1' }
+    const payload = { userId: 'admin-user-1', role: 'admin' }
+
+    const res = await request(app, 'POST', '/api/admin/roles/assign', headers, payload)
+    expect(res.status).toBe(200)
+    expect((res.body as any).success).toBe(true)
+  })
+
+  it('replays_response_for_same_idempotency_key', async () => {
+    const key = 'ia-test-replay-1'
+    const headers = { ...ADMIN_AUTH, 'idempotency-key': key }
+    const payload = { userId: 'admin-user-1', role: 'admin' }
+
+    const res1 = await request(app, 'POST', '/api/admin/roles/assign', headers, payload)
+    expect(res1.status).toBe(200)
+
+    const res2 = await request(app, 'POST', '/api/admin/roles/assign', headers, payload)
+    expect(res2.status).toBe(200)
+    expect(res2.body).toEqual(res1.body)
+  })
+
+  it('rejects_different_payload_for_same_key', async () => {
+    const key = 'ia-test-conflict-1'
+    const headers = { ...ADMIN_AUTH, 'idempotency-key': key }
+
+    await request(app, 'POST', '/api/admin/roles/assign', headers, { userId: 'admin-user-1', role: 'admin' })
+
+    const { status, body } = await request(app, 'POST', '/api/admin/roles/assign', headers, { userId: 'admin-user-1', role: 'super-admin' })
+    expect(status).toBe(400)
+    expect((body as any).error).toBe('IdempotencyParameterMismatch')
+  })
+
+  it('allows_different_keys_for_same_payload', async () => {
+    const payload = { userId: 'admin-user-1', role: 'admin' }
+
+    const res1 = await request(app, 'POST', '/api/admin/roles/assign', { ...ADMIN_AUTH, 'idempotency-key': 'ia-test-key-a' }, payload)
+    const res2 = await request(app, 'POST', '/api/admin/roles/assign', { ...ADMIN_AUTH, 'idempotency-key': 'ia-test-key-b' }, payload)
+
+    expect(res1.status).toBe(200)
+    expect(res2.status).toBe(200)
+  })
+
+  it('does_not_interfere_when_no_idempotency_key', async () => {
+    const payload = { userId: 'admin-user-1', role: 'admin' }
+
+    const res = await request(app, 'POST', '/api/admin/roles/assign', ADMIN_AUTH, payload)
+    expect(res.status).toBe(200)
+    expect((res.body as any).success).toBe(true)
+  })
+
+  it('applies_idempotency_to_key_revocation', async () => {
+    const key = 'ia-test-key-revoke-1'
+    const headers = { ...ADMIN_AUTH, 'idempotency-key': key }
+    const payload = { userId: 'verifier-user-1', apiKey: 'verifier-key-67890' }
+
+    const res1 = await request(app, 'POST', '/api/admin/keys/revoke', headers, payload)
+    expect(res1.status).toBe(200)
+
+    const res2 = await request(app, 'POST', '/api/admin/keys/revoke', headers, payload)
+    expect(res2.status).toBe(200)
+    expect(res2.body).toEqual(res1.body)
+  })
+})
+
+describe('Admin Routes — Audit Logged Actions', () => {
+  let app: Express
+
+  beforeEach(async () => {
+    await auditLogService.clearLogs()
+    const { createAdminRouter } = await import('./index.js')
+    app = express()
+    app.use(express.json())
+    app.use('/api/admin', createAdminRouter())
+    app.use(errorHandler)
+  })
+
+  it('does_not_log_on_auth_failure', async () => {
+    await request(app, 'POST', '/api/admin/roles/assign', {}, { userId: 'admin-user-1', role: 'admin' })
+
+    const logs = await auditLogService.getAllLogs()
+    const roleLogs = logs.filter((l) => l.action === AuditAction.ASSIGN_ROLE)
+    expect(roleLogs.length).toBe(0)
+  })
+
+  it('does_not_log_on_authorization_failure', async () => {
+    await request(app, 'POST', '/api/admin/roles/assign', VERIFIER_AUTH, { userId: 'admin-user-1', role: 'admin' })
+
+    const logs = await auditLogService.getAllLogs()
+    const roleLogs = logs.filter((l) => l.action === AuditAction.ASSIGN_ROLE)
+    expect(roleLogs.length).toBe(0)
+  })
+
+  it('logs_role_assignment_on_success', async () => {
+    const payload = { userId: 'admin-user-1', role: 'admin' }
+    await request(app, 'POST', '/api/admin/roles/assign', ADMIN_AUTH, payload)
+
+    const logs = await auditLogService.getAllLogs()
+    const roleLogs = logs.filter((l) => l.action === AuditAction.ASSIGN_ROLE)
+    expect(roleLogs.length).toBeGreaterThanOrEqual(1)
+    const lastLog = roleLogs[roleLogs.length - 1]
+    expect(lastLog.actorId).toBe('admin-user-1')
+    expect(lastLog.actorEmail).toBe('admin@credence.org')
+    expect(lastLog.resourceId).toBe('admin-user-1')
+    expect(lastLog.status).toBe('success')
+    expect(lastLog.details).toHaveProperty('oldRole')
+    expect(lastLog.details).toHaveProperty('newRole', 'admin')
+  })
+
+  it('logs_invalid_role_attempt_as_failure', async () => {
+    const payload = { userId: 'admin-user-1', role: 'nonexistent-role' }
+    await request(app, 'POST', '/api/admin/roles/assign', ADMIN_AUTH, payload)
+
+    const logs = await auditLogService.getAllLogs()
+    const roleLogs = logs.filter((l) => l.action === AuditAction.ASSIGN_ROLE)
+    expect(roleLogs.length).toBeGreaterThanOrEqual(1)
+    const lastLog = roleLogs[roleLogs.length - 1]
+    expect(lastLog.status).toBe('failure')
+  })
+
+  it('logs_user_not_found_as_failure', async () => {
+    const payload = { userId: 'nonexistent-user', role: 'admin' }
+    await request(app, 'POST', '/api/admin/roles/assign', ADMIN_AUTH, payload)
+
+    const logs = await auditLogService.getAllLogs()
+    const roleLogs = logs.filter((l) => l.action === AuditAction.ASSIGN_ROLE)
+    expect(roleLogs.length).toBeGreaterThanOrEqual(1)
+    const lastLog = roleLogs[roleLogs.length - 1]
+    expect(lastLog.status).toBe('failure')
+  })
+
+  it('logs_multiple_actions_independently', async () => {
+    await request(app, 'POST', '/api/admin/roles/assign', ADMIN_AUTH, { userId: 'admin-user-1', role: 'admin' })
+    await request(app, 'POST', '/api/admin/keys/revoke', ADMIN_AUTH, { userId: 'verifier-user-1', apiKey: 'verifier-key-67890' })
+
+    const logs = await auditLogService.getAllLogs()
+    const assignLogs = logs.filter((l) => l.action === AuditAction.ASSIGN_ROLE)
+    const revokeLogs = logs.filter((l) => l.action === AuditAction.REVOKE_API_KEY)
+    expect(assignLogs.length).toBeGreaterThanOrEqual(1)
+    expect(revokeLogs.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('logs_key_revocation_on_success', async () => {
+    const payload = { userId: 'admin-user-1', apiKey: 'admin-key-12345' }
+    await request(app, 'POST', '/api/admin/keys/revoke', ADMIN_AUTH, payload)
+
+    const logs = await auditLogService.getAllLogs()
+    const revokeLogs = logs.filter((l) => l.action === AuditAction.REVOKE_API_KEY)
+    expect(revokeLogs.length).toBeGreaterThanOrEqual(1)
+    const lastLog = revokeLogs[revokeLogs.length - 1]
+    expect(lastLog.actorId).toBe('admin-user-1')
+    expect(lastLog.status).toBe('success')
+  })
+})

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -9,6 +9,8 @@ import {
   buildPaginationMeta,
   parsePaginationParams,
 } from "../../lib/pagination.js";
+import { idempotencyMiddleware } from "../../middleware/idempotency.js";
+import { IdempotencyRepository } from "../../db/repositories/idempotencyRepository.js";
 import { AdminService } from "../../services/admin/index.js";
 import { auditLogService } from "../../services/audit/index.js";
 import { impersonationService } from "../../services/impersonation/index.js";
@@ -32,6 +34,9 @@ import { pool } from "../../db/pool.js";
 export function createAdminRouter(): Router {
   const router = Router()
   const adminService = new AdminService(auditLogService)
+
+  // Idempotency Setup
+  const idempotencyRepo = new IdempotencyRepository(pool)
 
   // Replay Service Setup
   const replayRepo = new FailedInboundEventsRepository(pool)
@@ -60,32 +65,33 @@ export function createAdminRouter(): Router {
         if (!validRoles.includes(req.query.role as UserRole)) {
           throw new ValidationError(`Invalid role: ${req.query.role}`)
         }
-
-        // Get users
-        const result = await adminService.listUsers(
-          user.id,
-          user.email,
-          { page, limit, offset },
-          filters,
-        );
-
-        res.status(200).json({
-          success: true,
-          data: {
-            ...result,
-            ...buildPaginationMeta(result.total, page, limit),
-          },
-        });
-      } catch (error) {
-        next(error);
+        filters.role = req.query.role
       }
-    },
-  );
+
+      const result = await adminService.listUsers(
+        user.id,
+        user.email,
+        { page, limit, offset },
+        filters,
+      )
+
+      res.status(200).json({
+        success: true,
+        data: {
+          ...result,
+          ...buildPaginationMeta(result.total, page, limit),
+        },
+      })
+    } catch (error) {
+      next(error)
+    }
+  },
+  )
 
   /**
    * POST /api/admin/roles/assign
    */
-  router.post('/roles/assign', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next) => {
+  router.post('/roles/assign', requireUserAuth, requireAdminRole, idempotencyMiddleware(idempotencyRepo), async (req: Request, res: Response, next) => {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
@@ -98,27 +104,21 @@ export function createAdminRouter(): Router {
 
       const result = await adminService.assignRole(user.id, user.email, assignRequest)
 
-        const result = await adminService.assignRole(
-          user.id,
-          user.email,
-          assignRequest,
-        );
-
-        res.status(200).json({
-          success: true,
-          message: result.message,
-          data: result.user,
-        });
-      } catch (error) {
-        next(error);
-      }
-    },
-  );
+      res.status(200).json({
+        success: true,
+        message: result.message,
+        data: result.user,
+      })
+    } catch (error) {
+      next(error)
+    }
+  },
+  )
 
   /**
    * POST /api/admin/keys/revoke
    */
-  router.post('/keys/revoke', requireUserAuth, requireAdminRole, async (req: Request, res: Response, next) => {
+  router.post('/keys/revoke', requireUserAuth, requireAdminRole, idempotencyMiddleware(idempotencyRepo), async (req: Request, res: Response, next) => {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
@@ -131,28 +131,22 @@ export function createAdminRouter(): Router {
 
       const result = await adminService.revokeApiKey(user.id, user.email, revokeRequest)
 
-        const result = await adminService.revokeApiKey(
-          user.id,
-          user.email,
-          revokeRequest,
-        );
-
-        res.status(200).json({
-          success: true,
-          message: result.message,
-        });
-      } catch (error) {
-        next(error);
-      }
-    },
-  );
+      res.status(200).json({
+        success: true,
+        message: result.message,
+      })
+    } catch (error) {
+      next(error)
+    }
+  },
+  )
 
   /**
    * POST /api/admin/impersonate
    *
    * Issue a short-lived impersonation token for support/debug purposes.
    */
-  router.post('/impersonate', requireUserAuth, requireAdminRole, (req: Request, res: Response, next) => {
+  router.post('/impersonate', requireUserAuth, requireAdminRole, idempotencyMiddleware(idempotencyRepo), (req: Request, res: Response, next) => {
     try {
       const authReq = req as AuthenticatedRequest
       const user = authReq.user!
@@ -167,29 +161,30 @@ export function createAdminRouter(): Router {
         return
       }
 
-        const issued = impersonationService.issueToken(
-          user.id,
-          user.email,
-          {
-            targetUserId: body.targetUserId,
-            reason: body.reason,
-            ttlSeconds: body.ttlSeconds,
-          },
-          req.ip,
-        );
+      const issued = impersonationService.issueToken(
+        user.id,
+        user.email,
+        user.tenantId,
+        {
+          targetUserId: body.targetUserId,
+          reason: body.reason,
+          ttlSeconds: body.ttlSeconds,
+        },
+        req.ip,
+      )
 
-        res.status(201).json({ success: true, data: issued });
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Unknown error";
-        if (/User not found/i.test(message)) {
-          res.status(404).json({ error: "NotFound", message });
-          return;
-        }
-        res.status(400).json({ error: "BadRequest", message });
+      res.status(201).json({ success: true, data: issued })
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown error"
+      if (/User not found/i.test(message)) {
+        res.status(404).json({ error: "NotFound", message })
+        return
       }
-    },
-  );
+      res.status(400).json({ error: "BadRequest", message })
+    }
+  },
+  )
 
   /**
    * POST /api/admin/impersonate/:tokenId/revoke
@@ -215,21 +210,10 @@ export function createAdminRouter(): Router {
         res.status(404).json({ error: 'NotFound', message })
         return
       }
-
-      try {
-        impersonationService.revokeToken(user.id, user.email, tokenId, req.ip);
-        res.status(200).json({ success: true });
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Unknown error";
-        if (/Token not found/i.test(message)) {
-          res.status(404).json({ error: "NotFound", message });
-          return;
-        }
-        res.status(400).json({ error: "BadRequest", message });
-      }
-    },
-  );
+      res.status(400).json({ error: 'BadRequest', message })
+    }
+  },
+  )
 
   /**
    * GET /api/admin/audit-logs
@@ -253,7 +237,7 @@ export function createAdminRouter(): Router {
       if (req.query.from) filters.from = req.query.from
       if (req.query.to) filters.to = req.query.to
 
-      const result = await adminService.getAuditLogs(user.id, user.email, filters, limit, offset)
+      const result = await adminService.getAuditLogs(user.id, user.email, filters, limit, offset, user)
 
       res.status(200).json({
         success: true,
@@ -307,60 +291,28 @@ export function createAdminRouter(): Router {
           exportedAt: new Date().toISOString(),
           exportedBy: user.email,
           dateRange: { start: startDate.toISOString(), end: endDate.toISOString() },
-          schemaVersion: "1.0"
-        }
-
-        const stream = adminService.exportAuditLogs(
-          user.id,
-          user.email,
-          startDate,
-          endDate,
-          user,
-        );
-
-        // Set headers for NDJSON streaming
-        res.setHeader("Content-Type", "application/x-ndjson");
-        res.setHeader(
-          "Content-Disposition",
-          'attachment; filename="audit-logs.ndjson"',
-        );
-
-        const metadata = {
-          _meta: {
-            exportedAt: new Date().toISOString(),
-            exportedBy: user.email,
-            dateRange: {
-              start: startDate.toISOString(),
-              end: endDate.toISOString(),
-            },
-            schemaVersion: "1.0",
-          },
-        };
-        res.write(JSON.stringify(metadata) + "\n");
-
-        let count = 0;
-        for await (const log of stream) {
-          res.write(JSON.stringify(log) + "\n");
-          count++;
-        }
-
-        adminService.logExportCompletion(
-          user.id,
-          user.email,
-          startDate,
-          endDate,
-          count,
-        );
-        res.end();
-      } catch (error) {
-        if (!res.headersSent) {
-          next(error);
-        } else {
-          res.end();
-        }
+          schemaVersion: '1.0',
+        },
       }
-    },
-  );
+      res.write(JSON.stringify(metadata) + '\n')
+
+      let count = 0
+      for await (const log of stream) {
+        res.write(JSON.stringify(log) + '\n')
+        count++
+      }
+
+      adminService.logExportCompletion(user.id, user.email, startDate, endDate, count)
+      res.end()
+    } catch (error) {
+      if (!res.headersSent) {
+        next(error)
+      } else {
+        res.end()
+      }
+    }
+  },
+  )
 
   /**
    * GET /api/admin/events/failed


### PR DESCRIPTION
## Summary

Fixes duplicate code blocks in admin route handlers, adds idempotency middleware to mutation endpoints, and provides comprehensive test coverage.

## Changes

- **`src/routes/admin/index.ts`**: Removed duplicate code blocks in `/roles/assign`, `/keys/revoke`, `/impersonate`, `/impersonate/:tokenId/revoke`, `GET /users`, and `/audit-logs/export` handlers. Added `idempotencyMiddleware` to POST mutation endpoints.
- **`src/routes/admin/admin.test.ts`** (new): 17 tests covering access control (401/403), idempotency (replay/conflict), and audit logging (content/failure/absence on auth failures).

## Verification

- All 1266 tests pass (85 test files)
- Lint passes
- No new type errors

Closes #759 