### PR TITLE
fix(audit): enforce tenant scoping on audit log export

### DIFF
--- a/src/routes/auditLog.test.ts
+++ b/src/routes/auditLog.test.ts
@@ -44,7 +44,7 @@ function buildApp(service: Partial<AuditLogService>) {
   const app = express()
   // Attach a minimal req.user so requireMinRole passes
   app.use((req: any, _res, next) => {
-    req.user = { id: 'admin-1', address: 'GADMIN', role: 'admin' }
+    req.user = { id: 'admin-1', address: 'GADMIN', role: 'admin', tenantId: 'tenant-1' }
     next()
   })
   app.use('/api/audit', createAuditLogRouter(service as AuditLogService))
@@ -92,7 +92,7 @@ describe('GET /api/audit/export', () => {
     expect(res.text.trim()).toBe('')
   })
 
-  it('passes from/to query params to the service', async () => {
+  it('passes from/to query params and the caller tenant to the service', async () => {
     service.exportLogsStream.mockReturnValue(makeStream([]))
 
     await request(buildApp(service))
@@ -101,9 +101,44 @@ describe('GET /api/audit/export', () => {
     expect(service.exportLogsStream).toHaveBeenCalledWith(
       new Date('2024-01-01T00:00:00Z'),
       new Date('2024-03-30T23:59:59Z'),
-      undefined,
-      { allowSuperScope: true },
+      'tenant-1',
     )
+  })
+
+  it('returns 400 when caller has no tenant context', async () => {
+    service.exportLogsStream.mockReturnValue(makeStream([]))
+
+    const app = express()
+    app.use((req: any, _res, next) => {
+      req.user = { id: 'admin-1', address: 'GADMIN', role: 'admin' }
+      next()
+    })
+    app.use('/api/audit', createAuditLogRouter(service as AuditLogService))
+    app.use(errorHandler)
+
+    const res = await request(app).get('/api/audit/export')
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('MissingTenantContext')
+    expect(service.exportLogsStream).not.toHaveBeenCalled()
+  })
+
+  it('does not leak logs from other tenants when exporting', async () => {
+    service.exportLogsStream.mockReturnValue(
+      makeStream([makeEntry({ id: 'own-tenant-entry' })]),
+    )
+
+    const res = await request(buildApp(service)).get('/api/audit/export')
+
+    expect(res.status).toBe(200)
+    expect(service.exportLogsStream).toHaveBeenCalledWith(
+      expect.any(Date),
+      expect.any(Date),
+      'tenant-1',
+    )
+    // Confirm no super-scope / cross-tenant bypass option is ever passed.
+    const callArgs = service.exportLogsStream.mock.calls[0]
+    expect(callArgs).toHaveLength(3)
   })
 
   it('returns 400 for invalid date params', async () => {

--- a/src/routes/auditLog.ts
+++ b/src/routes/auditLog.ts
@@ -59,6 +59,18 @@ export function createAuditLogRouter(service: AuditLogService = auditLogService)
         return
       }
 
+      // SECURITY: Scope the export to the caller's own tenant. Never allow a
+      // blanket cross-tenant export — there is no "super admin" role in this
+      // RBAC system, so every admin must be confined to their own tenant.
+      const tenantId = (req as Request & { user?: { tenantId?: string } }).user?.tenantId
+      if (!tenantId) {
+        res.status(400).json({
+          error: 'MissingTenantContext',
+          message: 'Tenant context is required to export audit logs',
+        })
+        return
+      }
+
       // Validate export window is not too large
       const windowMs = to.getTime() - from.getTime()
       if (windowMs > maxWindowMs) {
@@ -76,7 +88,7 @@ export function createAuditLogRouter(service: AuditLogService = auditLogService)
 
       let stream: any
       try {
-        stream = service.exportLogsStream(from, to, undefined, { allowSuperScope: true })
+        stream = service.exportLogsStream(from, to, tenantId)
 
         // Set up gzip only after successfully starting the stream
         let outputStream: any = res


### PR DESCRIPTION
## Summary
- `GET /api/audit/export` unconditionally passed `{ allowSuperScope: true }` to `AuditLogService.exportLogsStream()`, so any authenticated admin — regardless of tenant — could export every tenant's audit logs.
- The route now derives `tenantId` from the caller (`req.user.tenantId`) and scopes the export to it. If no tenant context is present, the route returns `400 MissingTenantContext` instead of silently exporting cross-tenant.
- There's no super-admin role in this RBAC system (`admin` is already the top role), so there's no legitimate case for a blanket cross-tenant bypass here.

## Test plan
- [x] `npx vitest run src/routes/auditLog.test.ts` — updated existing test to assert tenant-scoped calls, added a 400-on-missing-tenant test and a no-leak regression test.
- [x] `npx vitest run` across `src/db/repositories`, `src/routes/admin`, `src/routes/auditLog.test.ts` — all passing.

Closes #946