### PR TITLE
test(jobs): cover idempotency sweeper TTL boundary

### DIFF
--- a/src/jobs/idempotencyKeySweeper.test.ts
+++ b/src/jobs/idempotencyKeySweeper.test.ts
@@ -205,6 +205,114 @@ describe('IdempotencyKeySweeper', () => {
     })
   })
 
+  describe('TTL boundary semantics', () => {
+    /**
+     * Rather than pre-programming canned responses, this fake extracts the
+     * actual comparison operator (`<=` vs `<`) from the SQL the sweeper sends
+     * and applies it against real Date values. That keeps the test coupled
+     * to the production query: if the sweeper's expiry comparison regresses
+     * (e.g. `<=` narrowed to `<`), these boundary cases fail instead of
+     * silently passing against a re-implemented copy of the logic.
+     */
+    function createStatefulMockQueryable(seed: Array<{ key: string; expiresAt: Date }>): {
+      db: Queryable
+      remainingKeys: () => string[]
+    } {
+      const storage = new Map(seed.map((row) => [row.key, row.expiresAt]))
+
+      const isExpired = (sql: string, expiresAt: Date, now: Date): boolean => {
+        const operator = sql.match(/expires_at\s*(<=|<)\s*NOW\(\)/)?.[1]
+        if (!operator) throw new Error(`Could not find expiry comparison in query: ${sql}`)
+        return operator === '<=' ? expiresAt <= now : expiresAt < now
+      }
+
+      const db = {
+        query: vi.fn(async (sql: string, params?: unknown[]) => {
+          const now = new Date()
+
+          if (sql.includes('COUNT(*)')) {
+            const count = [...storage.values()].filter((expiresAt) => isExpired(sql, expiresAt, now)).length
+            return { rows: [{ count: String(count) }] }
+          }
+
+          if (sql.includes('DELETE FROM idempotency_keys')) {
+            const limit = (params?.[0] as number | undefined) ?? Number.POSITIVE_INFINITY
+            const expiredKeys = [...storage.entries()]
+              .filter(([, expiresAt]) => isExpired(sql, expiresAt, now))
+              .map(([key]) => key)
+              .slice(0, limit)
+
+            for (const key of expiredKeys) storage.delete(key)
+
+            return { rows: [], rowCount: expiredKeys.length }
+          }
+
+          return { rows: [], rowCount: 0 }
+        }),
+      } as unknown as Queryable
+
+      return { db, remainingKeys: () => [...storage.keys()] }
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'))
+    })
+
+    it('treats a key exactly at its expiry boundary as expired', async () => {
+      const now = new Date()
+      const { db, remainingKeys } = createStatefulMockQueryable([{ key: 'at-boundary', expiresAt: now }])
+
+      const result = await new IdempotencyKeySweeper(db, { logger }).run()
+
+      expect(result.expiredCount).toBe(1)
+      expect(result.deletedCount).toBe(1)
+      expect(remainingKeys()).not.toContain('at-boundary')
+    })
+
+    it('does not treat a key one millisecond before expiry as expired (no false positive)', async () => {
+      const now = new Date()
+      const notYetExpired = new Date(now.getTime() + 1)
+      const { db, remainingKeys } = createStatefulMockQueryable([
+        { key: 'not-yet-expired', expiresAt: notYetExpired },
+      ])
+
+      const result = await new IdempotencyKeySweeper(db, { logger }).run()
+
+      expect(result.expiredCount).toBe(0)
+      expect(result.deletedCount).toBe(0)
+      expect(remainingKeys()).toContain('not-yet-expired')
+    })
+
+    it('treats a key one millisecond past expiry as expired', async () => {
+      const now = new Date()
+      const justExpired = new Date(now.getTime() - 1)
+      const { db, remainingKeys } = createStatefulMockQueryable([{ key: 'just-expired', expiresAt: justExpired }])
+
+      const result = await new IdempotencyKeySweeper(db, { logger }).run()
+
+      expect(result.expiredCount).toBe(1)
+      expect(result.deletedCount).toBe(1)
+      expect(remainingKeys()).not.toContain('just-expired')
+    })
+
+    it('sweeps only expired keys out of a mixed batch, leaving unexpired keys untouched', async () => {
+      const now = new Date()
+      const { db, remainingKeys } = createStatefulMockQueryable([
+        { key: 'expired-well-before', expiresAt: new Date(now.getTime() - 1000) },
+        { key: 'expired-at-boundary', expiresAt: now },
+        { key: 'valid-one-ms-away', expiresAt: new Date(now.getTime() + 1) },
+        { key: 'valid-well-after', expiresAt: new Date(now.getTime() + 1000) },
+      ])
+
+      const result = await new IdempotencyKeySweeper(db, { logger }).run()
+
+      expect(result.expiredCount).toBe(2)
+      expect(result.deletedCount).toBe(2)
+      expect(remainingKeys().sort()).toEqual(['valid-one-ms-away', 'valid-well-after'])
+    })
+  })
+
   describe('isRunning', () => {
     it('should return true during run', async () => {
       const mockQuery = vi.fn().mockImplementation(() => 


### PR DESCRIPTION
## Description
The idempotency-key sweeper (`src/jobs/idempotencyKeySweeper.ts`) deletes rows where `expires_at <= NOW()`, but the existing unit tests only asserted against pre-programmed mock responses (`mockResolvedValueOnce`). They never exercised the actual boundary condition, so a regression narrowing `<=` to `<` (or otherwise shifting the TTL boundary) would ship silently.

## Changes
- Added a `TTL boundary semantics` test suite to `src/jobs/idempotencyKeySweeper.test.ts` with a stateful fake `Queryable` that parses the real comparison operator out of the SQL text (instead of re-implementing the boundary logic independently in the test), then applies it to real `Date` values under a frozen system clock (`vi.setSystemTime`) for determinism.
- New cases:
  - A key with `expires_at` **exactly equal to now** → treated as expired (inclusive boundary).
  - A key with `expires_at` **one millisecond in the future** → not expired (no false positive).
  - A key with `expires_at` **one millisecond in the past** → expired.
  - A **mixed batch** of expired/valid keys → only expired ones are swept; valid ones are left untouched.

## Closes
Closes #727

## Evidence/Media (screenshots/videos)

**All tests passing on current code:**
```
✓ src/jobs/idempotencyKeySweeper.test.ts (16 tests) 176ms

 Test Files  1 passed (1)
      Tests  16 passed (16)
```

**Regression check** — temporarily narrowed the sweeper's query from `expires_at <= NOW()` to `expires_at < NOW()` to confirm the new tests actually catch it (then reverted):
```
 FAIL  src/jobs/idempotencyKeySweeper.test.ts > IdempotencyKeySweeper > TTL boundary semantics > treats a key exactly at its expiry boundary as expired
AssertionError: expected +0 to be 1

 FAIL  src/jobs/idempotencyKeySweeper.test.ts > IdempotencyKeySweeper > TTL boundary semantics > sweeps only expired keys out of a mixed batch, leaving unexpired keys untouched
AssertionError: expected 1 to be 2

 Test Files  1 failed (1)
      Tests  2 failed | 14 passed (16)
```
This confirms the two boundary-sensitive tests fail when the boundary regresses, and the other 14 pre-existing tests are unaffected.

## Notes
- `npx tsc --noEmit` currently fails due to pre-existing syntax errors in `src/routes/admin/index.ts`. Verified these errors are present on `main` prior to this branch (unrelated admin-route merge) and are out of scope for this issue.
- 12 test files under `src/jobs` fail identically on `main` and on this branch (timezone/DST-related flakiness and unrelated module issues, e.g. `invoiceDueDate.test.ts`, `pgStatActivitySnapshotJob.test.ts`) — not introduced by this change. Confirmed via `git stash` comparison against `main`.
- Only `src/jobs/idempotencyKeySweeper.test.ts` was modified; no production code changes.