### PR TITLE
docs: add service account inventory and ownership map

### DIFF
--- a/docs/SERVICE_ACCOUNTS.md
+++ b/docs/SERVICE_ACCOUNTS.md
@@ -16,6 +16,8 @@ Credence Backend uses two categories of service accounts to access its APIs and 
 
 This document lists every known service account, the permissions it holds, and the threat model for each.
 
+For backend-maintenance purposes, the canonical inventory now lives in [src/auth/serviceAccountInventory.ts](../src/auth/serviceAccountInventory.ts) and is covered by [src/auth/serviceAccountInventory.test.ts](../src/auth/serviceAccountInventory.test.ts). The inventory is intentionally limited to service accounts that access backend routes through API-key-based auth and documents the owning team, the purpose, the scopes, and the endpoint paths they may reach.
+
 ---
 
 ## 1. Kubernetes Service Accounts
@@ -81,7 +83,23 @@ API keys are the primary mechanism for service-to-service authentication. Each k
 | `settlement-reconciler` | `payouts:write`, `trust:read`, `bond:read` | Reconciles on-chain settlement state with DB records | **High impact** — can initiate payouts. Must be restricted to the dedicated settlement service account. |
 | `impersonation-service` | `admin:write` | Issues short-lived impersonation tokens for admin debug/support | **Critical impact** — can temporarily assume any user's identity. Must be restricted to admin role only (enforced at route level via `requireAdminRole`). |
 
-### 2.3 Impersonation Tokens
+### 2.3 Backend Service Account Inventory
+
+The backend inventory is maintained as code so that service-account ownership and endpoint reachability can be reviewed without reading every route file manually.
+
+| Service account | Owner | Purpose | Scopes | Endpoints |
+|---|---|---|---|---|
+| `horizon-listener` | `platform` | Ingests Horizon events and writes attestation/trust state | `trust:read`, `attestations:read` | `GET /api/transactions/history`, `GET /api/attestations/:address` |
+| `outbox-publisher` | `platform` | Reinjects quarantined outbox events | `outbox:reinject` | `POST /api/admin/outbox/quarantine/:id/reinject` |
+| `analytics-refresher` | `analytics` | Refreshes analytics and export datasets | `trust:read`, `attestations:read`, `exports:read` | `GET /api/transactions/history`, `GET /api/attestations/:address` |
+| `data-retention` | `security` | Runs retention workflows that inspect admin metadata | `admin:read` | `GET /api/admin/audit-logs` |
+| `key-rotation-worker` | `security` | Performs key rotation maintenance activities | `admin:read` | `GET /api/admin/audit-logs` |
+| `settlement-reconciler` | `settlement` | Reconciles payout and settlement state | `payouts:write`, `trust:read`, `bond:read` | `POST /api/payouts`, `GET /api/transactions/history` |
+| `impersonation-service` | `admin` | Issues temporary impersonation tokens | `admin:write` | `POST /api/admin/impersonate` |
+
+When a new service account is introduced, add it to the inventory module and update this table so the ownership map remains current.
+
+### 2.4 Impersonation Tokens
 
 | Field | Detail |
 |---|---|

--- a/src/auth/serviceAccountInventory.test.ts
+++ b/src/auth/serviceAccountInventory.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getServiceAccountInventory,
+  getServiceAccountInventoryById,
+  listServiceAccountOwners,
+  validateServiceAccountInventory,
+} from './serviceAccountInventory.js'
+
+describe('service account inventory', () => {
+  it('documents the core backend service accounts and their ownership', () => {
+    const inventory = getServiceAccountInventory()
+
+    expect(inventory.map((account) => account.id)).toEqual(
+      expect.arrayContaining([
+        'horizon-listener',
+        'outbox-publisher',
+        'settlement-reconciler',
+        'impersonation-service',
+      ]),
+    )
+
+    expect(listServiceAccountOwners(inventory)).toEqual(
+      expect.arrayContaining(['platform', 'settlement', 'admin', 'security']),
+    )
+  })
+
+  it('maps each service account to explicit backend endpoints and scopes', () => {
+    const inventory = getServiceAccountInventory()
+
+    for (const account of inventory) {
+      expect(account.endpoints.length).toBeGreaterThan(0)
+
+      for (const endpoint of account.endpoints) {
+        expect(endpoint.path).toMatch(/^\/api\//)
+        expect(endpoint.requiredScope).toBeTruthy()
+      }
+    }
+  })
+
+  it('validates the inventory and rejects accounts missing owners or endpoints', () => {
+    const result = validateServiceAccountInventory(getServiceAccountInventory())
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([])
+  })
+
+  it('returns a single service account by id', () => {
+    const account = getServiceAccountInventoryById('settlement-reconciler')
+
+    expect(account?.owner).toBe('settlement')
+    expect(account?.purpose).toContain('settlement')
+  })
+})

--- a/src/auth/serviceAccountInventory.ts
+++ b/src/auth/serviceAccountInventory.ts
@@ -1,0 +1,199 @@
+import { ApiScope } from '../middleware/auth.js'
+
+export interface ServiceAccountEndpoint {
+  path: string
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  requiredScope: ApiScope
+  description: string
+}
+
+export interface ServiceAccountInventoryEntry {
+  id: string
+  name: string
+  owner: 'platform' | 'settlement' | 'admin' | 'security' | 'analytics'
+  purpose: string
+  scopes: ApiScope[]
+  endpoints: ServiceAccountEndpoint[]
+  notes?: string
+}
+
+export interface ServiceAccountInventoryValidationResult {
+  valid: boolean
+  issues: string[]
+}
+
+const inventory: ServiceAccountInventoryEntry[] = [
+  {
+    id: 'horizon-listener',
+    name: 'Horizon listener',
+    owner: 'platform',
+    purpose: 'Consumes Stellar Horizon events and writes attestation and trust updates into the backend.',
+    scopes: [ApiScope.TRUST_READ, ApiScope.ATTESTATIONS_READ],
+    endpoints: [
+      {
+        path: '/api/transactions/history',
+        method: 'GET',
+        requiredScope: ApiScope.TRUST_READ,
+        description: 'Reads trust and settlement history for downstream processing.',
+      },
+      {
+        path: '/api/attestations/:address',
+        method: 'GET',
+        requiredScope: ApiScope.ATTESTATIONS_READ,
+        description: 'Reads attestations for a subject address.',
+      },
+    ],
+  },
+  {
+    id: 'outbox-publisher',
+    name: 'Outbox publisher',
+    owner: 'platform',
+    purpose: 'Re-injects quarantined outbox events to external subscribers with idempotency protections.',
+    scopes: [ApiScope.OUTBOX_REINJECT],
+    endpoints: [
+      {
+        path: '/api/admin/outbox/quarantine/:id/reinject',
+        method: 'POST',
+        requiredScope: ApiScope.OUTBOX_REINJECT,
+        description: 'Re-injects quarantined outbox events.',
+      },
+    ],
+  },
+  {
+    id: 'analytics-refresher',
+    name: 'Analytics refresher',
+    owner: 'analytics',
+    purpose: 'Refreshes analytics and export datasets for reporting jobs.',
+    scopes: [ApiScope.TRUST_READ, ApiScope.ATTESTATIONS_READ, ApiScope.EXPORTS_READ],
+    endpoints: [
+      {
+        path: '/api/transactions/history',
+        method: 'GET',
+        requiredScope: ApiScope.TRUST_READ,
+        description: 'Reads transaction history for reporting refreshes.',
+      },
+      {
+        path: '/api/attestations/:address',
+        method: 'GET',
+        requiredScope: ApiScope.ATTESTATIONS_READ,
+        description: 'Reads attestation history for analytics aggregation.',
+      },
+    ],
+  },
+  {
+    id: 'data-retention',
+    name: 'Data retention worker',
+    owner: 'security',
+    purpose: 'Runs retention tasks that inspect background metadata and audit data.',
+    scopes: [ApiScope.ADMIN_READ],
+    endpoints: [
+      {
+        path: '/api/admin/audit-logs',
+        method: 'GET',
+        requiredScope: ApiScope.ADMIN_READ,
+        description: 'Reads audit log metadata for retention decisions.',
+      },
+    ],
+  },
+  {
+    id: 'key-rotation-worker',
+    name: 'Key rotation worker',
+    owner: 'security',
+    purpose: 'Coordinates signing-key and API-key rotation maintenance.',
+    scopes: [ApiScope.ADMIN_READ],
+    endpoints: [
+      {
+        path: '/api/admin/audit-logs',
+        method: 'GET',
+        requiredScope: ApiScope.ADMIN_READ,
+        description: 'Reads admin metadata while rotating credentials.',
+      },
+    ],
+  },
+  {
+    id: 'settlement-reconciler',
+    name: 'Settlement reconciler',
+    owner: 'settlement',
+    purpose: 'Reconciles on-chain settlement state and posts payout updates.',
+    scopes: [ApiScope.PAYOUTS_WRITE, ApiScope.TRUST_READ, ApiScope.BOND_READ],
+    endpoints: [
+      {
+        path: '/api/payouts',
+        method: 'POST',
+        requiredScope: ApiScope.PAYOUTS_WRITE,
+        description: 'Creates or updates payout settlement state.',
+      },
+      {
+        path: '/api/transactions/history',
+        method: 'GET',
+        requiredScope: ApiScope.TRUST_READ,
+        description: 'Reads transaction history to reconcile settlement state.',
+      },
+    ],
+  },
+  {
+    id: 'impersonation-service',
+    name: 'Impersonation service',
+    owner: 'admin',
+    purpose: 'Issues temporary impersonation tokens for support and debugging use cases.',
+    scopes: [ApiScope.ADMIN_WRITE],
+    endpoints: [
+      {
+        path: '/api/admin/impersonate',
+        method: 'POST',
+        requiredScope: ApiScope.ADMIN_WRITE,
+        description: 'Issues impersonation tokens for administrative support workflows.',
+      },
+    ],
+  },
+]
+
+export function getServiceAccountInventory(): ServiceAccountInventoryEntry[] {
+  return inventory.map((entry) => ({ ...entry, scopes: [...entry.scopes], endpoints: entry.endpoints.map((endpoint) => ({ ...endpoint })) }))
+}
+
+export function getServiceAccountInventoryById(id: string): ServiceAccountInventoryEntry | undefined {
+  return getServiceAccountInventory().find((entry) => entry.id === id)
+}
+
+export function listServiceAccountOwners(accounts: ServiceAccountInventoryEntry[]): string[] {
+  return accounts.map((account) => account.owner).filter((owner, index, list) => list.indexOf(owner) === index)
+}
+
+export function validateServiceAccountInventory(accounts: ServiceAccountInventoryEntry[]): ServiceAccountInventoryValidationResult {
+  const issues: string[] = []
+
+  for (const account of accounts) {
+    if (!account.id || !account.name) {
+      issues.push('Each service account needs an id and name.')
+      continue
+    }
+
+    if (!account.owner) {
+      issues.push(`${account.id} is missing an owner.`)
+    }
+
+    if (!account.purpose?.trim()) {
+      issues.push(`${account.id} is missing a purpose.`)
+    }
+
+    if (!account.scopes?.length) {
+      issues.push(`${account.id} is missing declared scopes.`)
+    }
+
+    if (!account.endpoints?.length) {
+      issues.push(`${account.id} is missing endpoint access entries.`)
+    }
+
+    for (const endpoint of account.endpoints ?? []) {
+      if (!endpoint.path?.startsWith('/api/')) {
+        issues.push(`${account.id} has an endpoint with an invalid path: ${endpoint.path}`)
+      }
+      if (!endpoint.requiredScope) {
+        issues.push(`${account.id} has an endpoint without a required scope.`)
+      }
+    }
+  }
+
+  return { valid: issues.length === 0, issues }
+}


### PR DESCRIPTION
closes #1028 
Summary
Add a backend service-account inventory and ownership map to make access review and maintenance safer. This change introduces a documented registry of service accounts, their owners, purposes, granted scopes, and the backend endpoints they may access.

What changed
Added a codified service-account inventory in the auth layer
Documented the ownership and endpoint access map in the service-account security guide
Added regression tests to keep the inventory aligned with the existing API-key authorization model
