### PR TITLE
Document cache invalidation triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,8 @@ The service includes a Redis-based caching layer with:
 
 See [docs/caching.md](./docs/caching.md) for detailed documentation, and
 [docs/CACHE_INVENTORY.md](./docs/CACHE_INVENTORY.md) for the full list of
-cache namespaces and their TTLs.
+cache namespaces and their TTLs. For the mutation-to-invalidation map, see
+[docs/CACHE_INVALIDATION_TRIGGERS.md](./docs/CACHE_INVALIDATION_TRIGGERS.md).
 
 ## API Clients & SDKs
 

--- a/docs/CACHE_INVALIDATION_TRIGGERS.md
+++ b/docs/CACHE_INVALIDATION_TRIGGERS.md
@@ -1,0 +1,45 @@
+# Cache Invalidation Triggers
+
+This guide maps cache writes to the operations that must clear them. Use it when reviewing a change that updates bonds, attestations, settlements, reports, replay jobs, tenant-scoped data, profile data, trust scores, or bulk-verification jobs.
+
+For TTLs and cache ownership, read [CACHE_INVENTORY.md](CACHE_INVENTORY.md). For the invalidation API and bus behavior, read [CACHE_INVALIDATION.md](CACHE_INVALIDATION.md).
+
+## Trigger Matrix
+
+| Mutation trigger | Cache namespace and keys | Invalidation entrypoint | Source |
+| --- | --- | --- | --- |
+| Bond status update | `bond:id:{id}` and `bond:identity:{identityAddress}` | `invalidateCache()` for both keys after `BondsRepository.updateStatus()` returns the updated bond | `src/services/bondCacheService.ts` |
+| Bond debit | `bond:id:{id}` and `bond:identity:{identityAddress}` | `invalidateCache()` for both keys after `BondsRepository.debit()` returns the updated bond | `src/services/bondCacheService.ts` |
+| Attestation score update | `attestation:id:{id}`, `attestation:subject:{subjectAddress}`, and `attestation:bond:{bondId}` | `invalidateCache()` for all related lookup keys; the ID key uses stale-score verification | `src/services/attestationCacheService.ts` |
+| Attestation creation | Subject and bond attestation lists, plus the broader `attestation` namespace | `invalidateForAttestation()` clears subject, bond, and namespace-level entries after create | `src/services/attestationCacheService.ts` |
+| Settlement upsert | `settlement:{transactionHash}`, `settlement:id:{id}`, and `settlement:bondId:{bondId}` | `invalidateMultiple()` after the upsert result is known | `src/services/settlementService.ts` |
+| Batch settlement upsert | `settlement:{transactionHash}` for each batch item | `invalidateCache()` with status verification per returned settlement | `src/services/settlementService.ts` |
+| Report job status transition | `report:{jobId}` | `invalidateCache()` after the report repository status update and fresh job reload | `src/jobs/reportWorker.ts` |
+| Failed-event replay | `failed_event:{id}` | `invalidateCache()` with status verification after replay status changes | `src/services/replayService.ts` |
+| Tenant support purge | Every key in the tenant UUID namespace | `invalidateTenantCache()` after UUID validation and cache health check | `src/cli/invalidateTenantCache.ts`, `src/cache/invalidation.ts` |
+| Profile or member mutation | `member:org:{orgId}:members` and `member:id:{memberId}` | `profileInvalidationHook.execute(orgId, memberId)` | `src/cache/invalidationHooks.ts` |
+| Trust-score recalculation | `trust:{addressLowerCase}` | `trustScoreInvalidationHook.execute(...addresses)` | `src/cache/invalidationHooks.ts` |
+| Bulk-verification completion | `bulk:job:{jobId}` and `bulk:org:{orgId}:results` | `bulkVerificationInvalidationHook.execute(jobId, orgId)` | `src/cache/invalidationHooks.ts` |
+
+## Reviewer Checklist
+
+- Identify every read-through cache key that could have been populated before the mutation.
+- Invalidate all equivalent lookup shapes, not only the key used by the current request.
+- Prefer `createCacheKey()` for structured keys so docs, services, and tests use the same shape.
+- Use `verify: true` when a stale value can cause a user-visible status, score, or amount mismatch.
+- Keep invalidation after the database mutation has succeeded. If the mutation is transactional, use the post-commit path already built into `invalidateCache()`.
+- Publish through the shared invalidation utilities instead of deleting Redis keys directly, so other replicas receive the invalidation bus event.
+
+## Safe Failure Modes
+
+Invalidation should not leak cached values into logs. If a cache backend is unavailable, surface the operation-specific error and log key counts or namespaces only. The tenant purge CLI follows this rule by validating UUID input, checking cache health, and returning only `{ tenantId, keysCleared }`.
+
+## Adding A New Trigger
+
+When a new mutation writes data that has a cached read path:
+
+1. Add or update the cached read key in `docs/CACHE_INVENTORY.md`.
+2. Add the mutation-to-key mapping in this file.
+3. Invalidate every affected key through `invalidateCache()`, `invalidateMultiple()`, `invalidatePattern()`, or a named hook from `src/cache/invalidationHooks.ts`.
+4. Add a unit or static test that proves the mutation path references the expected invalidation entrypoint.
+5. Include the local command in the PR description, for example `npm test -- src/cache/invalidation.test.ts` or the narrower test file that covers the new trigger.

--- a/tests/docs/cacheInvalidationTriggers.test.ts
+++ b/tests/docs/cacheInvalidationTriggers.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const doc = readFileSync(resolve(root, 'docs/CACHE_INVALIDATION_TRIGGERS.md'), 'utf8')
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8')
+
+describe('cache invalidation trigger documentation', () => {
+  it('documents each public invalidation primitive and support CLI', () => {
+    for (const marker of [
+      'invalidateCache()',
+      'invalidateMultiple()',
+      'invalidateTenantCache()',
+      'profileInvalidationHook.execute',
+      'trustScoreInvalidationHook.execute',
+      'bulkVerificationInvalidationHook.execute',
+      'src/cli/invalidateTenantCache.ts',
+    ]) {
+      expect(doc).toContain(marker)
+    }
+  })
+
+  it('keeps the documented service triggers tied to real source files', () => {
+    const sources = {
+      bond: read('src/services/bondCacheService.ts'),
+      attestation: read('src/services/attestationCacheService.ts'),
+      settlement: read('src/services/settlementService.ts'),
+      report: read('src/jobs/reportWorker.ts'),
+      replay: read('src/services/replayService.ts'),
+      hooks: read('src/cache/invalidationHooks.ts'),
+    }
+
+    expect(sources.bond).toContain("invalidateCache('bond'")
+    expect(sources.attestation).toContain("invalidateCache('attestation'")
+    expect(sources.settlement).toContain("invalidateMultiple('settlement'")
+    expect(sources.report).toContain('invalidateCache("report"')
+    expect(sources.replay).toContain("invalidateCache('failed_event'")
+    expect(sources.hooks).toContain('profileInvalidationHook')
+    expect(sources.hooks).toContain('trustScoreInvalidationHook')
+    expect(sources.hooks).toContain('bulkVerificationInvalidationHook')
+  })
+})


### PR DESCRIPTION
## Summary
- add a cache invalidation trigger matrix for bond, attestation, settlement, report, replay, tenant purge, profile, trust-score, and bulk-verification mutations
- link the trigger map from the README caching section
- add a static docs test tying the guide to the real invalidation source files

Closes #1165

## Validation
- git diff --check`n- Static marker check for README/doc/test references
- Not run: 
pm test -- tests/docs/cacheInvalidationTriggers.test.ts because dependencies are not installed in this workspace and I did not install project packages.