### PR TITLE
docs: add integration API key lifecycle document (create, list, rotat…

### DIFF
--- a/docs/API_KEY_LIFECYCLE.md
+++ b/docs/API_KEY_LIFECYCLE.md
@@ -1,0 +1,373 @@
+# Integration API Key Lifecycle
+
+**Target audience:** Contributors and operators who need to understand the complete
+integration API key lifecycle — creation, listing, rotation, and revocation.
+
+The Credence Backend provides a programmatic API for managing integration API keys.
+Every mutating operation is recorded in the audit trail and every response is
+subject to ownership and authorization checks.
+
+---
+
+## 1. Key Format
+
+All keys follow the format:
+
+```
+cr_<64 lowercase hex characters>
+```
+
+Total length: **67 characters**. Example:
+
+```
+cr_a3f2b1c0d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1
+```
+
+The first 8 hex characters after the `cr_` prefix serve as a **lookup prefix**
+for fast database index scans without full-hash comparisons on every request.
+
+---
+
+## 2. Storage & Security
+
+- Raw keys are **never persisted**. Only the **SHA-256 hash** is stored in the
+  `api_keys` table (`hashed_key` column, `varchar(64)`, unique).
+- The raw key is returned **exactly once**: in the response body of a successful
+  `POST` (create) or `POST .../rotate` (rotate) call. After that the service
+  cannot recover it.
+- Validation uses constant-time hash comparison to mitigate timing attacks.
+- The `api_keys` table includes a composite index on `(owner_id, active)` for
+  efficient per-owner queries.
+
+See `src/migrations/006_add_api_keys_table.ts` for the full schema.
+
+---
+
+## 3. API Endpoints
+
+All endpoints are mounted at `/api/integrations/keys` and require **user
+authentication** via JWT (`requireUserAuth` middleware). API-key-based auth is
+not accepted for key management operations.
+
+| Method   | Path                                 | Description                          |
+|----------|--------------------------------------|--------------------------------------|
+| `POST`   | `/api/integrations/keys`             | Issue a new integration API key      |
+| `GET`    | `/api/integrations/keys`             | List keys for the authenticated user |
+| `POST`   | `/api/integrations/keys/:id/rotate`  | Rotate a key (safe invalidation)     |
+| `DELETE` | `/api/integrations/keys/:id`         | Permanently revoke a key             |
+
+### 3.1 Create — `POST /api/integrations/keys`
+
+Issue a new API key with an optional scope and tier.
+
+**Request:**
+
+```http
+POST /api/integrations/keys
+Content-Type: application/json
+Authorization: Bearer <jwt_token>
+
+{
+  "scope": "read",
+  "tier": "free"
+}
+```
+
+| Field   | Type   | Default  | Description                                                  |
+|---------|--------|----------|--------------------------------------------------------------|
+| `scope` | string | `"read"` | Access scope — `"read"` or `"full"`.                         |
+| `tier`  | string | `"free"` | Subscription tier controlling rate limits — `"free"`, `"pro"`, or `"enterprise"`. |
+
+**Success response (201):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "a1b2c3d4",
+    "key": "cr_a3f2b1c0d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1",
+    "prefix": "a3f2b1c0",
+    "scope": "read",
+    "scopes": ["read"],
+    "tier": "free",
+    "createdAt": "2026-07-29T12:00:00.000Z"
+  }
+}
+```
+
+> **Store the `key` value securely.** It is the last time the raw key will be visible.
+
+**Validation errors (400):**
+
+```json
+{ "error": "Invalid scope. Allowed values: read, full" }
+```
+```json
+{ "error": "Invalid tier. Allowed values: free, pro, enterprise" }
+```
+
+### 3.2 List — `GET /api/integrations/keys`
+
+Return all keys belonging to the authenticated user. The raw key and its hash
+are **never** included in the response.
+
+**Request:**
+
+```http
+GET /api/integrations/keys
+Authorization: Bearer <jwt_token>
+```
+
+**Success response (200):**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "a1b2c3d4",
+      "prefix": "a3f2b1c0",
+      "scope": "read",
+      "scopes": ["read"],
+      "tier": "free",
+      "ownerId": "user_abc",
+      "createdAt": "2026-07-29T12:00:00.000Z",
+      "lastUsedAt": null,
+      "active": true
+    },
+    {
+      "id": "e5f6a7b8",
+      "prefix": "c9d0e1f2",
+      "scope": "full",
+      "scopes": ["full"],
+      "tier": "pro",
+      "ownerId": "user_abc",
+      "createdAt": "2026-07-28T10:00:00.000Z",
+      "lastUsedAt": "2026-07-29T11:30:00.000Z",
+      "active": false
+    }
+  ]
+}
+```
+
+Keys are returned in **descending order** by `createdAt`. Both active and
+revoked keys are listed so operators can audit historical key assignments.
+
+### 3.3 Rotate — `POST /api/integrations/keys/:id/rotate`
+
+Atomically revoke the existing key and issue a replacement that inherits the
+same owner, scope, and tier. This is the canonical "safe invalidation" path.
+
+**Request:**
+
+```http
+POST /api/integrations/keys/a1b2c3d4/rotate
+Authorization: Bearer <jwt_token>
+```
+
+**Success response (200):**
+
+```json
+{
+  "success": true,
+  "message": "API key rotated. Store the new key securely — it will not be shown again.",
+  "data": {
+    "id": "f9e8d7c6",
+    "key": "cr_b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5",
+    "prefix": "b4c5d6e7",
+    "scope": "read",
+    "scopes": ["read"],
+    "tier": "free",
+    "createdAt": "2026-07-29T12:05:00.000Z"
+  }
+}
+```
+
+**Error responses:**
+
+| Status | Condition                  | Body                                                     |
+|--------|----------------------------|----------------------------------------------------------|
+| 404    | Key ID not found           | `{ "error": "API key", "message": "API key 'bad-id' not found" }` |
+| 409    | Key already revoked        | `{ "error": "Conflict", "message": "API key is already revoked and cannot be rotated" }` |
+| 403    | Non-owner, non-admin caller | `{ "error": "Forbidden", "message": "You do not have permission to rotate this API key" }` |
+
+**Ownership rules:**
+- A user can rotate their own keys.
+- Admin and super-admin users can rotate any key.
+- Non-admin, non-owner callers receive `403 Forbidden`.
+
+### 3.4 Revoke — `DELETE /api/integrations/keys/:id`
+
+Permanently deactivate an API key. Subsequent requests using the revoked key
+receive `401 Unauthorized`.
+
+**Request:**
+
+```http
+DELETE /api/integrations/keys/a1b2c3d4
+Authorization: Bearer <jwt_token>
+```
+
+**Success response (200):**
+
+```json
+{
+  "success": true,
+  "message": "API key revoked successfully"
+}
+```
+
+**Error responses:**
+
+| Status | Condition                  | Body                                                                |
+|--------|----------------------------|---------------------------------------------------------------------|
+| 404    | Key ID not found           | `{ "error": "API key", "message": "API key 'bad-id' not found" }`  |
+| 403    | Non-owner, non-admin caller | `{ "error": "Forbidden", "message": "You do not have permission to revoke this API key" }` |
+
+The same ownership rules as rotation apply.
+
+---
+
+## 4. Audit Trail
+
+Every lifecycle operation is written to the chain-backed audit log:
+
+| Operation | Audit action               | Status `"success"` includes      | Status `"failure"` includes            |
+|-----------|----------------------------|-----------------------------------|----------------------------------------|
+| Create    | `CREATE_API_KEY`           | key ID, prefix, scope, tier       | — (creation cannot fail at service layer) |
+| Rotate    | `ROTATE_API_KEY`           | revoked key ID, new key ID, new key prefix, scope, tier, owner ID | `reason`: `"key_not_found"` or `"key_already_revoked"` |
+| Revoke    | `REVOKE_API_KEY`           | key ID, owner ID, prefix          | — (failure logged with `"API key not found"`) |
+
+All entries include:
+
+| Field        | Description                                      |
+|--------------|--------------------------------------------------|
+| `tenantId`   | Resolved from the ambient request context (ALS). |
+| `actorId`    | The authenticated user's ID.                     |
+| `actorEmail` | The authenticated user's email.                  |
+| `resourceId` | The API key's opaque ID.                         |
+| `resourceType` | Always `"api_key"`.                            |
+| `ipAddress`  | The originating IP, when available.              |
+
+See `src/services/apiKeyRotationService.ts` for the implementation of every
+audit record.
+
+---
+
+## 5. Authorization Model
+
+| Operation | Authenticated as     | Authorization check                           |
+|-----------|----------------------|-----------------------------------------------|
+| Create    | Any authenticated user | No additional check (user creates for self) |
+| List      | Any authenticated user | Scoped to caller's `ownerId`                 |
+| Rotate    | Owner or admin       | Owner match or admin/super-admin role          |
+| Revoke    | Owner or admin       | Owner match or admin/super-admin role          |
+
+Authentication is enforced by the `requireUserAuth` middleware (JWT bearer
+token). API keys themselves cannot manage other API keys — this prevents a
+compromised integration key from escalating privileges.
+
+---
+
+## 6. Scopes & Tiers
+
+### Scopes
+
+| Scope   | Description                                                                 |
+|---------|-----------------------------------------------------------------------------|
+| `read`  | Read-only access to the integration's permitted resources.                  |
+| `full`  | Full read/write access within the integration's permitted resource scope.    |
+
+Scope validation is strict: any value other than `"read"` or `"full"` is
+rejected with a `400` error.
+
+### Tiers
+
+| Tier        | Rate limit (requests/min) | Intended use case            |
+|-------------|---------------------------|------------------------------|
+| `free`      | 100                       | Development / low-volume     |
+| `pro`       | 1 000                     | Production / moderate-volume |
+| `enterprise`| 10 000                    | High-volume / dedicated      |
+
+See `docs/RATE_LIMITING_DESIGN.md` for burst allowances and reset windows.
+
+---
+
+## 7. Implementation Architecture
+
+```
+┌──────────────┐     HTTP     ┌───────────────────┐
+│   Client     │ ──────────▶  │  createApiKeyRouter│
+│ (JWT-auth)   │ ◀──────────  │   (routes/apiKeys) │
+└──────────────┘              └────────┬──────────┘
+                                       │
+                          ┌────────────┴────────────┐
+                          │  ApiKeyRotationService   │
+                          │  (business logic + audit)│
+                          └────────┬────────────────┘
+                                   │
+                    ┌──────────────┴──────────────┐
+                    │        ApiKeyRepository      │
+                    │   (InMemoryApiKeyRepository  │
+                    │     or future DB adapter)    │
+                    └──────────────┬──────────────┘
+                                   │
+                          ┌───────┴───────┐
+                          │   apiKeys.ts  │
+                          │ (key gen,     │
+                          │  hash, store) │
+                          └───────────────┘
+```
+
+- **`src/routes/apiKeys.ts`** — Express router with four endpoints.
+- **`src/services/apiKeyRotationService.ts`** — Business logic with audit logging.
+- **`src/repositories/apiKeyRepository.ts`** — `ApiKeyRepository` interface and
+  `InMemoryApiKeyRepository` implementation.
+- **`src/services/apiKeys.ts`** — Low-level key generation, hashing, and
+  in-memory store functions.
+- **`src/middleware/auth.ts`** — `requireUserAuth` JWT middleware.
+- **`src/db/repositories/apiKeysRepository.ts`** — PostgreSQL-backed repository
+  (ready for DB wiring).
+
+---
+
+## 8. Security Properties
+
+1. **Hash-only storage:** Raw keys are SHA-256 hashed before storage. The raw
+   value exists only in the HTTP response and the caller's secure store.
+2. **Constant-time comparison:** Validation uses the full SHA-256 hash, not
+   string prefix matching, to prevent timing side channels.
+3. **No key-for-key management:** You cannot use an API key to manage other API
+   keys. Only JWT-authenticated sessions may create, list, rotate, or revoke
+   keys.
+4. **Audit trail:** Every mutation is logged with the actor, resource, and
+   outcome. Rotation failures (not found, already revoked) are also recorded so
+   suspicious probes are visible.
+5. **Ownership scoping:** By default a user can only act on their own keys.
+   Admins may act on any key — this is audited through the same mechanism.
+
+---
+
+## 9. Configuration
+
+No environment variables are required specifically for the API key lifecycle.
+The feature is self-contained and uses defaults throughout.
+
+| Variable (if wired)     | Default | Purpose                       |
+|-------------------------|---------|-------------------------------|
+| `DATABASE_URL`          | —       | When set, enables DB-backed key repository (future) |
+
+---
+
+## 10. Related Documents
+
+| Document | Covers |
+|---|---|
+| `docs/api-keys.md` | API key format, granular scopes, subscription tiers, error response reference |
+| `docs/SECRETS.md` | Secret types, rotation cadence, and blast radius for all credential types |
+| `docs/SECURITY.md` | Security architecture overview |
+| `docs/JWT_CLAIMS.md` | JWT claims, headers, and consumer middleware |
+| `docs/RATE_LIMITING_DESIGN.md` | Rate limit tiers, burst allowances, reset windows |
+| `src/routes/apiKeys.ts` | Route handler implementation |
+| `src/services/apiKeyRotationService.ts` | Audit-logged rotation service implementation |
+| `tests/routes/apiKeys.test.ts` | Route-level test suite (all four operations, auth guards, audit verification) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,3 +20,4 @@ This directory contains additional documentation for the Credence Backend.
 - **[Rate Limiting Design](RATE_LIMITING_DESIGN.md)** – tenant/IP/key rate-limiting windows and tiers.
 - **[Input Validation Guide](INPUT_VALIDATION.md)** – how we validate request inputs (path params, query, body) and surface errors.
 - **[Key Rotation Procedure](KEY_ROTATION_PROCEDURE.md)** – JWT signing key rotation cadence, grace window, and verification checks.
+- **[Integration API Key Lifecycle](API_KEY_LIFECYCLE.md)** – complete lifecycle for integration API keys: create, list, rotate, revoke, with audit trail and authorization model.

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -63,10 +63,14 @@ export function createApiKeyRouter(
   })
 
   // ── GET /api/integrations/keys ──────────────────────────────────────────
-  router.get('/', requireUserAuth, (req: Request, res: Response): void => {
-    const { user } = req as AuthenticatedRequest
-    const keys = rotationService.listKeys(user!.id)
-    res.status(200).json({ success: true, data: keys })
+  router.get('/', requireUserAuth, async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { user } = req as AuthenticatedRequest
+      const keys = await rotationService.listKeys(user!.id)
+      res.status(200).json({ success: true, data: keys })
+    } catch (err) {
+      next(err)
+    }
   })
 
   // ── POST /api/integrations/keys/:id/rotate ──────────────────────────────

--- a/tests/routes/apiKeys.test.ts
+++ b/tests/routes/apiKeys.test.ts
@@ -17,12 +17,12 @@ import { InMemoryApiKeyRepository } from '../../src/repositories/apiKeyRepositor
 import { ApiKeyRotationService } from '../../src/services/apiKeyRotationService.js'
 import { InMemoryAuditLogsRepository } from '../../src/db/repositories/auditLogsRepository.js'
 import { AuditLogService } from '../../src/services/audit/index.js'
-import { _resetStore } from '../../src/services/apiKeys.js'
+import { _resetStore, _setUseInMemory } from '../../src/services/apiKeys.js'
 import { userRepo } from '../../src/repositories/userRepository.js'
 
-function createUserAndToken(repo: InMemoryApiKeyRepository, id: string, role: 'super-admin' | 'verifier' | 'admin' | 'user') {
+async function createUserAndToken(repo: InMemoryApiKeyRepository, id: string, role: 'super-admin' | 'verifier' | 'admin' | 'user') {
   userRepo.upsert({ id, role, email: `${id}@example.test`, tenantId: `tenant-${id}` })
-  const created = repo.create(id)
+  const created = await repo.create(id)
   return `Bearer ${created.key}`
 }
 
@@ -92,6 +92,7 @@ function buildApp() {
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
+  _setUseInMemory(true)
   _resetStore()
   userRepo._reset()
 })
@@ -99,7 +100,7 @@ beforeEach(() => {
 describe('POST /api/integrations/keys', () => {
   it('issues a new key with default scope and tier', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
     })
@@ -115,7 +116,7 @@ describe('POST /api/integrations/keys', () => {
 
   it('respects explicit scope and tier in the request body', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
       body: { scope: 'full', tier: 'enterprise' },
@@ -129,7 +130,7 @@ describe('POST /api/integrations/keys', () => {
 
   it('rejects an invalid scope with 400', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
       body: { scope: 'superuser' },
@@ -140,7 +141,7 @@ describe('POST /api/integrations/keys', () => {
 
   it('rejects an invalid tier with 400', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
       body: { tier: 'platinum' },
@@ -151,7 +152,7 @@ describe('POST /api/integrations/keys', () => {
 
   it('returns 401 when no auth header is provided', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'POST', '/api/integrations/keys')
 
     expect(res.status).toBe(401)
@@ -159,7 +160,7 @@ describe('POST /api/integrations/keys', () => {
 
   it('records a CREATE_API_KEY audit entry', async () => {
     const { app, repo, auditSvc } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     await makeRequest(app, 'POST', '/api/integrations/keys', { auth: ADMIN_TOKEN })
 
     const { logs } = await auditSvc.getLogs(undefined, { action: 'CREATE_API_KEY' }, 100, 0, { allowSuperScope: true })
@@ -172,7 +173,7 @@ describe('POST /api/integrations/keys', () => {
 describe('GET /api/integrations/keys', () => {
   it('returns an empty array when the user has no keys', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'GET', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
     })
@@ -184,8 +185,8 @@ describe('GET /api/integrations/keys', () => {
 
   it('lists only keys belonging to the requesting user', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
-    const VERIFIER_TOKEN = createUserAndToken(repo, 'verifier-1', 'verifier')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
+    const VERIFIER_TOKEN = await createUserAndToken(repo, 'verifier-1', 'verifier')
 
     // Issue one key as admin and one as verifier
     await makeRequest(app, 'POST', '/api/integrations/keys', { auth: ADMIN_TOKEN })
@@ -200,7 +201,7 @@ describe('GET /api/integrations/keys', () => {
 
   it('returns 401 when unauthenticated', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'GET', '/api/integrations/keys')
     expect(res.status).toBe(401)
   })
@@ -209,7 +210,7 @@ describe('GET /api/integrations/keys', () => {
 describe('POST /api/integrations/keys/:id/rotate', () => {
   it('rotates a key successfully and returns a new raw key', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
 
     // Issue a key first
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
@@ -236,7 +237,7 @@ describe('POST /api/integrations/keys/:id/rotate', () => {
 
   it('preserves the original scope and tier after rotation', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
 
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
@@ -258,7 +259,7 @@ describe('POST /api/integrations/keys/:id/rotate', () => {
 
   it('returns 409 when the key has already been revoked', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
 
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
@@ -283,7 +284,7 @@ describe('POST /api/integrations/keys/:id/rotate', () => {
 
   it('returns 404 for an unknown key ID', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(
       app,
       'POST',
@@ -296,8 +297,8 @@ describe('POST /api/integrations/keys/:id/rotate', () => {
 
   it('returns 403 when a non-owner attempts to rotate another user\'s key', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
-    const VERIFIER_TOKEN = createUserAndToken(repo, 'verifier-1', 'verifier')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
+    const VERIFIER_TOKEN = await createUserAndToken(repo, 'verifier-1', 'verifier')
 
     // Admin creates a key
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
@@ -324,7 +325,7 @@ describe('POST /api/integrations/keys/:id/rotate', () => {
 
   it('writes a ROTATE_API_KEY success entry to the audit log', async () => {
     const { app, repo, auditSvc } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
 
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
@@ -344,7 +345,7 @@ describe('POST /api/integrations/keys/:id/rotate', () => {
 
   it('logs a failure audit entry when rotating a non-existent key', async () => {
     const { app, repo, auditSvc } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
 
     await makeRequest(app, 'POST', '/api/integrations/keys/ghost-id/rotate', {
       auth: ADMIN_TOKEN,
@@ -360,7 +361,7 @@ describe('POST /api/integrations/keys/:id/rotate', () => {
 describe('DELETE /api/integrations/keys/:id', () => {
   it('revokes an active key successfully', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
 
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
@@ -380,7 +381,7 @@ describe('DELETE /api/integrations/keys/:id', () => {
 
   it('returns 404 for an unknown key ID', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
     const res = await makeRequest(app, 'DELETE', '/api/integrations/keys/ghost-id', {
       auth: ADMIN_TOKEN,
     })
@@ -390,8 +391,8 @@ describe('DELETE /api/integrations/keys/:id', () => {
 
   it('returns 403 when a non-owner attempts to revoke another user\'s key', async () => {
     const { app, repo } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
-    const VERIFIER_TOKEN = createUserAndToken(repo, 'verifier-1', 'verifier')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
+    const VERIFIER_TOKEN = await createUserAndToken(repo, 'verifier-1', 'verifier')
 
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,
@@ -416,7 +417,7 @@ describe('DELETE /api/integrations/keys/:id', () => {
 
   it('writes a REVOKE_API_KEY audit entry on success', async () => {
     const { app, repo, auditSvc } = buildApp()
-    const ADMIN_TOKEN = createUserAndToken(repo, 'admin-1', 'super-admin')
+    const ADMIN_TOKEN = await createUserAndToken(repo, 'admin-1', 'super-admin')
 
     const createRes = await makeRequest(app, 'POST', '/api/integrations/keys', {
       auth: ADMIN_TOKEN,


### PR DESCRIPTION
…e, revoke)

Documents the complete lifecycle for integration API keys at /api/integrations/keys. Covers all four operations with concrete HTTP examples, the audit trail, authorization model, scope/tier reference, and implementation architecture.

Also fixes two test bugs:
  - Unawaited repo.create() in createUserAndToken helper causing undefined raw key in auth header
  - Missing await on async listKeys() in GET route handler causing Promise object in JSON response

Closes #852