### PR TITLE
feat(auth): add API key rotation endpoint with audit logging

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import { createImportsRouter } from "./routes/imports.js";
 import { createAdminRouter } from "./routes/admin/index.js";
 import { createWebhookAdminRouter } from "./routes/admin/webhooks.js";
 import { createFeatureFlagAdminRouter } from "./routes/admin/featureFlags.js";
+import { createApiKeyRouter } from "./routes/apiKeys.js";
 import { createPolicyRouter } from "./routes/policy.js";
 import { createAnalyticsRouter } from "./routes/analytics.js";
 import { createPayoutsRouter } from "./routes/payouts.js";
@@ -223,6 +224,7 @@ try {
 }
 
 app.use("/api/trust", trustRouter);
+app.use("/api/integrations/keys", createApiKeyRouter());
 
 // Bond status — uses the real BondService + BondStore backed by
 // deriveBondPaymentStatus, with read-through caching via CacheService.

--- a/src/routes/apiKeys.test.ts
+++ b/src/routes/apiKeys.test.ts
@@ -3,6 +3,9 @@ import request from 'supertest'
 import express from 'express'
 import apiKeysRouter from './apiKeys.js'
 import { generateApiKey, _setUseInMemory, _resetStore, ApiKeyScope } from '../services/apiKeys.js'
+import { createApiKeyRouter } from './apiKeys.js'
+import { auditLogService, AuditAction } from '../services/audit/index.js'
+import { userRepo } from '../repositories/userRepository.js'
 
 describe('API Keys Routes', () => {
   let app: express.Express
@@ -197,6 +200,84 @@ describe('API Keys Routes', () => {
       const response = await request(app).post('/api/api-keys/some-id/rotate')
 
       expect(response.status).toBe(401)
+    })
+  })
+})
+
+describe('Integration API Key Rotation Routes', () => {
+  let app: express.Express
+  let ownerKey: string
+  let ownerKeyId: string
+
+  beforeEach(async () => {
+    _resetStore()
+    _setUseInMemory(true)
+    userRepo._reset()
+    await auditLogService.clearLogs()
+
+    userRepo.upsert({
+      id: 'owner-user',
+      role: 'user',
+      email: 'owner@example.com',
+      tenantId: 'tenant-rotation',
+      active: true,
+    })
+
+    const result = await generateApiKey('owner-user', [ApiKeyScope.BOND_READ, ApiKeyScope.TRUST_READ], 'pro')
+    ownerKey = result.key
+    ownerKeyId = result.id
+
+    app = express()
+    app.use(express.json())
+    app.use('/api/integrations/keys', createApiKeyRouter())
+  })
+
+  afterEach(() => {
+    _resetStore()
+    userRepo._reset()
+  })
+
+  it('rotates a key, logs the audit event, and invalidates the old key', async () => {
+    const response = await request(app)
+      .post(`/api/integrations/keys/${ownerKeyId}/rotate`)
+      .set('Authorization', `Bearer ${ownerKey}`)
+
+    expect(response.status).toBe(200)
+    expect(response.body.success).toBe(true)
+    expect(response.body.data).toHaveProperty('key')
+    expect(response.body.data.key).not.toBe(ownerKey)
+    expect(response.body.data.scopes).toEqual([ApiKeyScope.BOND_READ, ApiKeyScope.TRUST_READ])
+
+    const logs = await auditLogService.getAllLogs()
+    const rotationLogs = logs.filter((entry) => entry.action === AuditAction.ROTATE_API_KEY)
+    expect(rotationLogs).toHaveLength(1)
+    expect(rotationLogs[0].status).toBe('success')
+    expect(rotationLogs[0].details).toMatchObject({
+      revokedKeyId: ownerKeyId,
+      ownerId: 'owner-user',
+      scope: ApiKeyScope.BOND_READ,
+    })
+
+    const oldKeyResponse = await request(app)
+      .get('/api/integrations/keys')
+      .set('Authorization', `Bearer ${ownerKey}`)
+
+    expect(oldKeyResponse.status).toBe(401)
+  })
+
+  it('records a failed rotation attempt for a missing key', async () => {
+    const response = await request(app)
+      .post('/api/integrations/keys/missing-key/rotate')
+      .set('Authorization', `Bearer ${ownerKey}`)
+
+    expect(response.status).toBe(404)
+
+    const logs = await auditLogService.getAllLogs()
+    const failureLogs = logs.filter((entry) => entry.action === AuditAction.ROTATE_API_KEY && entry.status === 'failure')
+    expect(failureLogs).toHaveLength(1)
+    expect(failureLogs[0].details).toMatchObject({
+      keyId: 'missing-key',
+      reason: 'key_not_found',
     })
   })
 })

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -4,10 +4,10 @@
  * Integration API key management endpoints.
  *
  * Routes (all require Bearer auth):
- *   POST   /api/integrations/keys            – Issue a new key
- *   GET    /api/integrations/keys            – List keys for the authenticated user
- *   POST   /api/integrations/keys/:id/rotate – Rotate a key (safe invalidation)
- *   DELETE /api/integrations/keys/:id        – Permanently revoke a key
+ *   POST   /api/integrations/keys            - Issue a new key
+ *   GET    /api/integrations/keys            - List keys for the authenticated user
+ *   POST   /api/integrations/keys/:id/rotate - Rotate a key (safe invalidation)
+ *   DELETE /api/integrations/keys/:id        - Permanently revoke a key
  */
 
 import { Router, type Request, type Response, type NextFunction } from 'express'
@@ -15,7 +15,15 @@ import { requireUserAuth, UserRole, type AuthenticatedRequest, requireApiKey } f
 import { InMemoryApiKeyRepository } from '../repositories/apiKeyRepository.js'
 import { ApiKeyRotationService } from '../services/apiKeyRotationService.js'
 import { auditLogService } from '../services/audit/index.js'
-import type { KeyScope, SubscriptionTier } from '../services/apiKeys.js'
+import {
+  generateApiKey,
+  listApiKeys,
+  revokeApiKey,
+  rotateApiKey,
+  ApiKeyScope,
+  type KeyScope,
+  type SubscriptionTier,
+} from '../services/apiKeys.js'
 import { ValidationError, NotFoundError, ForbiddenError, sendError, ErrorCode } from '../lib/errors.js'
 
 const VALID_SCOPES: KeyScope[] = ['read', 'full']
@@ -24,7 +32,7 @@ const VALID_TIERS: SubscriptionTier[] = ['free', 'pro', 'enterprise']
 /**
  * Create and return an Express Router for integration API key management.
  *
- * Accepts optional pre-built dependencies for testability — production callers
+ * Accepts optional pre-built dependencies for testability - production callers
  * can omit them and rely on the shared singletons.
  */
 export function createApiKeyRouter(
@@ -33,7 +41,7 @@ export function createApiKeyRouter(
 ): Router {
   const router = Router()
 
-  // ── POST /api/integrations/keys ─────────────────────────────────────────
+  // POST /api/integrations/keys
   router.post('/', requireUserAuth, async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const { user } = req as AuthenticatedRequest
@@ -62,7 +70,7 @@ export function createApiKeyRouter(
     }
   })
 
-  // ── GET /api/integrations/keys ──────────────────────────────────────────
+  // GET /api/integrations/keys
   router.get('/', requireUserAuth, async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const { user } = req as AuthenticatedRequest
@@ -73,33 +81,33 @@ export function createApiKeyRouter(
     }
   })
 
-  // ── POST /api/integrations/keys/:id/rotate ──────────────────────────────
+  // POST /api/integrations/keys/:id/rotate
   router.post('/:id/rotate', requireUserAuth, async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const { user } = req as AuthenticatedRequest
       const { id } = req.params
 
       const existing = repo.findById(id)
-      if (!existing) {
-        throw new NotFoundError('API key', id)
-      }
-
       const isAdmin = user!.role === UserRole.ADMIN || user!.role === UserRole.SUPER_ADMIN
-      if (!isAdmin && existing.ownerId !== user!.id) {
+
+      if (existing && !isAdmin && existing.ownerId !== user!.id) {
         throw new ForbiddenError('You do not have permission to rotate this API key')
       }
 
       const newKey = await rotationService.rotateKey(id, user!.id, user!.email, req.ip)
 
       if (!newKey) {
-        // Key existed but was already revoked — conflict.
+        if (!existing) {
+          throw new NotFoundError('API key', id)
+        }
+
         sendError(res, ErrorCode.CONFLICT, 'API key is already revoked and cannot be rotated')
         return
       }
 
       res.status(200).json({
         success: true,
-        message: 'API key rotated. Store the new key securely — it will not be shown again.',
+        message: 'API key rotated. Store the new key securely - it will not be shown again.',
         data: newKey,
       })
     } catch (err) {
@@ -107,7 +115,7 @@ export function createApiKeyRouter(
     }
   })
 
-  // ── DELETE /api/integrations/keys/:id ───────────────────────────────────
+  // DELETE /api/integrations/keys/:id
   router.delete('/:id', requireUserAuth, async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const { user } = req as AuthenticatedRequest
@@ -141,7 +149,6 @@ function createDefaultRouter(): Router {
   const router = Router()
   const auth = requireApiKey('bond:write' as any)
 
-  // POST /
   router.post('/', auth, async (req: Request, res: Response): Promise<void> => {
     const { ownerId, scopes, tier } = req.body
     if (!ownerId) {
@@ -163,13 +170,11 @@ function createDefaultRouter(): Router {
     res.status(201).json(key)
   })
 
-  // GET /:ownerId
   router.get('/:ownerId', auth, async (req: Request, res: Response): Promise<void> => {
     const keys = await listApiKeys(req.params.ownerId)
     res.status(200).json(keys)
   })
 
-  // DELETE /:id
   router.delete('/:id', auth, async (req: Request, res: Response): Promise<void> => {
     const revoked = await revokeApiKey(req.params.id)
     if (!revoked) {
@@ -179,7 +184,6 @@ function createDefaultRouter(): Router {
     }
   })
 
-  // POST /:id/rotate
   router.post('/:id/rotate', auth, async (req: Request, res: Response): Promise<void> => {
     const result = await rotateApiKey(req.params.id)
     if (!result) {

--- a/src/services/apiKeyRotationService.ts
+++ b/src/services/apiKeyRotationService.ts
@@ -124,6 +124,18 @@ export class ApiKeyRotationService {
     // Guard: rotate() checks the same conditions, but a concurrent revoke
     // between our findById and this call could yield null here.
     if (!newKey) {
+      await this.audit.logAction({
+        tenantId: this.resolveTenantId(),
+        actorId,
+        actorEmail,
+        action: AuditAction.ROTATE_API_KEY,
+        resourceType: 'api_key',
+        resourceId: keyId,
+        details: { keyId, reason: 'rotation_failed_after_validation' },
+        status: 'failure',
+        errorMessage: 'API key rotation failed',
+        ipAddress,
+      })
       return null
     }
 


### PR DESCRIPTION
## Summary
- mount the integration API key router on the documented backend path
- audit-log successful and failed key rotations
- ensure revoked keys stop authenticating immediately after rotation

## Testing
- `npm test -- src/routes/apiKeys.test.ts` could not be completed in this workspace because dependencies are not installed locally

Closes #970 
closes #970 