### PR TITLE
feat(audit): add NDJSON export endpoint with RBAC

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -60,6 +60,7 @@ import { sunsetHeaderMiddleware } from "./middleware/sunsetHeader.js";
 import { createOutboxAdminRouter } from "./routes/admin/outbox.js";
 import { structuredLoggingMiddleware } from "./middleware/structuredLogging.js";
 import { createWebhookReplayRouter } from "./routes/webhookReplay.js";
+import { createExportRouter } from "./routes/export/index.js";
 
 const app = express();
 


### PR DESCRIPTION
## Summary

Wire up the audit log export router (`createExportRouter`) in `app.ts`. The export endpoint was fully implemented in `src/routes/export/index.ts` with streaming NDJSON, RBAC via `requireApiKey(EXPORTS_READ)`, rate limiting, and row-limit enforcement but was never imported and mounted.

## Changes

- **src/app.ts**: Added missing import for `createExportRouter` from `./routes/export/index.js`

## Verification

- TypeScript compilation: `createExportRouter` error resolved (confirmed via `tsc --noEmit`)
- Existing tests in `tests/routes/export.test.ts` and `src/services/exportService.test.ts` cover the endpoint

Closes #958
