### PR TITLE
feat: authenticate API keys against hashed database store, remove mocks

### DIFF
--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -181,6 +181,7 @@ Response: **204 No Content**. Subsequent requests using the revoked key receive 
 
 ## Security Notes
 
+- All key validation is performed exclusively against the persistent, hashed database store via `validateApiKey()` in `src/services/apiKeys.ts`. There are **no hardcoded keys, mock users, or plaintext key comparisons** anywhere in the authentication code path.
 - Keys are stored as **SHA-256 hashes** — the raw key is never persisted and is shown exactly once.
 - Issue keys with the **minimum scopes required** for the integration. Do not use `enterprise` unless all operations are needed.
 - Rotate keys periodically; compromised keys can be revoked at any time.

--- a/docs/security.md
+++ b/docs/security.md
@@ -110,3 +110,48 @@ tier ceiling on a per-tenant basis without affecting other tenants.
 
 > **Warning:** Do not set `RATE_LIMIT_FAIL_OPEN=true` in production.  The
 > application will refuse to start with this configuration.
+
+## API Key Authentication
+
+All API key validation is performed against the **persistent, hashed database
+store** (`src/services/apiKeys.ts`). No hardcoded keys, mock users, or
+plaintext key comparisons exist in the runtime code path.
+
+### Key storage
+
+- Keys are stored as **SHA-256 hashes** only. The raw key is never persisted.
+- Lookup uses a **prefix + hash** index for fast retrieval without scanning.
+- The `validateApiKey` function performs a timing-safe hash comparison — the
+  raw input key is hashed before any comparison against stored data, so the
+  runtime code path never compares raw key strings.
+
+### Key lifecycle
+
+- **Issue:** `POST /api/api-keys` — generates a `cr_`-prefixed key, stores
+  its SHA-256 hash, and returns the raw key exactly once.
+- **Rotate:** `POST /api/api-keys/:id/rotate` — atomically revokes the old
+  key and creates a new one with identical scopes and tier.
+- **Revoke:** `DELETE /api/api-keys/:id` — marks the key inactive; subsequent
+  validation returns `401 Unauthorized`.
+
+### Middleware
+
+Two middleware paths are available:
+
+| Middleware | File | Purpose |
+|---|---|---|
+| `requireApiKey(scope)` | `src/middleware/auth.ts` | Enforces a specific `ApiScope`. Uses the legacy `ApiScope` enum and `scopeSatisfies()` for backward-compatible authorization. |
+| `requireApiKey()` + `requireScope(scope)` | `src/middleware/apiKey.ts` | Canonical two-step middleware for DB-backed key validation with scope enforcement. |
+
+Both paths share `validateApiKey()` from `src/services/apiKeys.ts` as the
+single authoritative key validator.
+
+### Security guarantees
+
+- **Deny-by-default:** Unknown, revoked, or inactive keys receive `401`.
+- **No raw key logging:** Raw key values are never logged or included in
+  error responses.
+- **Constant-time hash comparison:** The hash is computed before any lookup,
+  preventing timing side-channels on key prefix or value.
+- **No in-code secrets:** All hardcoded keys (`API_KEYS`, `MOCK_USERS`,
+  `API_KEY_TO_USER`) were removed in favour of the database-backed store.

--- a/src/__tests__/auth.scopes.test.ts
+++ b/src/__tests__/auth.scopes.test.ts
@@ -2,6 +2,7 @@
  * @file src/__tests__/auth.scopes.test.ts
  *
  * Comprehensive tests for the granular API scope model.
+ * All keys are generated via `generateApiKey()` — no hardcoded keys.
  *
  * Coverage targets
  * ────────────────
@@ -11,6 +12,7 @@
  * • requireApiKey() middleware — per-scope enforcement
  *   - missing key → 401
  *   - invalid key → 401
+ *   - revoked key → 401
  *   - key with insufficient scope → 403 (deny-by-default)
  *   - key with exact scope → 200 / next()
  *   - key with superset scopes → 200 / next()
@@ -19,7 +21,6 @@
  *   - req.apiKey metadata shape (scopes array + legacy scope field)
  *   - Authorization: Bearer header accepted alongside X-API-Key
  *   - unknown scope string → deny
- *   - backward compat: existing test-enterprise-key-12345 still works
  */
 
 import { Request, Response, NextFunction } from 'express'
@@ -31,6 +32,8 @@ import {
   scopeSatisfies,
   AuthenticatedRequest,
 } from '../middleware/auth.js'
+import { generateApiKey, _resetStore, revokeApiKey } from '../services/apiKeys.js'
+import { userRepo } from '../repositories/userRepository.js'
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -48,6 +51,25 @@ function makeRes(): { res: Partial<Response>; status: ReturnType<typeof vi.fn>; 
 function makeNext(): NextFunction {
   return vi.fn() as unknown as NextFunction
 }
+
+/** Helper to create a key with legacy scope string and return the raw key. */
+function legacyKey(scope: 'read' | 'full'): string {
+  return generateApiKey('u-admin', scope).key
+}
+
+/** Helper to create a key with granular scopes and return the raw key. */
+function granularKey(scopes: string[]): string {
+  return generateApiKey('u-admin', scopes).key
+}
+
+// ─── seed on every test ─────────────────────────────────────────────────────
+
+beforeEach(() => {
+  _resetStore()
+  userRepo._reset()
+  userRepo.upsert({ id: 'u-admin', role: 'super-admin', email: 'a@x.com', tenantId: 't-admin' })
+  userRepo.upsert({ id: 'u-verifier', role: 'verifier', email: 'v@x.com', tenantId: 't-ver' })
+})
 
 // ─── ApiScope enum ───────────────────────────────────────────────────────────
 
@@ -226,20 +248,20 @@ describe('requireApiKey() middleware', () => {
   // ── missing key ────────────────────────────────────────────────────────────
 
   describe('missing API key', () => {
-    it('returns 401 when no key header is present', () => {
+    it('returns 401 when no key header is present', async () => {
       const req = makeReq()
       const { res, status, json } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(401)
       expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Unauthorized' }))
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 401 when X-API-Key is empty string', () => {
+    it('returns 401 when X-API-Key is empty string', async () => {
       const req = makeReq({ 'x-api-key': '' })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(401)
       expect(next).not.toHaveBeenCalled()
@@ -249,20 +271,42 @@ describe('requireApiKey() middleware', () => {
   // ── invalid key ────────────────────────────────────────────────────────────
 
   describe('invalid API key', () => {
-    it('returns 401 for an unrecognised key', () => {
+    it('returns 401 for an unrecognised key', async () => {
       const req = makeReq({ 'x-api-key': 'not-a-real-key' })
       const { res, status, json } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(401)
       expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'Unauthorized', message: 'Invalid API key' }))
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 401 for a random string', () => {
+    it('returns 401 for a random string', async () => {
       const req = makeReq({ 'x-api-key': 'random-garbage-xyz' })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 for revoked keys', async () => {
+      const key = generateApiKey('u-admin', 'full')
+      revokeApiKey(key.id)
+
+      const req = makeReq({ 'x-api-key': key.key })
+      const { res, status } = makeRes()
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+
+      expect(status).toHaveBeenCalledWith(401)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('returns 401 for unknown but well-formed keys', async () => {
+      const randomKey = 'cr_' + 'f'.repeat(64)
+      const req = makeReq({ 'x-api-key': randomKey })
+      const { res, status } = makeRes()
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(401)
       expect(next).not.toHaveBeenCalled()
@@ -272,10 +316,11 @@ describe('requireApiKey() middleware', () => {
   // ── insufficient scope (deny-by-default) ──────────────────────────────────
 
   describe('insufficient scope — deny-by-default', () => {
-    it('returns 403 when trust:read key is used on attestations:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+    it('returns 403 when trust:read key is used on attestations:write endpoint', async () => {
+      const key = granularKey(['trust:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status, json } = makeRes()
-      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(json).toHaveBeenCalledWith(expect.objectContaining({
@@ -285,82 +330,91 @@ describe('requireApiKey() middleware', () => {
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when attestations:write key is used on payouts:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+    it('returns 403 when attestations:write key is used on payouts:write endpoint', async () => {
+      const key = granularKey(['attestations:read', 'attestations:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when reports key is used on webhooks:admin endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-reports-key' })
+    it('returns 403 when reports key is used on webhooks:admin endpoint', async () => {
+      const key = granularKey(['reports:generate', 'exports:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.WEBHOOKS_ADMIN)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.WEBHOOKS_ADMIN)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when admin:read key is used on admin:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-admin-read-key' })
+    it('returns 403 when admin:read key is used on admin:write endpoint', async () => {
+      const key = granularKey(['admin:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ADMIN_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ADMIN_WRITE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when PUBLIC key is used on payouts:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+    it('returns 403 when PUBLIC key is used on payouts:write endpoint', async () => {
+      const key = legacyKey('read')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when PUBLIC key is used on reports:generate endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+    it('returns 403 when PUBLIC key is used on reports:generate endpoint', async () => {
+      const key = legacyKey('read')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.REPORTS_GENERATE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.REPORTS_GENERATE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when bond:read key is used on bond:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-bond-read-key' })
+    it('returns 403 when bond:read key is used on bond:write endpoint', async () => {
+      const key = granularKey(['bond:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.BOND_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.BOND_WRITE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when bond:read key is used on payouts:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-bond-read-key' })
+    it('returns 403 when bond:read key is used on payouts:write endpoint', async () => {
+      const key = granularKey(['bond:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('returns 403 when flags:read key is used on flags:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-flags-read-key' })
+    it('returns 403 when flags:read key is used on flags:write endpoint', async () => {
+      const key = granularKey(['flags:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.FLAGS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.FLAGS_WRITE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()
     })
 
-    it('response body includes grantedScopes for debugging', () => {
-      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+    it('response body includes grantedScopes for debugging', async () => {
+      const key = granularKey(['trust:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, json } = makeRes()
-      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
 
       expect(json).toHaveBeenCalledWith(expect.objectContaining({
         grantedScopes: expect.arrayContaining([ApiScope.TRUST_READ]),
@@ -371,127 +425,141 @@ describe('requireApiKey() middleware', () => {
   // ── exact scope match ──────────────────────────────────────────────────────
 
   describe('exact scope match — allow', () => {
-    it('trust:read key passes trust:read endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+    it('trust:read key passes trust:read endpoint', async () => {
+      const key = granularKey(['trust:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('attestations:write key passes attestations:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+    it('attestations:write key passes attestations:write endpoint', async () => {
+      const key = granularKey(['attestations:read', 'attestations:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('attestations:write key also passes attestations:read endpoint (superset)', () => {
-      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+    it('attestations:write key also passes attestations:read endpoint (superset)', async () => {
+      const key = granularKey(['attestations:read', 'attestations:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ATTESTATIONS_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ATTESTATIONS_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('payouts:write key passes payouts:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-payouts-write-key' })
+    it('payouts:write key passes payouts:write endpoint', async () => {
+      const key = granularKey(['payouts:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.PAYOUTS_WRITE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('reports key passes reports:generate endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-reports-key' })
+    it('reports key passes reports:generate endpoint', async () => {
+      const key = granularKey(['reports:generate', 'exports:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.REPORTS_GENERATE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.REPORTS_GENERATE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('reports key passes exports:read endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-reports-key' })
+    it('reports key passes exports:read endpoint', async () => {
+      const key = granularKey(['reports:generate', 'exports:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.EXPORTS_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.EXPORTS_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('webhooks:admin key passes webhooks:admin endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-webhooks-admin-key' })
+    it('webhooks:admin key passes webhooks:admin endpoint', async () => {
+      const key = granularKey(['webhooks:admin'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.WEBHOOKS_ADMIN)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.WEBHOOKS_ADMIN)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('admin:write key passes admin:read endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-admin-write-key' })
+    it('admin:write key passes admin:read endpoint', async () => {
+      const key = granularKey(['admin:read', 'admin:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ADMIN_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ADMIN_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('admin:write key passes admin:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-admin-write-key' })
+    it('admin:write key passes admin:write endpoint', async () => {
+      const key = granularKey(['admin:read', 'admin:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ADMIN_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ADMIN_WRITE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('flags:read key passes flags:read endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-flags-read-key' })
+    it('flags:read key passes flags:read endpoint', async () => {
+      const key = granularKey(['flags:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.FLAGS_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.FLAGS_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('flags:write key passes flags:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-flags-write-key' })
+    it('flags:write key passes flags:write endpoint', async () => {
+      const key = granularKey(['flags:read', 'flags:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.FLAGS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.FLAGS_WRITE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('bond:read key passes bond:read endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-bond-read-key' })
+    it('bond:read key passes bond:read endpoint', async () => {
+      const key = granularKey(['bond:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.BOND_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.BOND_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('bond:write key passes bond:read endpoint (superset)', () => {
-      const req = makeReq({ 'x-api-key': 'test-bond-write-key' })
+    it('bond:write key passes bond:read endpoint (superset)', async () => {
+      const key = granularKey(['bond:read', 'bond:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.BOND_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.BOND_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('bond:write key passes bond:write endpoint', () => {
-      const req = makeReq({ 'x-api-key': 'test-bond-write-key' })
+    it('bond:write key passes bond:write endpoint', async () => {
+      const key = granularKey(['bond:read', 'bond:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.BOND_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.BOND_WRITE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
@@ -501,8 +569,6 @@ describe('requireApiKey() middleware', () => {
   // ── ENTERPRISE superset ────────────────────────────────────────────────────
 
   describe('ENTERPRISE key — superset of all scopes', () => {
-    const enterpriseKey = 'test-enterprise-key-12345'
-
     const allGranularScopes: ApiScope[] = [
       ApiScope.TRUST_READ,
       ApiScope.ATTESTATIONS_READ,
@@ -521,20 +587,22 @@ describe('requireApiKey() middleware', () => {
     ]
 
     for (const scope of allGranularScopes) {
-      it(`ENTERPRISE key satisfies ${scope}`, () => {
-        const req = makeReq({ 'x-api-key': enterpriseKey })
+      it(`ENTERPRISE key satisfies ${scope}`, async () => {
+        const key = legacyKey('full')
+        const req = makeReq({ 'x-api-key': key })
         const { res, status } = makeRes()
-        requireApiKey(scope)(req as Request, res as Response, next)
+        await requireApiKey(scope)(req as Request, res as Response, next)
 
         expect(next).toHaveBeenCalled()
         expect(status).not.toHaveBeenCalled()
       })
     }
 
-    it('ENTERPRISE key satisfies legacy ENTERPRISE scope (backward compat)', () => {
-      const req = makeReq({ 'x-api-key': enterpriseKey })
+    it('ENTERPRISE key satisfies legacy ENTERPRISE scope (backward compat)', async () => {
+      const key = legacyKey('full')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
@@ -544,30 +612,31 @@ describe('requireApiKey() middleware', () => {
   // ── PUBLIC key ─────────────────────────────────────────────────────────────
 
   describe('PUBLIC key — read-only subset', () => {
-    const publicKey = 'test-public-key-67890'
-
-    it('PUBLIC key satisfies trust:read', () => {
-      const req = makeReq({ 'x-api-key': publicKey })
+    it('PUBLIC key satisfies trust:read', async () => {
+      const key = legacyKey('read')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('PUBLIC key satisfies attestations:read', () => {
-      const req = makeReq({ 'x-api-key': publicKey })
+    it('PUBLIC key satisfies attestations:read', async () => {
+      const key = legacyKey('read')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ATTESTATIONS_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ATTESTATIONS_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('PUBLIC key satisfies legacy PUBLIC scope', () => {
-      const req = makeReq({ 'x-api-key': publicKey })
+    it('PUBLIC key satisfies legacy PUBLIC scope', async () => {
+      const key = legacyKey('read')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.PUBLIC)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.PUBLIC)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
@@ -586,10 +655,11 @@ describe('requireApiKey() middleware', () => {
     ]
 
     for (const scope of writeScopes) {
-      it(`PUBLIC key is denied for ${scope}`, () => {
-        const req = makeReq({ 'x-api-key': publicKey })
+      it(`PUBLIC key is denied for ${scope}`, async () => {
+        const key = legacyKey('read')
+        const req = makeReq({ 'x-api-key': key })
         const { res, status } = makeRes()
-        requireApiKey(scope)(req as Request, res as Response, next)
+        await requireApiKey(scope)(req as Request, res as Response, next)
 
         expect(status).toHaveBeenCalledWith(403)
         expect(next).not.toHaveBeenCalled()
@@ -600,65 +670,72 @@ describe('requireApiKey() middleware', () => {
   // ── req.apiKey metadata ────────────────────────────────────────────────────
 
   describe('req.apiKey metadata', () => {
-    it('attaches scopes array to req.apiKey', () => {
-      const req = makeReq({ 'x-api-key': 'test-attestations-write-key' })
+    it('attaches scopes array to req.apiKey', async () => {
+      const key = granularKey(['attestations:read', 'attestations:write'])
+      const req = makeReq({ 'x-api-key': key })
       const { res } = makeRes()
-      requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ATTESTATIONS_WRITE)(req as Request, res as Response, next)
 
       const authReq = req as AuthenticatedRequest & { apiKey: any }
       expect(authReq.apiKey).toBeDefined()
-      expect(authReq.apiKey.scopes).toContain(ApiScope.ATTESTATIONS_READ)
-      expect(authReq.apiKey.scopes).toContain(ApiScope.ATTESTATIONS_WRITE)
+      expect(authReq.apiKey.scopes).toContain('attestations:read')
+      expect(authReq.apiKey.scopes).toContain('attestations:write')
     })
 
-    it('attaches legacy scope field for backward compatibility', () => {
-      const req = makeReq({ 'x-api-key': 'test-enterprise-key-12345' })
+    it('attaches legacy scope field for backward compatibility', async () => {
+      const key = legacyKey('full')
+      const req = makeReq({ 'x-api-key': key })
       const { res } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       const authReq = req as any
-      expect(authReq.apiKey.scope).toBe(ApiScope.ENTERPRISE)
+      expect(authReq.apiKey.scope).toBe('full')
     })
 
-    it('attaches key value to req.apiKey.key', () => {
-      const req = makeReq({ 'x-api-key': 'test-trust-read-key' })
+    it('attaches StoredApiKey record with ownerId to req.apiKey', async () => {
+      const key = granularKey(['trust:read'])
+      const req = makeReq({ 'x-api-key': key })
       const { res } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       const authReq = req as any
-      expect(authReq.apiKey.key).toBe('test-trust-read-key')
+      expect(authReq.apiKey).toBeDefined()
+      expect(authReq.apiKey.ownerId).toBe('u-admin')
+      expect(authReq.apiKey.active).toBe(true)
     })
   })
 
   // ── Authorization: Bearer header ──────────────────────────────────────────
 
   describe('Authorization: Bearer header', () => {
-    it('accepts key from Authorization: Bearer header', () => {
-      const req = makeReq({ authorization: 'Bearer test-trust-read-key' })
+    it('accepts key from Authorization: Bearer header', async () => {
+      const key = granularKey(['trust:read'])
+      const req = makeReq({ authorization: `Bearer ${key}` })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('X-API-Key takes precedence over Authorization header', () => {
-      // X-API-Key has a valid key; Authorization has an invalid one
+    it('X-API-Key takes precedence over Authorization header', async () => {
+      const goodKey = granularKey(['trust:read'])
+      const badKeyStr = 'cr_' + 'b'.repeat(64)
       const req = makeReq({
-        'x-api-key': 'test-trust-read-key',
-        authorization: 'Bearer invalid-key',
+        'x-api-key': goodKey,
+        authorization: `Bearer ${badKeyStr}`,
       })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('returns 401 when Bearer token is invalid', () => {
+    it('returns 401 when Bearer token is invalid', async () => {
       const req = makeReq({ authorization: 'Bearer not-a-real-key' })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.TRUST_READ)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(401)
       expect(next).not.toHaveBeenCalled()
@@ -668,28 +745,31 @@ describe('requireApiKey() middleware', () => {
   // ── backward compatibility ─────────────────────────────────────────────────
 
   describe('backward compatibility', () => {
-    it('existing test-enterprise-key-12345 still works for ENTERPRISE scope', () => {
-      const req = makeReq({ 'x-api-key': 'test-enterprise-key-12345' })
+    it('full-scope key satisfies ENTERPRISE scope (backward compat)', async () => {
+      const key = legacyKey('full')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('existing test-public-key-67890 still works for PUBLIC scope', () => {
-      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+    it('read-scope key satisfies PUBLIC scope (backward compat)', async () => {
+      const key = legacyKey('read')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.PUBLIC)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.PUBLIC)(req as Request, res as Response, next)
 
       expect(next).toHaveBeenCalled()
       expect(status).not.toHaveBeenCalled()
     })
 
-    it('existing enterprise key is denied for ENTERPRISE scope when using public key', () => {
-      const req = makeReq({ 'x-api-key': 'test-public-key-67890' })
+    it('PUBLIC key is denied for ENTERPRISE scope', async () => {
+      const key = legacyKey('read')
+      const req = makeReq({ 'x-api-key': key })
       const { res, status } = makeRes()
-      requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
+      await requireApiKey(ApiScope.ENTERPRISE)(req as Request, res as Response, next)
 
       expect(status).toHaveBeenCalledWith(403)
       expect(next).not.toHaveBeenCalled()

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { requireApiKey, ApiScope, AuthenticatedRequest } from '../middleware/auth.js'
-import { _resetStore, generateApiKey } from '../services/apiKeys.js'
+import { _resetStore, generateApiKey, revokeApiKey } from '../services/apiKeys.js'
 import { userRepo } from '../repositories/userRepository.js'
 
 describe('Auth Middleware', () => {
@@ -11,6 +11,7 @@ describe('Auth Middleware', () => {
 
   beforeEach(() => {
     _resetStore()
+    userRepo._reset()
     // Seed users for owner resolution
     userRepo.upsert({ id: 'u-admin', role: 'super-admin', email: 'a@x.com', tenantId: 't-admin' })
     userRepo.upsert({ id: 'u-verifier', role: 'verifier', email: 'v@x.com', tenantId: 't-ver' })
@@ -26,9 +27,9 @@ describe('Auth Middleware', () => {
 
   describe('requireApiKey', () => {
     describe('Missing API Key', () => {
-      it('should return 401 when API key header is missing', () => {
+      it('should return 401 when API key header is missing', async () => {
         const middleware = requireApiKey(ApiScope.PUBLIC)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(mockResponse.status).toHaveBeenCalledWith(401)
         expect(mockResponse.json).toHaveBeenCalledWith({
@@ -38,10 +39,10 @@ describe('Auth Middleware', () => {
         expect(nextFunction).not.toHaveBeenCalled()
       })
 
-      it('should return 401 when API key header is empty string', () => {
+      it('should return 401 when API key header is empty string', async () => {
         mockRequest.headers = { 'x-api-key': '' }
         const middleware = requireApiKey(ApiScope.PUBLIC)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(mockResponse.status).toHaveBeenCalledWith(401)
         expect(mockResponse.json).toHaveBeenCalledWith({
@@ -53,10 +54,10 @@ describe('Auth Middleware', () => {
     })
 
     describe('Invalid API Key', () => {
-      it('should return 401 when API key is invalid', () => {
+      it('should return 401 when API key is invalid', async () => {
         mockRequest.headers = { 'x-api-key': 'invalid-key-12345' }
         const middleware = requireApiKey(ApiScope.PUBLIC)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(mockResponse.status).toHaveBeenCalledWith(401)
         expect(mockResponse.json).toHaveBeenCalledWith({
@@ -66,10 +67,20 @@ describe('Auth Middleware', () => {
         expect(nextFunction).not.toHaveBeenCalled()
       })
 
-      it('should return 401 for random string', () => {
+      it('should return 401 for random string', async () => {
         mockRequest.headers = { 'x-api-key': 'random-string' }
         const middleware = requireApiKey(ApiScope.PUBLIC)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+
+        expect(mockResponse.status).toHaveBeenCalledWith(401)
+        expect(nextFunction).not.toHaveBeenCalled()
+      })
+
+      it('should return 401 for a well-formed but non-existent key', async () => {
+        const random = 'cr_' + 'a'.repeat(64)
+        mockRequest.headers = { 'x-api-key': random }
+        const middleware = requireApiKey(ApiScope.PUBLIC)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(mockResponse.status).toHaveBeenCalledWith(401)
         expect(nextFunction).not.toHaveBeenCalled()
@@ -77,10 +88,11 @@ describe('Auth Middleware', () => {
     })
 
     describe('Insufficient Scope', () => {
-      it('should return 403 when public key is used for enterprise endpoint', () => {
-        mockRequest.headers = { 'x-api-key': 'test-public-key-67890' }
+      it('should return 403 when public key is used for enterprise endpoint', async () => {
+        const pub = generateApiKey('u-verifier', 'read')
+        mockRequest.headers = { 'x-api-key': pub.key }
         const middleware = requireApiKey(ApiScope.ENTERPRISE)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(mockResponse.status).toHaveBeenCalledWith(403)
         expect(mockResponse.json).toHaveBeenCalledWith({
@@ -89,45 +101,55 @@ describe('Auth Middleware', () => {
         })
         expect(nextFunction).not.toHaveBeenCalled()
       })
+
+      it('should return 403 when trust:read key is used for payouts:write endpoint', async () => {
+        const key = generateApiKey('u-verifier', ['trust:read'])
+        mockRequest.headers = { 'x-api-key': key.key }
+        const middleware = requireApiKey(ApiScope.PAYOUTS_WRITE)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+
+        expect(mockResponse.status).toHaveBeenCalledWith(403)
+        expect(nextFunction).not.toHaveBeenCalled()
+      })
     })
 
     describe('Valid API Keys', () => {
-      it('should accept valid public API key for public endpoint', () => {
+      it('should accept valid public API key for public endpoint', async () => {
         const pub = generateApiKey('u-verifier', 'read')
         mockRequest.headers = { 'x-api-key': pub.key }
         const middleware = requireApiKey(ApiScope.PUBLIC)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(nextFunction).toHaveBeenCalled()
         expect(mockResponse.status).not.toHaveBeenCalled()
         expect(mockResponse.json).not.toHaveBeenCalled()
       })
 
-      it('should accept valid enterprise API key for public endpoint', () => {
+      it('should accept valid enterprise API key for public endpoint', async () => {
         const ent = generateApiKey('u-admin', 'full')
         mockRequest.headers = { 'x-api-key': ent.key }
         const middleware = requireApiKey(ApiScope.PUBLIC)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(nextFunction).toHaveBeenCalled()
         expect(mockResponse.status).not.toHaveBeenCalled()
       })
 
-      it('should accept valid enterprise API key for enterprise endpoint', () => {
+      it('should accept valid enterprise API key for enterprise endpoint', async () => {
         const ent = generateApiKey('u-admin', 'full')
         mockRequest.headers = { 'x-api-key': ent.key }
         const middleware = requireApiKey(ApiScope.ENTERPRISE)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(nextFunction).toHaveBeenCalled()
         expect(mockResponse.status).not.toHaveBeenCalled()
       })
 
-      it('should attach API key metadata to request', () => {
+      it('should attach API key metadata to request', async () => {
         const ent = generateApiKey('u-admin', 'full')
         mockRequest.headers = { 'x-api-key': ent.key }
         const middleware = requireApiKey(ApiScope.ENTERPRISE)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         const authReq = mockRequest as AuthenticatedRequest
         expect(authReq.apiKey).toBeDefined()
@@ -135,22 +157,62 @@ describe('Auth Middleware', () => {
         expect(authReq.apiKey?.scope).toBe('full')
       })
 
-      it('should attach correct scope for public key', () => {
-        mockRequest.headers = { 'x-api-key': 'test-public-key-67890' }
+      it('should attach correct scope for public key', async () => {
+        const pub = generateApiKey('u-verifier', 'read')
+        mockRequest.headers = { 'x-api-key': pub.key }
         const middleware = requireApiKey(ApiScope.PUBLIC)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         const authReq = mockRequest as AuthenticatedRequest
-        expect(authReq.apiKey?.scope).toBe(ApiScope.PUBLIC)
+        expect(authReq.apiKey?.scope).toBe('read')
+      })
+    })
+
+    describe('Revoked Key', () => {
+      it('should return 401 for a revoked key', async () => {
+        const key = generateApiKey('u-admin', 'full')
+        // Manually revoke by finding and deactivating
+        revokeApiKey(key.id)
+
+        mockRequest.headers = { 'x-api-key': key.key }
+        const middleware = requireApiKey(ApiScope.ENTERPRISE)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+
+        expect(mockResponse.status).toHaveBeenCalledWith(401)
+        expect(nextFunction).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('Authorization: Bearer header', () => {
+      it('should accept key from Authorization: Bearer header', async () => {
+        const key = generateApiKey('u-admin', 'full')
+        mockRequest.headers = { authorization: `Bearer ${key.key}` }
+        const middleware = requireApiKey(ApiScope.ENTERPRISE)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+
+        expect(nextFunction).toHaveBeenCalled()
+      })
+
+      it('should prefer X-API-Key over Authorization header', async () => {
+        const goodKey = generateApiKey('u-admin', 'full')
+        const badKey = 'cr_' + 'b'.repeat(64)
+        mockRequest.headers = {
+          'x-api-key': goodKey.key,
+          authorization: `Bearer ${badKey}`,
+        }
+        const middleware = requireApiKey(ApiScope.ENTERPRISE)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+
+        expect(nextFunction).toHaveBeenCalled()
       })
     })
 
     describe('Case Sensitivity', () => {
-      it('should handle header name case-insensitively', () => {
-        // Express normalizes headers to lowercase
-        mockRequest.headers = { 'x-api-key': 'test-enterprise-key-12345' }
+      it('should handle header name case-insensitively', async () => {
+        const ent = generateApiKey('u-admin', 'full')
+        mockRequest.headers = { 'x-api-key': ent.key }
         const middleware = requireApiKey(ApiScope.ENTERPRISE)
-        middleware(mockRequest as Request, mockResponse as Response, nextFunction)
+        await middleware(mockRequest as Request, mockResponse as Response, nextFunction)
 
         expect(nextFunction).toHaveBeenCalled()
       })

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,8 +1,7 @@
 import { Request, Response, NextFunction } from "express";
-import type { StoredApiKey } from "../services/apiKeys.js";
+import type { StoredApiKey, KeyScope } from "../services/apiKeys.js";
 import { validateApiKey } from "../services/apiKeys.js";
 import { userRepo } from "../repositories/userRepository.js";
-import { requireApiKey as requireApiKeyFromApiKeyMiddleware } from "./apiKey.js";
 import { runWithTenant } from "../utils/tenantContext.js";
 
 /**
@@ -130,80 +129,40 @@ export interface AuthenticatedRequest extends Request {
   };
 }
 
-/**
- * Mock API key store — maps raw key → set of granted scopes.
- *
- * In production this is replaced by a database lookup via ApiKeyRepository.
- * The legacy single-scope values (PUBLIC / ENTERPRISE) are preserved here so
- * that existing test fixtures continue to work without modification.
- */
-const API_KEYS: Record<string, ApiScope[]> = {
-  // Legacy keys — kept for backward compatibility
-  "test-enterprise-key-12345": [ApiScope.ENTERPRISE],
-  "test-public-key-67890": [ApiScope.PUBLIC],
+// ── Hardcoded mock stores removed ───────────────────────────────────────
+// API_KEYS, MOCK_USERS, and API_KEY_TO_USER have been replaced by the
+// persistent, hashed key store in src/services/apiKeys.ts.
+// Test fixtures should use generateApiKey() to seed keys into the
+// in-memory or database store.
 
-  // Granular-scope test keys (used in auth.scopes.test.ts)
-  'test-trust-read-key': [ApiScope.TRUST_READ],
-  'test-attestations-write-key': [ApiScope.ATTESTATIONS_READ, ApiScope.ATTESTATIONS_WRITE],
-  'test-payouts-write-key': [ApiScope.PAYOUTS_WRITE],
-  'test-reports-key': [ApiScope.REPORTS_GENERATE, ApiScope.EXPORTS_READ],
-  'test-webhooks-admin-key': [ApiScope.WEBHOOKS_ADMIN],
-  'test-outbox-reinject-key': [ApiScope.OUTBOX_REINJECT],
-  'test-admin-read-key': [ApiScope.ADMIN_READ],
-  'test-admin-write-key': [ApiScope.ADMIN_READ, ApiScope.ADMIN_WRITE],
-  'test-flags-read-key': [ApiScope.FLAGS_READ],
-  'test-flags-write-key': [ApiScope.FLAGS_READ, ApiScope.FLAGS_WRITE],
-  'test-bond-read-key': [ApiScope.BOND_READ],
-  'test-bond-write-key': [ApiScope.BOND_READ, ApiScope.BOND_WRITE],
+/**
+ * Map DB-stored scope strings to ApiScope enum values.
+ * 'full' / 'enterprise' → ENTERPRISE (superset of all).
+ * 'read' / 'public' → PUBLIC (read-only subset).
+ * Granular scope strings (e.g. 'trust:read') pass through as-is.
+ */
+function mapDbScopesToApiScopes(dbScopes: string[]): ApiScope[] {
+  return dbScopes.map((s): ApiScope => {
+    if (s === 'full' || s === 'enterprise') return ApiScope.ENTERPRISE
+    if (s === 'read' || s === 'public') return ApiScope.PUBLIC
+    return s as ApiScope
+  })
 }
-
-/**
- * Mock user store - in production, use database or identity provider
- * Format: { userId: { id, role, email, apiKey } }
- */
-export const MOCK_USERS: Record<
-  string,
-  {
-    id: string;
-    role: UserRole;
-    email: string;
-    apiKey: string;
-    tenantId: string;
-  }
-> = {
-  "admin-user-1": {
-    id: "admin-user-1",
-    role: UserRole.SUPER_ADMIN,
-    email: "admin@credence.org",
-    apiKey: "admin-key-12345",
-    tenantId: "tenant-admin",
-  },
-  "verifier-user-1": {
-    id: "verifier-user-1",
-    role: UserRole.VERIFIER,
-    email: "verifier@credence.org",
-    apiKey: "verifier-key-67890",
-    tenantId: "tenant-verifier",
-  },
-};
-
-/**
- * Mock API key to user mapping - in production, use database
- */
-export const API_KEY_TO_USER: Record<string, string> = {
-  "admin-key-12345": "admin-user-1",
-  "verifier-key-67890": "verifier-user-1",
-};
 
 /**
  * Middleware to validate API key and enforce a required scope.
  *
+ * Key lookup is performed exclusively against the hashed database store
+ * via `validateApiKey`. Keys are never compared in plaintext and raw key
+ * values are never logged.
+ *
  * The middleware:
  * 1. Reads the key from `X-API-Key` or `Authorization: Bearer` headers.
- * 2. Looks up the granted scope set (deny-by-default when key is unknown).
- * 3. Calls `scopeSatisfies` to check whether the granted scopes cover the
+ * 2. Validates the key against the persistent, hashed key store.
+ * 3. Maps stored scope strings to `ApiScope` enum values.
+ * 4. Calls `scopeSatisfies` to check whether the granted scopes cover the
  *    required scope — including legacy ENTERPRISE superset expansion.
- * 4. Attaches `{ key, scopes }` to `req.apiKey` for downstream handlers.
+ * 5. Attaches the full `StoredApiKey` record to `req.apiKey`.
  *
  * @param requiredScope - The single scope that must be satisfied.
  *
@@ -213,23 +172,18 @@ export const API_KEY_TO_USER: Record<string, string> = {
  * router.get('/api/trust/:id',     requireApiKey(ApiScope.TRUST_READ),          handler)
  * ```
  */
-/**
- * Adapter to the canonical `requireApiKey` implemented in `src/middleware/apiKey.ts`.
- * Keeps the old `ApiScope` enum surface but delegates validation to the
- * DB-backed key validator. Mapping of scopes is performed below.
- */
 export function requireApiKey(requiredScope: ApiScope) {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     // Accept key from X-API-Key header or Authorization: Bearer <key>
-    let apiKey = req.headers["x-api-key"] as string | undefined;
-    if (!apiKey) {
+    let rawKey = req.headers["x-api-key"] as string | undefined;
+    if (!rawKey) {
       const authHeader = req.headers["authorization"];
       if (authHeader?.startsWith("Bearer ")) {
-        apiKey = authHeader.slice(7);
+        rawKey = authHeader.slice(7);
       }
     }
 
-    if (!apiKey) {
+    if (!rawKey) {
       res.status(401).json({
         error: "Unauthorized",
         message: "API key is required",
@@ -237,27 +191,19 @@ export function requireApiKey(requiredScope: ApiScope) {
       return;
     }
 
-    let grantedScopes = API_KEYS[apiKey]
-    let dbKey: StoredApiKey | null = null
+    // Validate against the persistent, hashed key store only.
+    // `validateApiKey` performs a timing-safe SHA-256 hash comparison.
+    const dbKey: StoredApiKey | null = await validateApiKey(rawKey)
 
-    if (!grantedScopes) {
-      dbKey = await validateApiKey(apiKey)
-      if (dbKey) {
-        grantedScopes = dbKey.scopes.map((s): ApiScope => {
-          if (s === 'full') return ApiScope.ENTERPRISE
-          if (s === 'read') return ApiScope.PUBLIC
-          return s as ApiScope
-        })
-      }
-    }
-
-    if (!grantedScopes) {
+    if (!dbKey) {
       res.status(401).json({
         error: "Unauthorized",
         message: "Invalid API key",
       });
       return;
     }
+
+    const grantedScopes = mapDbScopesToApiScopes(dbKey.scopes)
 
     // Deny-by-default: key must satisfy the required scope
     if (!scopeSatisfies(grantedScopes, requiredScope)) {
@@ -277,18 +223,8 @@ export function requireApiKey(requiredScope: ApiScope) {
       return
     }
 
-    // Attach metadata to request for downstream handlers.
-    if (dbKey) {
-      ;(req as any).apiKey = dbKey
-    } else {
-      ;(req as any).apiKey = {
-        key: apiKey,
-        scopes: grantedScopes,
-        scope: grantedScopes.includes(ApiScope.ENTERPRISE)
-          ? ApiScope.ENTERPRISE
-          : grantedScopes[0],
-      }
-    }
+    // Attach the full database record to the request for downstream handlers.
+    ;(req as AuthenticatedRequest).apiKey = dbKey
     next()
   }
 }
@@ -361,38 +297,26 @@ export async function requireUserAuth(
   }
 
   const raw = authHeader.substring(7); // Remove 'Bearer ' prefix
- 
-  let key = await validateApiKey(raw);
-  let user: any = null;
- 
-  if (key) {
-    user = userRepo.findById(key.ownerId);
-  } else {
-    const userId = API_KEY_TO_USER[raw];
-    if (userId) {
-      const mockUser = MOCK_USERS[userId];
-      if (mockUser) {
-        user = mockUser;
-        key = {
-          id: mockUser.apiKey,
-          hashedKey: "",
-          prefix: "",
-          scopes: [ApiScope.ENTERPRISE],
-          scope: ApiScope.ENTERPRISE,
-          tier: "enterprise",
-          ownerId: mockUser.id,
-          createdAt: new Date(),
-          lastUsedAt: new Date(),
-          active: true,
-        } as any;
-      }
-    }
-  }
- 
-  if (!key || !user) {
+
+  // Validate the token against the persistent, hashed key store.
+  // `validateApiKey` performs a timing-safe SHA-256 hash comparison.
+  const key = await validateApiKey(raw);
+
+  if (!key) {
     res.status(401).json({
       error: "Unauthorized",
       message: "Invalid or expired token",
+    });
+    return;
+  }
+
+  // Resolve the user record from the database via the key's owner.
+  const user = userRepo.findById(key.ownerId);
+
+  if (!user) {
+    res.status(401).json({
+      error: "Unauthorized",
+      message: "User not found for this key",
     });
     return;
   }

--- a/src/routes/policy.integration.test.ts
+++ b/src/routes/policy.integration.test.ts
@@ -76,8 +76,6 @@ vi.mock('../middleware/auth.js', () => ({
   },
   // Re-export types used by the module under test
   ApiScope: {},
-  MOCK_USERS: {},
-  API_KEY_TO_USER: {},
 }))
 
 // ---------------------------------------------------------------------------

--- a/src/services/impersonation/index.ts
+++ b/src/services/impersonation/index.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'crypto'
-import { MOCK_USERS } from '../../middleware/auth.js'
+import { userRepo } from '../../repositories/userRepository.js'
 import { AuditLogService, AuditAction, auditLogService } from '../audit/index.js'
 import { pool } from '../../db/pool.js'
 import { ImpersonationTokenRepository } from '../../repositories/impersonationTokenRepository.js'
@@ -61,7 +61,7 @@ export class ImpersonationService {
       throw new Error('reason is required and must not be empty')
     }
 
-    const target = MOCK_USERS[targetUserId]
+    const target = userRepo.findById(targetUserId)
     if (!target) {
       await this.auditLog.logAction(
         tenantId,


### PR DESCRIPTION
## Summary

Resolves #996 — removes all hardcoded API keys, mock users, and plaintext key comparisons from the authentication middleware.

### Problem

`src/middleware/auth.ts` authenticated requests against in-source constants — `API_KEYS`, `MOCK_USERS`, and `API_KEY_TO_USER` — containing literal keys like `test-enterprise-key-12345` and `admin-key-12345`. These shipped in the binary and granted standing admin/enterprise access to anyone reading the code.

### Solution

All key validation now flows through `validateApiKey()` in `src/services/apiKeys.ts`, which performs timing-safe SHA-256 hash lookups against the persistent store. No plaintext keys remain in the codebase.

### Changes

| File | Change |
|---|---|
| `src/middleware/auth.ts` | Removed `API_KEYS`, `MOCK_USERS`, `API_KEY_TO_USER`. `requireApiKey()` and `requireUserAuth()` exclusively use `validateApiKey()` + `userRepo.findById()`. Added `mapDbScopesToApiScopes()` helper for scope conversion. |
| `src/services/impersonation/index.ts` | Replaced `MOCK_USERS[targetUserId]` with `userRepo.findById(targetUserId)` |
| `src/__tests__/auth.test.ts` | Migrated all tests to `generateApiKey()`-seeded keys with proper `await` on async middleware calls |
| `src/__tests__/auth.scopes.test.ts` | Complete rewrite: 82 tests now use DB-generated keys via `generateApiKey()`, covering revoked, unknown, scope-mismatch, missing header, and Bearer auth. Removed duplicate revoked/expired test. |
| `src/routes/policy.integration.test.ts` | Removed `MOCK_USERS` and `API_KEY_TO_USER` from module mock |
| `docs/security.md` | Added comprehensive API Key Authentication section documenting key storage, lifecycle, middleware paths, and security guarantees |
| `docs/api-keys.md` | Noted exclusive DB-backed validation (no hardcoded keys) |

### Security guarantees

- **Timing-safe validation:** SHA-256 hash computed before any comparison — no raw key comparisons or early-exit string checks
- **No raw key logging:** Raw key values are never logged or included in error responses
- **Deny-by-default:** Unknown, revoked, or inactive keys receive 401
- **Zero in-code secrets:** No hardcoded credentials ship in the binary

### Test results

```
 ✓ src/__tests__/auth.test.ts (18 tests) 
 ✓ src/__tests__/auth.scopes.test.ts (82 tests)
 Test Files  2 passed (2)
      Tests  100 passed (100)
```

### Edge cases covered

- Revoked key → 401
- Unknown/well-formed key → 401
- Invalid format key → 401
- Missing header → 401
- Scope mismatch → 403 (with grantedScopes in response)
- Bearer token header accepted alongside X-API-Key
- ENTERPRISE superset satisfies all granular scopes
- PUBLIC subset satisfies only read scopes