### PR TITLE
feat: validate report type against allowlist enum

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9752,3 +9752,259 @@ paths:
                 required:
                   - error
                   - message
+  /api/reports:
+    post:
+      summary: Start a report generation job
+      description: Queues an asynchronous report generation job for the given report
+        type. Returns job metadata immediately.
+      tags:
+        - Reports
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - trust_score_summary
+                    - bond_audit
+                    - attestation_export
+                    - top_talkers
+              required:
+                - type
+              additionalProperties: false
+      responses:
+        "202":
+          description: Report job queued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                  createdAt:
+                    type: string
+                required:
+                  - jobId
+                  - status
+                  - type
+                  - createdAt
+        "400":
+          description: Validation error (invalid or missing report type)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  details:
+                    type: array
+                    items:
+                      nullable: true
+                required:
+                  - error
+                  - details
+        "429":
+          description: Rate limit exceeded (maximum concurrent jobs per org)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                required:
+                  - error
+                  - code
+  /api/reports/top-talkers:
+    get:
+      summary: Top talkers report
+      description: Returns the top N tenants by request count in the aggregate window.
+      tags:
+        - Reports
+      parameters:
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 1440
+          required: false
+          name: windowMinutes
+          in: query
+      responses:
+        "200":
+          description: Top talkers data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      windowStart:
+                        type: string
+                      windowEnd:
+                        type: string
+                      windowMinutes:
+                        type: number
+                      totalRequests:
+                        type: number
+                      topTalkers:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            tenantId:
+                              type: string
+                            requestCount:
+                              type: number
+                            percentage:
+                              type: number
+                            lastRequestAt:
+                              type: string
+                          required:
+                            - tenantId
+                            - requestCount
+                            - percentage
+                    required:
+                      - windowStart
+                      - windowEnd
+                      - windowMinutes
+                      - totalRequests
+                      - topTalkers
+                required:
+                  - success
+                  - data
+  /api/reports/{jobId}:
+    get:
+      summary: Get report job status
+      description: Returns the status and artifact URL of a report generation job.
+      tags:
+        - Reports
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: jobId
+          in: path
+      responses:
+        "200":
+          description: Report job status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobId:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                  artifactUrl:
+                    type: string
+                  failureReason:
+                    type: string
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - jobId
+                  - status
+                  - type
+                  - createdAt
+                  - updatedAt
+        "404":
+          description: Report job not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+  /api/reports/download/{key}:
+    get:
+      summary: Download a report artifact
+      description: Serves the report artifact using a signed URL with expires and
+        signature query parameters.
+      tags:
+        - Reports
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: key
+          in: path
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: expires
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: signature
+          in: query
+      responses:
+        "200":
+          description: Report artifact (PDF)
+          content:
+            application/pdf:
+              schema:
+                nullable: true
+        "400":
+          description: Missing required query parameters (expires or signature)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                required:
+                  - error
+                  - code
+        "401":
+          description: Invalid or expired signed URL
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+                required:
+                  - error
+                  - code

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -893,6 +893,103 @@ registry.registerPath({
   },
 });
 
+// Reports paths
+registry.registerPath({
+  method: 'post',
+  path: '/api/reports',
+  summary: 'Start a report generation job',
+  description: 'Queues an asynchronous report generation job for the given report type. Returns job metadata immediately.',
+  tags: ['Reports'],
+  request: {
+    body: {
+      required: true,
+      content: { 'application/json': { schema: schemas.createReportBodySchema } },
+    },
+  },
+  responses: {
+    202: {
+      description: 'Report job queued',
+      content: {
+        'application/json': {
+          schema: z.object({ jobId: z.string(), status: z.string(), type: z.string(), createdAt: z.string() }),
+        },
+      },
+    },
+    400: {
+      description: 'Validation error (invalid or missing report type)',
+      content: { 'application/json': { schema: z.object({ error: z.string(), details: z.array(z.any()) }) } },
+    },
+    429: {
+      description: 'Rate limit exceeded (maximum concurrent jobs per org)',
+      content: { 'application/json': { schema: z.object({ error: z.string(), code: z.string() }) } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/reports/top-talkers',
+  summary: 'Top talkers report',
+  description: 'Returns the top N tenants by request count in the aggregate window.',
+  tags: ['Reports'],
+  request: { query: schemas.topTalkersQuerySchema },
+  responses: {
+    200: {
+      description: 'Top talkers data',
+      content: { 'application/json': { schema: schemas.topTalkersResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/reports/{jobId}',
+  summary: 'Get report job status',
+  description: 'Returns the status and artifact URL of a report generation job.',
+  tags: ['Reports'],
+  request: { params: schemas.reportJobParamsSchema },
+  responses: {
+    200: {
+      description: 'Report job status',
+      content: {
+        'application/json': {
+          schema: z.object({ jobId: z.string(), status: z.string(), type: z.string(), artifactUrl: z.string().optional(), failureReason: z.string().optional(), createdAt: z.string(), updatedAt: z.string() }),
+        },
+      },
+    },
+    404: {
+      description: 'Report job not found',
+      content: { 'application/json': { schema: z.object({ error: z.string() }) } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/reports/download/{key}',
+  summary: 'Download a report artifact',
+  description: 'Serves the report artifact using a signed URL with expires and signature query parameters.',
+  tags: ['Reports'],
+  request: {
+    params: z.object({ key: z.string().min(1) }),
+    query: z.object({ expires: z.string().min(1), signature: z.string().min(1) }),
+  },
+  responses: {
+    200: {
+      description: 'Report artifact (PDF)',
+      content: { 'application/pdf': { schema: z.any() } },
+    },
+    400: {
+      description: 'Missing required query parameters (expires or signature)',
+      content: { 'application/json': { schema: z.object({ error: z.string(), code: z.string() }) } },
+    },
+    401: {
+      description: 'Invalid or expired signed URL',
+      content: { 'application/json': { schema: z.object({ error: z.string(), code: z.string() }) } },
+    },
+  },
+});
+
 const generator = new OpenApiGeneratorV3(registry.definitions);
 
 const document = generator.generateDocument({

--- a/src/routes/report.test.ts
+++ b/src/routes/report.test.ts
@@ -3,6 +3,7 @@ import express, { type Request, type Response, type NextFunction } from 'express
 import request from 'supertest'
 import reportRouter from './report.js'
 import { auditLogService } from '../services/audit/index.js'
+import { errorHandler } from '../middleware/errorHandler.js'
 
 vi.mock('../middleware/auth.js', () => ({
   requireApiKey: () => (req: Request, _res: Response, next: NextFunction) => {
@@ -43,6 +44,7 @@ function setupApp() {
   const app = express()
   app.use(express.json())
   app.use('/api/reports', reportRouter)
+  app.use(errorHandler)
   return app
 }
 
@@ -84,6 +86,33 @@ describe('Reports Router - Top Talkers', () => {
       expect(res.status).toBe(202)
       expect(res.body.type).toBe('top_talkers')
       expect(res.body.jobId).toBe('job-123')
+    })
+  })
+
+  describe('POST /api/reports — type validation', () => {
+    it('returns 400 for an unknown report type', async () => {
+      const res = await request(setupApp())
+        .post('/api/reports')
+        .send({ type: 'nonexistent_report' })
+
+      expect(res.status).toBe(400)
+      expect(res.body.details).toBeDefined()
+    })
+
+    it('returns 400 when type is missing', async () => {
+      const res = await request(setupApp())
+        .post('/api/reports')
+        .send({})
+
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when body is empty', async () => {
+      const res = await request(setupApp())
+        .post('/api/reports')
+        .send()
+
+      expect(res.status).toBe(400)
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #1007 

Validates the `type` field in `POST /api/reports` against a Zod enum allowlist instead of accepting any arbitrary string. Invalid types now return `400` with a structured error response before reaching the service or worker layer.

## Changes

### Schema (`src/schemas/report.ts`)
- Defined `REPORT_TYPES` as a `const` array (`trust_score_summary`, `bond_audit`, `attestation_export`, `top_talkers`) — single source of truth for the route and worker
- Created `reportTypeSchema` via `z.enum(REPORT_TYPES)`
- Created `createReportBodySchema` with `.strict()` to reject unknown fields

### Route (`src/routes/report.ts`)
- Applied `validate({ body: createReportBodySchema })` middleware — already in place
- Removed the manual `if (!type || typeof type !== 'string')` block — already done

### OpenAPI Spec (`docs/openapi.yaml`)
- Registered all four report API paths in `scripts/generate-openapi.ts`:
  - `POST /api/reports` — start report generation
  - `GET /api/reports/top-talkers` — top talkers report
  - `GET /api/reports/{jobId}` — job status
  - `GET /api/reports/download/{key}` — artifact download
- Regenerated spec with `npm run generate:openapi`

### Tests
- **`src/schemas/report.test.ts`** — 14 tests covering all edge cases (valid types, unknown type, empty string, null, undefined, numeric, case sensitivity, overly long strings, extra fields)
- **`src/routes/report.test.ts`** — 3 new route-level tests: unknown type → 400, missing type → 400, empty body → 400
- **`tests/routes/report.test.ts`** — 13 existing route-level validation tests covering the same edge cases at the HTTP layer

## Testing

```bash
npm test
```
All report-related tests pass. Pre-existing test failures (Redis/DB connectivity, circuit breaker timeouts) are unrelated.
Notes
- The allowlist is extensible — add new types to REPORT_TYPES in src/schemas/report.ts
- The worker already imports REPORT_TYPES as the shared source of truth