### PR TITLE
feat(reports): add async report status endpoint with cancel support

### DIFF
--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -86,6 +86,7 @@ export enum ReportJobStatus {
   RUNNING = 'running',
   COMPLETED = 'completed',
   FAILED = 'failed',
+  CANCELLED = 'cancelled',
 }
 
 /**

--- a/src/routes/report.test.ts
+++ b/src/routes/report.test.ts
@@ -86,4 +86,27 @@ describe('Reports Router - Top Talkers', () => {
       expect(res.body.jobId).toBe('job-123')
     })
   })
+
+  describe('DELETE /api/reports/:jobId', () => {
+    it('cancels a report job', async () => {
+      const { ReportService } = await import('../services/reportService.js')
+      const mockCancel = vi.fn().mockResolvedValue({
+        id: 'job-123',
+        status: 'cancelled',
+        type: 'top_talkers',
+        failureReason: 'Cancelled by user',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      ReportService.prototype.cancelReportJob = mockCancel
+
+      const res = await request(setupApp()).delete('/api/reports/job-123')
+
+      expect(res.status).toBe(200)
+      expect(res.body.jobId).toBe('job-123')
+      expect(res.body.status).toBe('cancelled')
+      expect(res.body.failureReason).toBe('Cancelled by user')
+      expect(mockCancel).toHaveBeenCalledWith('job-123')
+    })
+  })
 })

--- a/src/routes/report.ts
+++ b/src/routes/report.ts
@@ -145,6 +145,48 @@ router.get(
 );
 
 /**
+ * DELETE /api/reports/:jobId
+ *
+ * Cancels a report generation job
+ *
+ * @requires reports:generate scope
+ *
+ * @param {string} jobId - Unique report job ID
+ *
+ * @returns {object} Job status and artifact availability
+ */
+router.delete(
+  "/:jobId",
+  requireApiKey(ApiScope.REPORTS_GENERATE),
+  validate({ params: reportJobParamsSchema }),
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const validatedReq = req as ValidatedRequest<ReportJobParams>
+      const { jobId } = validatedReq.validated.params
+
+      const job = await reportService.cancelReportJob(jobId);
+
+      if (!job) {
+        sendError(res, ErrorCode.NOT_FOUND, `Report job ${jobId} not found`);
+        return;
+      }
+
+      res.status(200).json({
+        jobId: job.id,
+        status: job.status,
+        type: job.type,
+        failureReason: job.failureReason,
+        createdAt: job.createdAt,
+        updatedAt: job.updatedAt,
+      });
+    } catch (error) {
+      console.error("Report cancel error:", error);
+      sendError(res, ErrorCode.INTERNAL_SERVER_ERROR, "An unexpected error occurred while cancelling report job");
+    }
+  },
+);
+
+/**
  * GET /api/reports/download/:key
  *
  * Downloads a report artifact using a signed URL.

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,1 +1,110 @@
-import { ReportRepository } from "../db/repositories/reportRepository.js"; import { ReportJob, ReportJobStatus } from "../jobs/types.js"; import { cache } from "../cache/redis.js"; import { ReportStorageService } from "./reportStorage.js"; import { computeRequestHash } from "../utils/hash.js"; import { loadConfig } from "../config/index.js"; const REPORT_CACHE_TTL = 60; export class ReportService { private config: ReturnType<typeof loadConfig> | null = null; constructor(private readonly reportRepository: ReportRepository, private readonly storage = new ReportStorageService()) {} private getConfig() { if (!this.config) { try { this.config = loadConfig(); } catch { this.config = { reports: { maxConcurrentJobsPerOrg: 10 } } as any; } } return this.config; } async startReportGeneration(type: string, tenantId: string = "default", params?: Record<string, unknown>): Promise<ReportJob> { const requestHash = computeRequestHash({ type, params }); const dedupKey = `report-dedup:${tenantId}:${requestHash}`; const countKey = `report-count:${tenantId}`; const existingJobId = await cache.get<string>("report", dedupKey); if (existingJobId) { const existingJob = await this.reportRepository.findById(existingJobId); if (existingJob && !this.isTerminalStatus(existingJob.status)) { return existingJob; } } const config = this.getConfig(); if (!config) throw new Error("Config not loaded"); const cap = config.reports.maxConcurrentJobsPerOrg; if (cap > 0) { const activeJobsStr = await cache.get<string>("report", countKey); const activeJobs = activeJobsStr ? parseInt(activeJobsStr, 10) : 0; if (activeJobs >= cap) { throw new Error(`Organization has reached maximum concurrent report jobs (${cap})`); } } const job = await this.reportRepository.create(type); await cache.set("report", dedupKey, job.id, 300); if (cap > 0) { const activeJobsStr = await cache.get<string>("report", countKey); const activeJobs = activeJobsStr ? parseInt(activeJobsStr, 10) : 0; await cache.set("report", countKey, String(activeJobs + 1), 300); } return job; } private isTerminalStatus(status: string): boolean { return status === ReportJobStatus.COMPLETED || status === ReportJobStatus.FAILED; } async getReportStatus(id: string): Promise<ReportJob | null> { const cached = await cache.get<ReportJob>("report", id); if (cached) return cached; const job = await this.reportRepository.findById(id); if (job) { const ttl = job.status === ReportJobStatus.COMPLETED || job.status === ReportJobStatus.FAILED ? 300 : REPORT_CACHE_TTL; await cache.set("report", id, job, ttl); } return job; } getSignedDownloadUrl(job: ReportJob): string | null { if (!job.storageKey) return null; return this.storage.generateSignedUrl(job.storageKey).url; } }
+import { ReportRepository } from "../db/repositories/reportRepository.js";
+import { ReportJob, ReportJobStatus } from "../jobs/types.js";
+import { cache } from "../cache/redis.js";
+import { ReportStorageService } from "./reportStorage.js";
+import { computeRequestHash } from "../utils/hash.js";
+import { loadConfig } from "../config/index.js";
+
+const REPORT_CACHE_TTL = 60;
+
+export class ReportService {
+  private config: ReturnType<typeof loadConfig> | null = null;
+
+  constructor(
+    private readonly reportRepository: ReportRepository,
+    private readonly storage = new ReportStorageService()
+  ) {}
+
+  private getConfig() {
+    if (!this.config) {
+      try {
+        this.config = loadConfig();
+      } catch {
+        this.config = { reports: { maxConcurrentJobsPerOrg: 10 } } as any;
+      }
+    }
+    return this.config;
+  }
+
+  async startReportGeneration(
+    type: string,
+    tenantId: string = "default",
+    params?: Record<string, unknown>
+  ): Promise<ReportJob> {
+    const requestHash = computeRequestHash({ type, params });
+    const dedupKey = `report-dedup:${tenantId}:${requestHash}`;
+    const countKey = `report-count:${tenantId}`;
+    
+    const existingJobId = await cache.get<string>("report", dedupKey);
+    if (existingJobId) {
+      const existingJob = await this.reportRepository.findById(existingJobId);
+      if (existingJob && !this.isTerminalStatus(existingJob.status)) {
+        return existingJob;
+      }
+    }
+    
+    const config = this.getConfig();
+    if (!config) throw new Error("Config not loaded");
+    const cap = config.reports.maxConcurrentJobsPerOrg;
+    if (cap > 0) {
+      const activeJobsStr = await cache.get<string>("report", countKey);
+      const activeJobs = activeJobsStr ? parseInt(activeJobsStr, 10) : 0;
+      if (activeJobs >= cap) {
+        throw new Error(`Organization has reached maximum concurrent report jobs (${cap})`);
+      }
+    }
+    
+    const job = await this.reportRepository.create(type);
+    await cache.set("report", dedupKey, job.id, 300);
+    if (cap > 0) {
+      const activeJobsStr = await cache.get<string>("report", countKey);
+      const activeJobs = activeJobsStr ? parseInt(activeJobsStr, 10) : 0;
+      await cache.set("report", countKey, String(activeJobs + 1), 300);
+    }
+    return job;
+  }
+
+  private isTerminalStatus(status: string): boolean {
+    return (
+      status === ReportJobStatus.COMPLETED ||
+      status === ReportJobStatus.FAILED ||
+      status === ReportJobStatus.CANCELLED
+    );
+  }
+
+  async getReportStatus(id: string): Promise<ReportJob | null> {
+    const cached = await cache.get<ReportJob>("report", id);
+    if (cached) return cached;
+    
+    const job = await this.reportRepository.findById(id);
+    if (job) {
+      const ttl = this.isTerminalStatus(job.status) ? 300 : REPORT_CACHE_TTL;
+      await cache.set("report", id, job, ttl);
+    }
+    return job;
+  }
+
+  async cancelReportJob(id: string): Promise<ReportJob | null> {
+    const job = await this.reportRepository.findById(id);
+    if (!job) return null;
+
+    if (this.isTerminalStatus(job.status)) {
+      return job; // Cannot cancel if already completed, failed, or cancelled
+    }
+
+    const cancelledJob = await this.reportRepository.updateStatus(id, ReportJobStatus.CANCELLED, {
+      failureReason: "Cancelled by user"
+    });
+
+    if (cancelledJob) {
+      await cache.set("report", id, cancelledJob, 300);
+    }
+
+    return cancelledJob;
+  }
+
+  getSignedDownloadUrl(job: ReportJob): string | null {
+    if (!job.storageKey) return null;
+    return this.storage.generateSignedUrl(job.storageKey).url;
+  }
+}

--- a/tests/integration/reportStatus.integration.test.ts
+++ b/tests/integration/reportStatus.integration.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { Pool } from 'pg'
+import { ReportRepository } from '../../src/db/repositories/reportRepository.js'
+import { ReportService } from '../../src/services/reportService.js'
+import { ReportJobStatus } from '../../src/jobs/types.js'
+import { cache } from '../../src/cache/redis.js'
+
+describe('Report Status and Cancellation Integration', () => {
+  let pool: Pool
+  let repository: ReportRepository
+  let service: ReportService
+
+  beforeAll(async () => {
+    pool = new Pool({
+      connectionString: process.env.TEST_DB_URL || 'postgresql://postgres:postgres@localhost:5432/test_db',
+    })
+    repository = new ReportRepository(pool)
+    service = new ReportService(repository)
+    
+    // Create tables if they don't exist
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS report_jobs (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        type VARCHAR(255) NOT NULL,
+        status VARCHAR(50) NOT NULL,
+        failure_reason TEXT,
+        artifact_url TEXT,
+        storage_key TEXT,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+      );
+    `)
+  })
+
+  afterAll(async () => {
+    await pool.query('DROP TABLE IF EXISTS report_jobs')
+    await pool.end()
+    await cache.client.quit() // Ensure redis connection is closed properly
+  })
+
+  it('should create a job, poll its status, and cancel it with durable state', async () => {
+    // 1. Create a job
+    const job = await service.startReportGeneration('test_report', 'tenant-1', { foo: 'bar' })
+    expect(job).toBeDefined()
+    expect(job.status).toBe(ReportJobStatus.QUEUED)
+    
+    // 2. Poll status
+    const status1 = await service.getReportStatus(job.id)
+    expect(status1).toBeDefined()
+    expect(status1!.id).toBe(job.id)
+    expect(status1!.status).toBe(ReportJobStatus.QUEUED)
+    
+    // 3. Cancel the job
+    const cancelledJob = await service.cancelReportJob(job.id)
+    expect(cancelledJob).toBeDefined()
+    expect(cancelledJob!.status).toBe(ReportJobStatus.CANCELLED)
+    expect(cancelledJob!.failureReason).toBe('Cancelled by user')
+    
+    // 4. Poll status again to ensure durable state (and cache update)
+    const status2 = await service.getReportStatus(job.id)
+    expect(status2).toBeDefined()
+    expect(status2!.status).toBe(ReportJobStatus.CANCELLED)
+    
+    // 5. Verify DB durable state
+    const dbJob = await repository.findById(job.id)
+    expect(dbJob!.status).toBe(ReportJobStatus.CANCELLED)
+  })
+})


### PR DESCRIPTION
## Description
Closes #982 

This PR introduces the ability to cancel an asynchronous report generation job via a new API endpoint, fulfilling the requirement for polling and optional cancellation with durable state.

### Changes Made:
- **Domain/Types:** Expanded the `ReportJobStatus` enum to include a `CANCELLED` state.
- **Service Layer (`ReportService`):** Implemented `cancelReportJob(id)`, which verifies that the job is not already in a terminal state (Completed, Failed, or Cancelled) before updating its status in the PostgreSQL database and immediately syncing the durable state with the Redis cache. It also sets the `failureReason` to "Cancelled by user".
- **API Endpoint:** Exposed a new `DELETE /api/reports/:jobId` endpoint (protected by `REPORTS_GENERATE` scope) to gracefully cancel queued or running jobs.
- **Testing:** 
  - Added unit tests in the router (`report.test.ts`) to verify the cancellation route behavior and mock mapping.
  - Added a comprehensive end-to-end integration test (`reportStatus.integration.test.ts`) to ensure a queued job is created, successfully polled, cancelled, and that the durable state reliably persists in the database.

### Review Focus:
- Does the Redis cache invalidation logic align perfectly with the updated database state during cancellation?
- Ensure the API response shape for `DELETE` matches expected conventions for report job returns.